### PR TITLE
Create Attack Adjacency Matrix

### DIFF
--- a/attack-viz.html
+++ b/attack-viz.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <title>D12 Game Attack Data</title>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-2.2.2.min.js"></script>
+    <script type="text/javascript" src="https://d3js.org/d3.v3.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3-tip/0.6.7/d3-tip.js"></script>
+    <script type="text/javascript" src="js/viz-utils.js"></script>
+    <style>
+        body {
+            font-family: "futura-pt", sans-serif;
+        }
+        .tick line {
+            shape-rendering: crispEdges;
+            stroke: #000;
+        }
+        path.domain {
+            fill: none;
+            stroke: black;
+        }
+        .d3-tip {
+            line-height: 1;
+            padding: 12px;
+            background: rgba(0, 0, 0, 0.8);
+            color: #fff;
+            border-radius: 2px;
+        }
+
+        .label {
+            font-weight: bold;
+        }
+        form {
+            display: inline
+        }
+        .a-input {
+            padding: 3px;
+        }
+    </style>
+</head>
+
+<body>
+    <h2>D12 Game Attack Targets</h2>
+    <div id="selectors">
+        <select id="game"></select>
+        <form id="dtype">
+            <input name="atype" type="radio" value="attacked" onclick="vizAttackData()" checked><span class="a-input">Num Attack</span>
+            <input name="atype" type="radio" value="killed" onclick="vizAttackData()"><span class="a-input">Killed</span>
+            <input name="atype" type="radio" value="lost" onclick="vizAttackData()"><span class="a-input">Lost</span>
+        </form>
+    </div>
+    <svg id="attacks"></svg>
+    <script type="text/javascript" src="js/attack.js"></script>
+</body>
+
+</html>

--- a/attack-viz.html
+++ b/attack-viz.html
@@ -72,9 +72,9 @@
     <div id="selectors">
         <select id="game"></select>
         <form id="dtype">
-            <input name="atype" type="radio" value="attacked" checked><span class="a-input">Num Attack</span>
-            <input name="atype" type="radio" value="killed"><span class="a-input">Killed</span>
-            <input name="atype" type="radio" value="lost"><span class="a-input">Lost</span>
+            <input name="atype" type="radio" value="attacked" checked><span class="a-input" title="The raw number of times that player A has attacked player B.">Num Attack</span>
+            <input name="atype" type="radio" value="killed"><span class="a-input" title="The number of troops that player A has killed when attacking player B.">Killed</span>
+            <input name="atype" type="radio" value="lost"><span class="a-input" title="The number of troops that player A has lost when attacking player B.">Lost</span>
         </form>
     </div>
     <svg id="attacks"></svg>

--- a/attack-viz.html
+++ b/attack-viz.html
@@ -4,7 +4,10 @@
 <head>
     <meta charset="utf-8">
     <title>D12 Game Attack Data</title>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-2.2.2.min.js"></script>
+    <!-- <link href="http://code.jquery.com/ui/1.10.4/themes/ui-lightness/jquery-ui.css" rel="stylesheet"> -->
+    <link rel="stylesheet" type="text/css" href="//code.jquery.com/ui/1.9.2/themes/base/jquery-ui.css">
+    <script src="http://code.jquery.com/jquery-1.10.2.js"></script>
+    <script src="http://code.jquery.com/ui/1.10.4/jquery-ui.js"></script>
     <script type="text/javascript" src="https://d3js.org/d3.v3.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3-tip/0.6.7/d3-tip.js"></script>
     <script type="text/javascript" src="js/viz-utils.js"></script>
@@ -26,6 +29,7 @@
             background: rgba(0, 0, 0, 0.8);
             color: #fff;
             border-radius: 2px;
+            z-index: 5;
         }
 
         .label {
@@ -37,6 +41,29 @@
         .a-input {
             padding: 3px;
         }
+
+        /* Slider Styles */
+        .ui-slider .ui-slider-handle {
+            height: 0.6em;
+        }
+        #rselect {
+            display: inline-block;
+        }
+        #rslider {
+            margin-bottom: 50px;
+        }
+        #rslider a {
+            text-decoration: none;
+            outline: none;
+        }
+        #sval1, #sval2 {
+            width: 50px;
+            text-align: center;
+            color: black;
+            text-decoration: none;
+            font: 14px sans-serif;
+            padding-left: 8px;
+        }
     </style>
 </head>
 
@@ -45,13 +72,21 @@
     <div id="selectors">
         <select id="game"></select>
         <form id="dtype">
-            <input name="atype" type="radio" value="attacked" onclick="vizAttackData()" checked><span class="a-input">Num Attack</span>
-            <input name="atype" type="radio" value="killed" onclick="vizAttackData()"><span class="a-input">Killed</span>
-            <input name="atype" type="radio" value="lost" onclick="vizAttackData()"><span class="a-input">Lost</span>
+            <input name="atype" type="radio" value="attacked" checked><span class="a-input">Num Attack</span>
+            <input name="atype" type="radio" value="killed"><span class="a-input">Killed</span>
+            <input name="atype" type="radio" value="lost"><span class="a-input">Lost</span>
         </form>
     </div>
     <svg id="attacks"></svg>
+    <div id="rselect">
+        <div id="rslider"></div>
+        <span id="sval1"></span>
+        <span id="sval2"></span>
+    </div>
     <script type="text/javascript" src="js/attack.js"></script>
+    <script>
+        $("input[name='atype']").click(function () { vizAttackData(true); });
+    </script>
 </body>
 
 </html>

--- a/data/600989.json
+++ b/data/600989.json
@@ -1,0 +1,5822 @@
+[
+  {
+    "message": "Game created.",
+    "timestamp": "2016-01-12T19:23:47.000Z",
+    "player": "unknown",
+    "round": 0
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-13T04:02:40.000Z",
+    "player": "ryanbmilbourne",
+    "round": 0
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 4 territories.",
+    "timestamp": "2016-01-13T04:02:40.000Z",
+    "player": "ryanbmilbourne",
+    "round": 0
+  },
+  {
+    "message": "Wayrest (ryanbmilbourne) was reinforced by ryanbmilbourne with 8 troops.",
+    "timestamp": "2016-01-13T04:03:11.000Z",
+    "player": "ryanbmilbourne",
+    "round": 0
+  },
+  {
+    "message": "Camlorn (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-13T04:03:15.000Z",
+    "player": "ryanbmilbourne",
+    "round": 0
+  },
+  {
+    "message": "Camlorn (ryanbmilbourne) attacked Daggerfall (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-13T04:03:21.000Z",
+    "player": "ryanbmilbourne",
+    "round": 0
+  },
+  {
+    "message": "Camlorn (ryanbmilbourne) occupied Daggerfall with 3 troops.",
+    "timestamp": "2016-01-13T04:03:26.000Z",
+    "player": "ryanbmilbourne",
+    "round": 0
+  },
+  {
+    "message": "Wayrest (ryanbmilbourne) attacked Jehanna (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-13T04:03:40.000Z",
+    "player": "ryanbmilbourne",
+    "round": 0
+  },
+  {
+    "message": "Wayrest (ryanbmilbourne) occupied Jehanna with 9 troops.",
+    "timestamp": "2016-01-13T04:03:42.000Z",
+    "player": "ryanbmilbourne",
+    "round": 0
+  },
+  {
+    "message": "Daggerfall (ryanbmilbourne) was fortified from Jehanna (ryanbmilbourne) with 2 troops.",
+    "timestamp": "2016-01-13T04:04:10.000Z",
+    "player": "ryanbmilbourne",
+    "round": 0
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-13T04:04:10.000Z",
+    "player": "ryanbmilbourne",
+    "round": 0
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-13T04:04:10.000Z",
+    "player": "ryanbmilbourne",
+    "round": 0
+  },
+  {
+    "message": "Round 8 started.",
+    "timestamp": "2016-01-13T04:04:10.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-13T04:19:17.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard received 3 troops for 2 territories.",
+    "timestamp": "2016-01-13T04:19:17.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Hegathe (gcochard) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-01-13T04:19:23.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Hegathe (gcochard) attacked Gilane (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-13T04:19:32.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Hegathe (gcochard) occupied Gilane with 10 troops.",
+    "timestamp": "2016-01-13T04:19:36.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-13T04:19:44.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-13T04:19:44.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-13T04:20:05.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren received 5 troops for 16 territories.",
+    "timestamp": "2016-01-13T04:20:05.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren received 3 troops for holding Summerset Isles.",
+    "timestamp": "2016-01-13T04:20:05.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren received 3 troops for holding Argonia.",
+    "timestamp": "2016-01-13T04:20:05.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Cheydinhal (kwren) was reinforced by kwren with 11 troops.",
+    "timestamp": "2016-01-13T04:20:15.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Cheydinhal (kwren) attacked Riften (mmacfreier) killing 2, losing 11.",
+    "timestamp": "2016-01-13T04:20:45.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Lillandril (kwren) attacked Hegathe (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-13T04:20:56.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Lillandril (kwren) occupied Hegathe with 1 troop.",
+    "timestamp": "2016-01-13T04:21:00.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-13T04:21:28.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-13T04:21:28.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Round 9 started.",
+    "timestamp": "2016-01-13T04:21:28.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-13T04:22:24.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "jobratt received 3 troops for 2 territories.",
+    "timestamp": "2016-01-13T04:22:24.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Taneth (jobratt) was reinforced by jobratt with 11 troops.",
+    "timestamp": "2016-01-13T04:22:44.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Taneth (jobratt) attacked Sentinel (ryanbmilbourne) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-01-13T04:23:51.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Taneth (jobratt) occupied Sentinel with 12 troops.",
+    "timestamp": "2016-01-13T04:23:57.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Sentinel (jobratt) attacked Dragonstar (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-13T04:24:12.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Sentinel (jobratt) occupied Dragonstar with 11 troops.",
+    "timestamp": "2016-01-13T04:24:16.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Dragonstar (jobratt) attacked Wayrest (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-13T04:24:20.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Dragonstar (jobratt) occupied Wayrest with 1 troop.",
+    "timestamp": "2016-01-13T04:24:32.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Dragonstar (jobratt) attacked Skaven (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-13T04:24:40.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Dragonstar (jobratt) occupied Skaven with 8 troops.",
+    "timestamp": "2016-01-13T04:24:41.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-13T04:24:47.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-13T04:24:47.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-13T04:36:56.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 received 6 troops for 18 territories.",
+    "timestamp": "2016-01-13T04:36:56.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 received 4 troops for holding Valenwood.",
+    "timestamp": "2016-01-13T04:36:56.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 received 4 troops for holding Elsweyr.",
+    "timestamp": "2016-01-13T04:36:56.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 received 2 troops on Woodhearth",
+    "timestamp": "2016-01-13T04:37:03.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 received 2 troops on Rimmen",
+    "timestamp": "2016-01-13T04:37:03.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Skingrad (tanleach1001) was reinforced by tanleach1001 with 4 troops.",
+    "timestamp": "2016-01-13T04:37:19.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Woodhearth (tanleach1001) was reinforced by tanleach1001 with 5 troops.",
+    "timestamp": "2016-01-13T04:37:34.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Rimmen (tanleach1001) was reinforced by tanleach1001 with 1 troop.",
+    "timestamp": "2016-01-13T04:37:42.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Anvil (tanleach1001) was reinforced by tanleach1001 with 12 troops.",
+    "timestamp": "2016-01-13T04:37:48.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Anvil (tanleach1001) attacked Firsthold (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-13T04:37:54.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Anvil (tanleach1001) occupied Firsthold with 1 troop.",
+    "timestamp": "2016-01-13T04:37:58.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Anvil (tanleach1001) attacked Kwatch (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-13T04:38:02.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Anvil (tanleach1001) occupied Kwatch with 1 troop.",
+    "timestamp": "2016-01-13T04:38:05.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Woodhearth (tanleach1001) attacked Skywatch (kwren) conquering it, killing 4, losing 4.",
+    "timestamp": "2016-01-13T04:38:27.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Woodhearth (tanleach1001) occupied Skywatch with 1 troop.",
+    "timestamp": "2016-01-13T04:38:36.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Skingrad (tanleach1001) was fortified from Anvil (tanleach1001) with 6 troops.",
+    "timestamp": "2016-01-13T04:39:18.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-13T04:39:19.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-13T04:39:19.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-13T04:39:51.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier received 6 troops for 18 territories.",
+    "timestamp": "2016-01-13T04:39:51.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Morrowind.",
+    "timestamp": "2016-01-13T04:39:51.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier received 5 troops for holding Skyrim.",
+    "timestamp": "2016-01-13T04:39:51.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Riften (mmacfreier) was reinforced by mmacfreier with 5 troops.",
+    "timestamp": "2016-01-13T04:40:18.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Falkreath (mmacfreier) was reinforced by mmacfreier with 4 troops.",
+    "timestamp": "2016-01-13T04:40:30.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Markarth (mmacfreier) was reinforced by mmacfreier with 6 troops.",
+    "timestamp": "2016-01-13T04:40:57.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Falkreath (mmacfreier) attacked Bruma (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-13T04:41:14.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Falkreath (mmacfreier) occupied Bruma with 1 troop.",
+    "timestamp": "2016-01-13T04:41:19.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Markarth (mmacfreier) was fortified from Solitude (mmacfreier) with 1 troop.",
+    "timestamp": "2016-01-13T04:41:26.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-13T04:41:27.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-13T04:41:27.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-13T04:43:46.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 4 territories.",
+    "timestamp": "2016-01-13T04:43:46.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Jehanna (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-13T04:43:55.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Jehanna (ryanbmilbourne) attacked Wayrest (jobratt) conquering it, killing 1, losing 7.",
+    "timestamp": "2016-01-13T04:44:09.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Jehanna (ryanbmilbourne) occupied Wayrest with 1 troop.",
+    "timestamp": "2016-01-13T04:44:30.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-13T05:43:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne ran out of time.",
+    "timestamp": "2016-01-13T05:43:47.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-13T17:00:46.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "gcochard received 3 troops for 1 territory.",
+    "timestamp": "2016-01-13T17:00:47.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Gilane (gcochard) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-01-13T17:00:52.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Gilane (gcochard) attacked Hegathe (kwren) conquering it, killing 1, losing 4.",
+    "timestamp": "2016-01-13T17:04:59.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Gilane (gcochard) occupied Hegathe with 8 troops.",
+    "timestamp": "2016-01-13T17:05:03.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Hegathe (gcochard) attacked Lillandril (kwren) conquering it, killing 2, losing 2.",
+    "timestamp": "2016-01-13T17:05:47.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Hegathe (gcochard) occupied Lillandril with 5 troops.",
+    "timestamp": "2016-01-13T17:05:50.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Lillandril (gcochard) attacked Firsthold (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-13T17:06:14.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Lillandril (gcochard) occupied Firsthold with 1 troop.",
+    "timestamp": "2016-01-13T17:06:21.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-13T17:07:03.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-13T17:07:03.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-13T17:39:17.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "kwren received 4 troops for 13 territories.",
+    "timestamp": "2016-01-13T17:39:17.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "kwren received 3 troops for holding Argonia.",
+    "timestamp": "2016-01-13T17:39:17.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Cloudrest (kwren) was reinforced by kwren with 7 troops.",
+    "timestamp": "2016-01-13T17:39:28.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Cloudrest (kwren) attacked Skywatch (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-13T17:39:32.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Cloudrest (kwren) occupied Skywatch with 7 troops.",
+    "timestamp": "2016-01-13T17:39:35.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Skywatch (kwren) attacked Firsthold (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-13T17:39:39.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Skywatch (kwren) occupied Firsthold with 5 troops.",
+    "timestamp": "2016-01-13T17:39:42.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Shimmerene (kwren) was fortified from Firsthold (kwren) with 4 troops.",
+    "timestamp": "2016-01-13T17:39:51.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-13T17:39:51.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-13T17:39:51.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Round 10 started.",
+    "timestamp": "2016-01-13T17:39:51.000Z",
+    "player": "unknown",
+    "round": 3
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-13T19:08:08.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt received 3 troops for 5 territories.",
+    "timestamp": "2016-01-13T19:08:08.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Dragonstar (jobratt) was reinforced by jobratt with 11 troops.",
+    "timestamp": "2016-01-13T19:08:46.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Dragonstar (jobratt) attacked Wayrest (ryanbmilbourne) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-13T19:08:54.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Dragonstar (jobratt) occupied Wayrest with 9 troops.",
+    "timestamp": "2016-01-13T19:09:10.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Wayrest (jobratt) was fortified from Skaven (jobratt) with 7 troops.",
+    "timestamp": "2016-01-13T19:09:42.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-13T19:09:42.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-13T19:09:42.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-13T19:33:01.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 received 6 troops for 19 territories.",
+    "timestamp": "2016-01-13T19:33:01.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 received 4 troops for holding Valenwood.",
+    "timestamp": "2016-01-13T19:33:01.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 received 4 troops for holding Elsweyr.",
+    "timestamp": "2016-01-13T19:33:01.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Anvil (tanleach1001) was reinforced by tanleach1001 with 14 troops.",
+    "timestamp": "2016-01-13T19:33:24.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Anvil (tanleach1001) attacked Firsthold (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-13T19:33:30.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Anvil (tanleach1001) occupied Firsthold with 20 troops.",
+    "timestamp": "2016-01-13T19:33:37.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Firsthold (tanleach1001) attacked Skywatch (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-13T19:33:41.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Firsthold (tanleach1001) occupied Skywatch with 19 troops.",
+    "timestamp": "2016-01-13T19:33:59.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Skywatch (tanleach1001) attacked Shimmerene (kwren) conquering it, killing 5, losing 0.",
+    "timestamp": "2016-01-13T19:34:05.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Skywatch (tanleach1001) occupied Shimmerene with 18 troops.",
+    "timestamp": "2016-01-13T19:34:08.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Shimmerene (tanleach1001) attacked Dusk (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-13T19:34:13.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Shimmerene (tanleach1001) occupied Dusk with 1 troop.",
+    "timestamp": "2016-01-13T19:34:54.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Shimmerene (tanleach1001) attacked Alinor (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-13T19:34:58.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Shimmerene (tanleach1001) occupied Alinor with 1 troop.",
+    "timestamp": "2016-01-13T19:35:10.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Shimmerene (tanleach1001) attacked Cloudrest (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-13T19:35:17.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Shimmerene (tanleach1001) occupied Cloudrest with 14 troops.",
+    "timestamp": "2016-01-13T19:35:20.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Cloudrest (tanleach1001) attacked Lillandril (gcochard) conquering it, killing 4, losing 0.",
+    "timestamp": "2016-01-13T19:35:27.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Cloudrest (tanleach1001) occupied Lillandril with 13 troops.",
+    "timestamp": "2016-01-13T19:36:39.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Firsthold (tanleach1001) was fortified from Woodhearth (tanleach1001) with 7 troops.",
+    "timestamp": "2016-01-13T19:37:26.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-13T19:37:26.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-13T19:37:26.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-13T19:39:17.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier received 6 troops for 19 territories.",
+    "timestamp": "2016-01-13T19:39:17.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Morrowind.",
+    "timestamp": "2016-01-13T19:39:17.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier received 5 troops for holding Skyrim.",
+    "timestamp": "2016-01-13T19:39:17.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Tear (mmacfreier) was reinforced by mmacfreier with 7 troops.",
+    "timestamp": "2016-01-13T19:39:34.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Markarth (mmacfreier) was reinforced by mmacfreier with 16 troops.",
+    "timestamp": "2016-01-13T19:39:43.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Markarth (mmacfreier) attacked Jehanna (ryanbmilbourne) conquering it, killing 2, losing 0.",
+    "timestamp": "2016-01-13T19:39:48.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Markarth (mmacfreier) occupied Jehanna with 26 troops.",
+    "timestamp": "2016-01-13T19:39:50.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Jehanna (mmacfreier) attacked Wayrest (jobratt) conquering it, killing 16, losing 14.",
+    "timestamp": "2016-01-13T19:40:10.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Jehanna (mmacfreier) occupied Wayrest with 11 troops.",
+    "timestamp": "2016-01-13T19:40:12.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Wayrest (mmacfreier) attacked Northpoint (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-13T19:40:17.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Wayrest (mmacfreier) occupied Northpoint with 1 troop.",
+    "timestamp": "2016-01-13T19:40:19.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Wayrest (mmacfreier) attacked Camlorn (ryanbmilbourne) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-13T19:40:24.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Wayrest (mmacfreier) occupied Camlorn with 6 troops.",
+    "timestamp": "2016-01-13T19:40:26.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Camlorn (mmacfreier) attacked Daggerfall (ryanbmilbourne) conquering it, killing 5, losing 0.",
+    "timestamp": "2016-01-13T19:40:33.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne was defeated by mmacfreier.",
+    "timestamp": "2016-01-13T19:40:33.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Camlorn (mmacfreier) occupied Daggerfall with 5 troops.",
+    "timestamp": "2016-01-13T19:40:37.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier received 2 troops on Mournhold",
+    "timestamp": "2016-01-13T19:40:42.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier received 2 troops on Bruma",
+    "timestamp": "2016-01-13T19:40:42.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Jehanna (mmacfreier) was reinforced by mmacfreier with 8 troops.",
+    "timestamp": "2016-01-13T19:40:55.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Jehanna (mmacfreier) attacked Dragonstar (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-13T19:41:03.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Jehanna (mmacfreier) occupied Dragonstar with 7 troops.",
+    "timestamp": "2016-01-13T19:41:05.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Markarth (mmacfreier) was fortified from Dragonstar (mmacfreier) with 6 troops.",
+    "timestamp": "2016-01-13T19:41:32.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-13T19:41:32.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-13T19:41:32.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-13T19:42:52.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard received 3 troops for 2 territories.",
+    "timestamp": "2016-01-13T19:42:52.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Gilane (gcochard) was reinforced by gcochard with 11 troops.",
+    "timestamp": "2016-01-13T19:43:11.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Gilane (gcochard) attacked Taneth (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-13T19:43:18.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Gilane (gcochard) occupied Taneth with 11 troops.",
+    "timestamp": "2016-01-13T19:43:27.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Taneth (gcochard) attacked Rihad (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-13T19:43:32.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Taneth (gcochard) occupied Rihad with 10 troops.",
+    "timestamp": "2016-01-13T19:43:35.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Rihad (gcochard) attacked Elinhir (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-13T19:43:39.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Rihad (gcochard) occupied Elinhir with 9 troops.",
+    "timestamp": "2016-01-13T19:43:41.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Elinhir (gcochard) attacked Skaven (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-13T19:43:45.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Elinhir (gcochard) occupied Skaven with 8 troops.",
+    "timestamp": "2016-01-13T19:43:47.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Skaven (gcochard) attacked Sentinel (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-13T19:43:52.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "jobratt was defeated by gcochard.",
+    "timestamp": "2016-01-13T19:43:52.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Skaven (gcochard) occupied Sentinel with 7 troops.",
+    "timestamp": "2016-01-13T19:43:54.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Sentinel (gcochard) attacked Dragonstar (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-13T19:43:59.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Sentinel (gcochard) occupied Dragonstar with 1 troop.",
+    "timestamp": "2016-01-13T19:44:04.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Taneth (gcochard) was fortified from Sentinel (gcochard) with 4 troops.",
+    "timestamp": "2016-01-13T19:44:19.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-13T19:44:19.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-13T19:44:19.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-13T19:44:32.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren received 3 troops for 9 territories.",
+    "timestamp": "2016-01-13T19:44:32.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren received 3 troops for holding Argonia.",
+    "timestamp": "2016-01-13T19:44:32.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren received 2 troops on Blackrose",
+    "timestamp": "2016-01-13T19:44:38.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Cheydinhal (kwren) was reinforced by kwren with 14 troops.",
+    "timestamp": "2016-01-13T19:44:45.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Cheydinhal (kwren) attacked Riften (mmacfreier) conquering it, killing 6, losing 2.",
+    "timestamp": "2016-01-13T19:44:55.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Cheydinhal (kwren) occupied Riften with 1 troop.",
+    "timestamp": "2016-01-13T19:45:06.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Cheydinhal (kwren) attacked Chorrol (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-13T19:45:11.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Cheydinhal (kwren) occupied Chorrol with 1 troop.",
+    "timestamp": "2016-01-13T19:45:16.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Helstrom (kwren) was fortified from Cheydinhal (kwren) with 10 troops.",
+    "timestamp": "2016-01-13T19:45:28.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-13T19:45:28.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-13T19:45:28.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Round 11 started.",
+    "timestamp": "2016-01-13T19:45:28.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-13T19:53:00.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 received 8 troops for 25 territories.",
+    "timestamp": "2016-01-13T19:53:00.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 received 4 troops for holding Valenwood.",
+    "timestamp": "2016-01-13T19:53:00.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 received 4 troops for holding Elsweyr.",
+    "timestamp": "2016-01-13T19:53:00.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Summerset Isles.",
+    "timestamp": "2016-01-13T19:53:00.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Lillandril (tanleach1001) was reinforced by tanleach1001 with 19 troops.",
+    "timestamp": "2016-01-13T19:53:10.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Lillandril (tanleach1001) attacked Daggerfall (mmacfreier) conquering it, killing 5, losing 5.",
+    "timestamp": "2016-01-13T19:53:32.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Lillandril (tanleach1001) occupied Daggerfall with 26 troops.",
+    "timestamp": "2016-01-13T19:53:33.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Daggerfall (tanleach1001) attacked Camlorn (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-13T19:53:41.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Daggerfall (tanleach1001) occupied Camlorn with 25 troops.",
+    "timestamp": "2016-01-13T19:53:43.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Camlorn (tanleach1001) attacked Northpoint (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-13T19:53:48.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Camlorn (tanleach1001) occupied Northpoint with 24 troops.",
+    "timestamp": "2016-01-13T19:53:54.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Northpoint (tanleach1001) attacked Wayrest (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-13T19:54:00.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Northpoint (tanleach1001) occupied Wayrest with 23 troops.",
+    "timestamp": "2016-01-13T19:54:03.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Wayrest (tanleach1001) attacked Jehanna (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-13T19:54:07.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Wayrest (tanleach1001) occupied Jehanna with 22 troops.",
+    "timestamp": "2016-01-13T19:54:33.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Wayrest (tanleach1001) was fortified from Firsthold (tanleach1001) with 7 troops.",
+    "timestamp": "2016-01-13T19:55:22.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-13T19:55:22.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-13T19:55:22.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-13T19:55:34.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier received 5 troops for 17 territories.",
+    "timestamp": "2016-01-13T19:55:34.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Morrowind.",
+    "timestamp": "2016-01-13T19:55:34.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Windhelm (mmacfreier) was reinforced by mmacfreier with 9 troops.",
+    "timestamp": "2016-01-13T19:55:46.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Windhelm (mmacfreier) attacked Riften (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-13T19:55:52.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Windhelm (mmacfreier) occupied Riften with 7 troops.",
+    "timestamp": "2016-01-13T19:55:53.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Riften (mmacfreier) was fortified from Bruma (mmacfreier) with 2 troops.",
+    "timestamp": "2016-01-13T19:56:00.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-13T19:56:00.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-13T19:56:00.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-13T19:57:21.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard received 3 troops for 8 territories.",
+    "timestamp": "2016-01-13T19:57:21.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard received 4 troops for holding Hammerfell.",
+    "timestamp": "2016-01-13T19:57:21.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Elinhir (gcochard) was reinforced by gcochard with 7 troops.",
+    "timestamp": "2016-01-13T19:57:37.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Elinhir (gcochard) attacked Bruma (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-13T19:57:43.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Elinhir (gcochard) occupied Bruma with 6 troops.",
+    "timestamp": "2016-01-13T19:57:47.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Taneth (gcochard) was fortified from Bruma (gcochard) with 5 troops.",
+    "timestamp": "2016-01-13T19:57:55.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-13T19:57:56.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-13T19:57:56.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-13T19:58:07.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "kwren received 3 troops for 10 territories.",
+    "timestamp": "2016-01-13T19:58:07.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "kwren received 3 troops for holding Argonia.",
+    "timestamp": "2016-01-13T19:58:07.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Chorrol (kwren) was reinforced by kwren with 6 troops.",
+    "timestamp": "2016-01-13T19:58:14.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Chorrol (kwren) attacked Bruma (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-13T19:58:18.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Chorrol (kwren) occupied Bruma with 6 troops.",
+    "timestamp": "2016-01-13T19:58:22.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Bruma (kwren) attacked Falkreath (mmacfreier) conquering it, killing 6, losing 1.",
+    "timestamp": "2016-01-13T19:58:31.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Bruma (kwren) occupied Falkreath with 1 troop.",
+    "timestamp": "2016-01-13T19:58:36.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Helstrom (kwren) was fortified from Bruma (kwren) with 3 troops.",
+    "timestamp": "2016-01-13T19:58:51.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-13T19:58:51.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-13T19:58:51.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Round 12 started.",
+    "timestamp": "2016-01-13T19:58:51.000Z",
+    "player": "unknown",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-14T00:26:33.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received 10 troops for 30 territories.",
+    "timestamp": "2016-01-14T00:26:33.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding High Rock.",
+    "timestamp": "2016-01-14T00:26:33.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Summerset Isles.",
+    "timestamp": "2016-01-14T00:26:33.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received 4 troops for holding Valenwood.",
+    "timestamp": "2016-01-14T00:26:33.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received 4 troops for holding Elsweyr.",
+    "timestamp": "2016-01-14T00:26:33.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Wayrest (tanleach1001) was reinforced by tanleach1001 with 24 troops.",
+    "timestamp": "2016-01-14T00:26:44.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Wayrest (tanleach1001) attacked Dragonstar (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T00:27:06.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Wayrest (tanleach1001) occupied Dragonstar with 31 troops.",
+    "timestamp": "2016-01-14T00:27:12.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Dragonstar (tanleach1001) attacked Sentinel (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T00:27:36.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Dragonstar (tanleach1001) occupied Sentinel with 30 troops.",
+    "timestamp": "2016-01-14T00:27:38.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Sentinel (tanleach1001) attacked Hegathe (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T00:27:49.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Sentinel (tanleach1001) occupied Hegathe with 28 troops.",
+    "timestamp": "2016-01-14T00:27:51.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Hegathe (tanleach1001) attacked Gilane (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T00:28:00.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Hegathe (tanleach1001) occupied Gilane with 26 troops.",
+    "timestamp": "2016-01-14T00:28:05.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Gilane (tanleach1001) attacked Taneth (gcochard) conquering it, killing 10, losing 5.",
+    "timestamp": "2016-01-14T00:28:34.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Gilane (tanleach1001) occupied Taneth with 20 troops.",
+    "timestamp": "2016-01-14T00:28:43.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Taneth (tanleach1001) attacked Rihad (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T00:28:53.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Taneth (tanleach1001) occupied Rihad with 19 troops.",
+    "timestamp": "2016-01-14T00:28:56.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Rihad (tanleach1001) attacked Elinhir (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T00:29:08.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Rihad (tanleach1001) occupied Elinhir with 17 troops.",
+    "timestamp": "2016-01-14T00:29:12.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Elinhir (tanleach1001) attacked Skaven (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T00:29:16.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "gcochard was defeated by tanleach1001.",
+    "timestamp": "2016-01-14T00:29:16.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Elinhir (tanleach1001) occupied Skaven with 1 troop.",
+    "timestamp": "2016-01-14T00:29:52.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received 2 troops on Arenthia",
+    "timestamp": "2016-01-14T00:30:05.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received 2 troops on Hegathe",
+    "timestamp": "2016-01-14T00:30:05.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received 2 troops on Rihad",
+    "timestamp": "2016-01-14T00:30:13.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Jehanna (tanleach1001) was reinforced by tanleach1001 with 16 troops.",
+    "timestamp": "2016-01-14T00:30:22.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Jehanna (tanleach1001) attacked Markarth (mmacfreier) conquering it, killing 7, losing 9.",
+    "timestamp": "2016-01-14T00:30:48.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Jehanna (tanleach1001) occupied Markarth with 28 troops.",
+    "timestamp": "2016-01-14T00:30:59.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Markarth (tanleach1001) attacked Solitude (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T00:31:08.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Markarth (tanleach1001) occupied Solitude with 1 troop.",
+    "timestamp": "2016-01-14T01:09:31.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Markarth (tanleach1001) attacked Morthal (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T01:09:35.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Markarth (tanleach1001) occupied Morthal with 1 troop.",
+    "timestamp": "2016-01-14T01:09:44.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Markarth (tanleach1001) attacked Whiterun (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T01:09:51.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Markarth (tanleach1001) occupied Whiterun with 25 troops.",
+    "timestamp": "2016-01-14T01:09:53.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Whiterun (tanleach1001) attacked Riften (mmacfreier) conquering it, killing 9, losing 7.",
+    "timestamp": "2016-01-14T01:10:12.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Whiterun (tanleach1001) occupied Riften with 1 troop.",
+    "timestamp": "2016-01-14T01:10:20.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Whiterun (tanleach1001) attacked Dawnstar (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T01:10:24.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Whiterun (tanleach1001) occupied Dawnstar with 4 troops.",
+    "timestamp": "2016-01-14T01:10:37.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Whiterun (tanleach1001) attacked Windhelm (mmacfreier) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-14T01:10:43.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Whiterun (tanleach1001) occupied Windhelm with 1 troop.",
+    "timestamp": "2016-01-14T01:10:50.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Dawnstar (tanleach1001) attacked Winterhold (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T01:10:54.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Dawnstar (tanleach1001) occupied Winterhold with 3 troops.",
+    "timestamp": "2016-01-14T01:11:02.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Whiterun (tanleach1001) attacked Falkreath (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T01:11:05.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Whiterun (tanleach1001) occupied Falkreath with 9 troops.",
+    "timestamp": "2016-01-14T01:11:07.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Markarth (tanleach1001) was fortified from Elinhir (tanleach1001) with 7 troops.",
+    "timestamp": "2016-01-14T01:11:42.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-14T01:11:42.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-14T01:11:42.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-14T17:11:59.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier received 3 troops for 8 territories.",
+    "timestamp": "2016-01-14T17:11:59.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Morrowind.",
+    "timestamp": "2016-01-14T17:11:59.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Blacklight (mmacfreier) was reinforced by mmacfreier with 7 troops.",
+    "timestamp": "2016-01-14T17:12:31.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Blacklight (mmacfreier) attacked Riften (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T17:12:39.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Blacklight (mmacfreier) occupied Riften with 16 troops.",
+    "timestamp": "2016-01-14T17:12:47.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Riften (mmacfreier) attacked Cheydinhal (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-14T17:12:58.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Riften (mmacfreier) occupied Cheydinhal with 13 troops.",
+    "timestamp": "2016-01-14T17:13:00.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Cheydinhal (mmacfreier) attacked Bravil (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T17:13:03.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Cheydinhal (mmacfreier) occupied Bravil with 12 troops.",
+    "timestamp": "2016-01-14T17:13:06.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Bravil (mmacfreier) attacked Rimmen (tanleach1001) killing 6, losing 8.",
+    "timestamp": "2016-01-14T17:13:16.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Blacklight (mmacfreier) was fortified from Bravil (mmacfreier) with 3 troops.",
+    "timestamp": "2016-01-14T17:13:30.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-14T17:13:30.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-14T17:13:30.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-14T17:31:04.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received 3 troops for 9 territories.",
+    "timestamp": "2016-01-14T17:31:04.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received 3 troops for holding Argonia.",
+    "timestamp": "2016-01-14T17:31:04.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Stormhold (kwren) was reinforced by kwren with 6 troops.",
+    "timestamp": "2016-01-14T17:31:08.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Stormhold (kwren) attacked Bravil (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T17:31:12.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Stormhold (kwren) occupied Bravil with 17 troops.",
+    "timestamp": "2016-01-14T17:31:14.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Bravil (kwren) attacked Rimmen (tanleach1001) conquering it, killing 4, losing 4.",
+    "timestamp": "2016-01-14T17:31:33.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Bravil (kwren) occupied Rimmen with 12 troops.",
+    "timestamp": "2016-01-14T17:31:35.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Rimmen (kwren) attacked Orcrest (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T17:31:40.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Rimmen (kwren) occupied Orcrest with 11 troops.",
+    "timestamp": "2016-01-14T17:31:42.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Orcrest (kwren) attacked Dune (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T17:31:45.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Orcrest (kwren) occupied Dune with 10 troops.",
+    "timestamp": "2016-01-14T17:31:47.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Dune (kwren) attacked Silvenar (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T17:31:51.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Dune (kwren) occupied Silvenar with 9 troops.",
+    "timestamp": "2016-01-14T17:31:52.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Silvenar (kwren) attacked Woodhearth (tanleach1001) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-01-14T17:31:58.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Silvenar (kwren) occupied Woodhearth with 5 troops.",
+    "timestamp": "2016-01-14T17:32:00.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Woodhearth (kwren) attacked Skywatch (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T17:32:04.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Woodhearth (kwren) occupied Skywatch with 4 troops.",
+    "timestamp": "2016-01-14T17:32:07.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Skywatch (kwren) attacked Cloudrest (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T17:32:11.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Skywatch (kwren) occupied Cloudrest with 3 troops.",
+    "timestamp": "2016-01-14T17:32:12.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Cloudrest (kwren) attacked Lillandril (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T17:32:15.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Cloudrest (kwren) occupied Lillandril with 2 troops.",
+    "timestamp": "2016-01-14T17:32:17.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Lillandril (kwren) attacked Daggerfall (tanleach1001) killing 0, losing 1.",
+    "timestamp": "2016-01-14T17:32:20.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Stormhold (kwren) was fortified from Helstrom (kwren) with 13 troops.",
+    "timestamp": "2016-01-14T17:33:31.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-14T17:33:31.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-14T17:33:31.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Round 13 started.",
+    "timestamp": "2016-01-14T17:33:31.000Z",
+    "player": "unknown",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-14T17:37:34.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 received 12 troops for 38 territories.",
+    "timestamp": "2016-01-14T17:37:34.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 received 4 troops for holding Hammerfell.",
+    "timestamp": "2016-01-14T17:37:34.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding High Rock.",
+    "timestamp": "2016-01-14T17:37:34.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 received 2 troops on Winterhold",
+    "timestamp": "2016-01-14T17:37:39.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 received 2 troops on Sentinel",
+    "timestamp": "2016-01-14T17:37:39.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Hegathe (tanleach1001) was reinforced by tanleach1001 with 17 troops.",
+    "timestamp": "2016-01-14T17:38:02.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Falkreath (tanleach1001) was reinforced by tanleach1001 with 10 troops.",
+    "timestamp": "2016-01-14T17:38:12.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Hegathe (tanleach1001) attacked Lillandril (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T17:38:21.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Hegathe (tanleach1001) occupied Lillandril with 18 troops.",
+    "timestamp": "2016-01-14T17:38:23.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Lillandril (tanleach1001) attacked Cloudrest (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T17:38:26.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Lillandril (tanleach1001) occupied Cloudrest with 17 troops.",
+    "timestamp": "2016-01-14T17:38:28.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Cloudrest (tanleach1001) attacked Skywatch (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T17:38:31.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Cloudrest (tanleach1001) occupied Skywatch with 16 troops.",
+    "timestamp": "2016-01-14T17:38:34.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Skywatch (tanleach1001) attacked Woodhearth (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T17:38:39.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Skywatch (tanleach1001) occupied Woodhearth with 14 troops.",
+    "timestamp": "2016-01-14T17:38:41.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Woodhearth (tanleach1001) attacked Silvenar (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T17:38:44.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Woodhearth (tanleach1001) occupied Silvenar with 13 troops.",
+    "timestamp": "2016-01-14T17:38:46.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Silvenar (tanleach1001) attacked Dune (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T17:38:50.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Silvenar (tanleach1001) occupied Dune with 12 troops.",
+    "timestamp": "2016-01-14T17:38:51.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Dune (tanleach1001) attacked Orcrest (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-14T17:38:59.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Dune (tanleach1001) occupied Orcrest with 9 troops.",
+    "timestamp": "2016-01-14T17:39:02.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Orcrest (tanleach1001) attacked Rimmen (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T17:39:07.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Orcrest (tanleach1001) occupied Rimmen with 7 troops.",
+    "timestamp": "2016-01-14T17:39:10.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Falkreath (tanleach1001) attacked Riften (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T17:48:49.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Falkreath (tanleach1001) occupied Riften with 18 troops.",
+    "timestamp": "2016-01-14T17:48:50.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Riften (tanleach1001) attacked Blacklight (mmacfreier) conquering it, killing 4, losing 6.",
+    "timestamp": "2016-01-14T17:49:00.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Riften (tanleach1001) occupied Blacklight with 11 troops.",
+    "timestamp": "2016-01-14T17:51:09.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Skingrad (tanleach1001) attacked Chorrol (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T17:51:33.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Skingrad (tanleach1001) occupied Chorrol with 11 troops.",
+    "timestamp": "2016-01-14T17:51:35.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Chorrol (tanleach1001) attacked Bruma (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T17:51:39.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Chorrol (tanleach1001) occupied Bruma with 9 troops.",
+    "timestamp": "2016-01-14T17:51:41.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Bruma (tanleach1001) attacked Cheydinhal (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T17:51:44.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Bruma (tanleach1001) occupied Cheydinhal with 8 troops.",
+    "timestamp": "2016-01-14T17:51:46.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Cheydinhal (tanleach1001) was fortified from Elinhir (tanleach1001) with 8 troops.",
+    "timestamp": "2016-01-14T17:52:03.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-14T17:52:03.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-14T17:52:03.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-14T18:11:24.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier received 3 troops for 7 territories.",
+    "timestamp": "2016-01-14T18:11:24.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Mournhold (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-14T18:11:39.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Narsis (mmacfreier) attacked Bravil (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:12:07.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Narsis (mmacfreier) occupied Bravil with 1 troop.",
+    "timestamp": "2016-01-14T18:12:11.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Mournhold (mmacfreier) attacked Cheydinhal (tanleach1001) killing 9, losing 12.",
+    "timestamp": "2016-01-14T18:12:26.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Mournhold (mmacfreier) was fortified from Tear (mmacfreier) with 7 troops.",
+    "timestamp": "2016-01-14T18:12:32.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-14T18:12:32.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-14T18:12:32.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-14T18:13:24.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 3 troops for 7 territories.",
+    "timestamp": "2016-01-14T18:13:24.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 3 troops for holding Argonia.",
+    "timestamp": "2016-01-14T18:13:24.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Stormhold (kwren) was reinforced by kwren with 14 troops.",
+    "timestamp": "2016-01-14T18:13:30.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Stormhold (kwren) attacked Bravil (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:13:33.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Stormhold (kwren) occupied Bravil with 27 troops.",
+    "timestamp": "2016-01-14T18:13:34.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Bravil (kwren) attacked Cheydinhal (tanleach1001) conquering it, killing 7, losing 3.",
+    "timestamp": "2016-01-14T18:13:41.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Bravil (kwren) occupied Cheydinhal with 6 troops.",
+    "timestamp": "2016-01-14T18:13:46.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Cheydinhal (kwren) attacked Riften (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:13:49.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Cheydinhal (kwren) occupied Riften with 5 troops.",
+    "timestamp": "2016-01-14T18:13:50.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Riften (kwren) attacked Whiterun (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:13:53.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Riften (kwren) occupied Whiterun with 4 troops.",
+    "timestamp": "2016-01-14T18:13:55.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Whiterun (kwren) attacked Falkreath (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:13:58.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Whiterun (kwren) occupied Falkreath with 3 troops.",
+    "timestamp": "2016-01-14T18:13:59.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Falkreath (kwren) attacked Dragonstar (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:14:02.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Falkreath (kwren) occupied Dragonstar with 2 troops.",
+    "timestamp": "2016-01-14T18:14:04.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Dragonstar (kwren) attacked Jehanna (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:14:07.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Bravil (kwren) attacked Rimmen (tanleach1001) conquering it, killing 7, losing 2.",
+    "timestamp": "2016-01-14T18:14:14.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Bravil (kwren) occupied Rimmen with 15 troops.",
+    "timestamp": "2016-01-14T18:14:16.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Rimmen (kwren) attacked Riverhold (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:14:19.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Rimmen (kwren) occupied Riverhold with 14 troops.",
+    "timestamp": "2016-01-14T18:14:21.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Riverhold (kwren) attacked Arenthia (tanleach1001) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-01-14T18:14:27.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Riverhold (kwren) occupied Arenthia with 11 troops.",
+    "timestamp": "2016-01-14T18:14:29.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Arenthia (kwren) attacked Silvenar (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:14:33.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Arenthia (kwren) occupied Silvenar with 10 troops.",
+    "timestamp": "2016-01-14T18:14:34.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Silvenar (kwren) attacked Woodhearth (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:14:37.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Silvenar (kwren) occupied Woodhearth with 9 troops.",
+    "timestamp": "2016-01-14T18:14:39.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Woodhearth (kwren) attacked Skywatch (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:14:43.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Woodhearth (kwren) occupied Skywatch with 1 troop.",
+    "timestamp": "2016-01-14T18:14:50.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Stormhold (kwren) was fortified from Woodhearth (kwren) with 7 troops.",
+    "timestamp": "2016-01-14T18:15:03.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-14T18:15:03.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-14T18:15:03.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Round 14 started.",
+    "timestamp": "2016-01-14T18:15:03.000Z",
+    "player": "unknown",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-14T18:16:12.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 received 13 troops for 39 territories.",
+    "timestamp": "2016-01-14T18:16:13.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Blacklight (tanleach1001) was reinforced by tanleach1001 with 13 troops.",
+    "timestamp": "2016-01-14T18:17:41.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Blacklight (tanleach1001) attacked Mournhold (mmacfreier) conquering it, killing 8, losing 4.",
+    "timestamp": "2016-01-14T18:17:50.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Blacklight (tanleach1001) occupied Mournhold with 19 troops.",
+    "timestamp": "2016-01-14T18:18:12.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Mournhold (tanleach1001) attacked Narsis (mmacfreier) killing 6, losing 18.",
+    "timestamp": "2016-01-14T18:18:32.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Markarth (tanleach1001) attacked Jehanna (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T18:19:39.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Markarth (tanleach1001) occupied Jehanna with 6 troops.",
+    "timestamp": "2016-01-14T18:19:43.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Falinesti (tanleach1001) attacked Woodhearth (kwren) killing 0, losing 2.",
+    "timestamp": "2016-01-14T18:19:49.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Sentinel (tanleach1001) attacked Dragonstar (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:20:00.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Sentinel (tanleach1001) occupied Dragonstar with 2 troops.",
+    "timestamp": "2016-01-14T18:20:03.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Lillandril (tanleach1001) was fortified from Winterhold (tanleach1001) with 4 troops.",
+    "timestamp": "2016-01-14T18:20:48.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-14T18:20:48.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-14T18:20:48.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-14T18:22:31.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier received 3 troops for 6 territories.",
+    "timestamp": "2016-01-14T18:22:31.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Tear (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-14T18:22:38.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Tear (mmacfreier) attacked Mournhold (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:22:41.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Tear (mmacfreier) occupied Mournhold with 3 troops.",
+    "timestamp": "2016-01-14T18:22:43.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Mournhold (mmacfreier) attacked Blacklight (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:22:49.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Mournhold (mmacfreier) occupied Blacklight with 2 troops.",
+    "timestamp": "2016-01-14T18:22:52.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-14T18:22:58.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-14T18:22:58.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-14T18:24:43.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren received 6 troops for 18 territories.",
+    "timestamp": "2016-01-14T18:24:43.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren received 3 troops for holding Argonia.",
+    "timestamp": "2016-01-14T18:24:43.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Falkreath (kwren) was reinforced by kwren with 9 troops.",
+    "timestamp": "2016-01-14T18:25:09.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Falkreath (kwren) attacked Elinhir (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:25:12.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Falkreath (kwren) occupied Elinhir with 9 troops.",
+    "timestamp": "2016-01-14T18:25:14.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Elinhir (kwren) attacked Kwatch (tanleach1001) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-14T18:25:19.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Elinhir (kwren) occupied Kwatch with 6 troops.",
+    "timestamp": "2016-01-14T18:25:20.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Kwatch (kwren) attacked Skingrad (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:25:27.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Kwatch (kwren) occupied Skingrad with 5 troops.",
+    "timestamp": "2016-01-14T18:25:29.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Skingrad (kwren) attacked Imperial City (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:26:12.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Skingrad (kwren) occupied Imperial City with 1 troop.",
+    "timestamp": "2016-01-14T18:26:28.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Rimmen (kwren) was fortified from Skingrad (kwren) with 3 troops.",
+    "timestamp": "2016-01-14T18:26:45.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-14T18:26:45.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-14T18:26:45.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Round 15 started.",
+    "timestamp": "2016-01-14T18:26:45.000Z",
+    "player": "unknown",
+    "round": 8
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-14T18:26:50.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "tanleach1001 received 12 troops for 36 territories.",
+    "timestamp": "2016-01-14T18:26:50.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding High Rock.",
+    "timestamp": "2016-01-14T18:26:50.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Rihad (tanleach1001) was reinforced by tanleach1001 with 15 troops.",
+    "timestamp": "2016-01-14T18:28:52.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Rihad (tanleach1001) attacked Elinhir (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T18:28:59.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Rihad (tanleach1001) occupied Elinhir with 16 troops.",
+    "timestamp": "2016-01-14T18:29:02.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Elinhir (tanleach1001) attacked Falkreath (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:29:10.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Elinhir (tanleach1001) occupied Falkreath with 15 troops.",
+    "timestamp": "2016-01-14T18:29:12.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Falkreath (tanleach1001) attacked Whiterun (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:29:15.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Falkreath (tanleach1001) occupied Whiterun with 14 troops.",
+    "timestamp": "2016-01-14T18:29:16.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Whiterun (tanleach1001) attacked Riften (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-14T18:29:25.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Whiterun (tanleach1001) occupied Riften with 11 troops.",
+    "timestamp": "2016-01-14T18:29:33.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Elinhir (tanleach1001) was fortified from Jehanna (tanleach1001) with 5 troops.",
+    "timestamp": "2016-01-14T18:30:15.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-14T18:30:15.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-14T18:30:15.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-14T18:31:30.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier received 3 troops for 8 territories.",
+    "timestamp": "2016-01-14T18:31:30.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Morrowind.",
+    "timestamp": "2016-01-14T18:31:30.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier received 2 troops on Narsis",
+    "timestamp": "2016-01-14T18:31:52.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Blacklight (mmacfreier) was reinforced by mmacfreier with 15 troops.",
+    "timestamp": "2016-01-14T18:32:03.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Blacklight (mmacfreier) attacked Windhelm (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:32:07.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Blacklight (mmacfreier) occupied Windhelm with 1 troop.",
+    "timestamp": "2016-01-14T18:32:11.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Blacklight (mmacfreier) attacked Riften (tanleach1001) conquering it, killing 11, losing 5.",
+    "timestamp": "2016-01-14T18:32:22.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Blacklight (mmacfreier) occupied Riften with 1 troop.",
+    "timestamp": "2016-01-14T18:32:27.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Mournhold (mmacfreier) was fortified from Blacklight (mmacfreier) with 3 troops.",
+    "timestamp": "2016-01-14T18:32:40.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-14T18:32:40.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-14T18:32:40.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-14T18:32:53.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received 6 troops for 18 territories.",
+    "timestamp": "2016-01-14T18:32:53.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received 3 troops for holding Argonia.",
+    "timestamp": "2016-01-14T18:32:53.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Rimmen (kwren) was reinforced by kwren with 9 troops.",
+    "timestamp": "2016-01-14T18:32:58.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Rimmen (kwren) attacked Corinthe (tanleach1001) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-14T18:33:06.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Rimmen (kwren) occupied Corinthe with 10 troops.",
+    "timestamp": "2016-01-14T18:33:10.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Corinthe (kwren) attacked Orcrest (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:33:14.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Corinthe (kwren) occupied Orcrest with 1 troop.",
+    "timestamp": "2016-01-14T18:33:17.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Corinthe (kwren) attacked Senchal (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:33:20.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Corinthe (kwren) occupied Senchal with 8 troops.",
+    "timestamp": "2016-01-14T18:33:22.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Senchal (kwren) attacked Torval (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:33:27.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Senchal (kwren) occupied Torval with 7 troops.",
+    "timestamp": "2016-01-14T18:33:28.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Torval (kwren) attacked Dune (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T18:33:37.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Torval (kwren) occupied Dune with 5 troops.",
+    "timestamp": "2016-01-14T18:33:39.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Dune (kwren) attacked Haven (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:33:45.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Dune (kwren) occupied Haven with 4 troops.",
+    "timestamp": "2016-01-14T18:33:48.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Haven (kwren) attacked Elden Root (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:33:52.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Haven (kwren) occupied Elden Root with 3 troops.",
+    "timestamp": "2016-01-14T18:33:54.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Elden Root (kwren) attacked Southpoint (tanleach1001) killing 0, losing 2.",
+    "timestamp": "2016-01-14T18:33:58.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Skywatch (kwren) was fortified from Thorn (kwren) with 7 troops.",
+    "timestamp": "2016-01-14T18:34:21.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-14T18:34:21.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-14T18:34:21.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Round 16 started.",
+    "timestamp": "2016-01-14T18:34:21.000Z",
+    "player": "unknown",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-14T18:36:46.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 received 10 troops for 31 territories.",
+    "timestamp": "2016-01-14T18:36:46.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding High Rock.",
+    "timestamp": "2016-01-14T18:36:46.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 received 4 troops for holding Hammerfell.",
+    "timestamp": "2016-01-14T18:36:46.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Firsthold (tanleach1001) was reinforced by tanleach1001 with 17 troops.",
+    "timestamp": "2016-01-14T18:37:06.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Firsthold (tanleach1001) attacked Skywatch (kwren) conquering it, killing 8, losing 0.",
+    "timestamp": "2016-01-14T18:37:13.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Firsthold (tanleach1001) occupied Skywatch with 17 troops.",
+    "timestamp": "2016-01-14T18:37:15.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Skywatch (tanleach1001) attacked Woodhearth (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-14T18:38:46.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Skywatch (tanleach1001) occupied Woodhearth with 14 troops.",
+    "timestamp": "2016-01-14T18:38:49.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Woodhearth (tanleach1001) attacked Elden Root (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T18:39:00.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Woodhearth (tanleach1001) occupied Elden Root with 12 troops.",
+    "timestamp": "2016-01-14T18:39:02.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Elden Root (tanleach1001) attacked Haven (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:39:06.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Elden Root (tanleach1001) occupied Haven with 1 troop.",
+    "timestamp": "2016-01-14T18:39:10.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Elden Root (tanleach1001) attacked Silvenar (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:39:14.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Elden Root (tanleach1001) occupied Silvenar with 6 troops.",
+    "timestamp": "2016-01-14T18:39:29.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Silvenar (tanleach1001) attacked Arenthia (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:39:33.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Silvenar (tanleach1001) occupied Arenthia with 3 troops.",
+    "timestamp": "2016-01-14T18:40:12.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Elinhir (tanleach1001) attacked Kwatch (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:40:48.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Elinhir (tanleach1001) occupied Kwatch with 5 troops.",
+    "timestamp": "2016-01-14T18:40:50.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Kwatch (tanleach1001) attacked Skingrad (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:41:05.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Kwatch (tanleach1001) occupied Skingrad with 4 troops.",
+    "timestamp": "2016-01-14T18:41:07.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Skingrad (tanleach1001) attacked Riverhold (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:41:10.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Skingrad (tanleach1001) occupied Riverhold with 1 troop.",
+    "timestamp": "2016-01-14T18:41:17.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Markarth (tanleach1001) was fortified from Lillandril (tanleach1001) with 4 troops.",
+    "timestamp": "2016-01-14T18:41:42.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-14T18:41:42.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-14T18:41:42.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-14T18:42:30.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier received 3 troops for 10 territories.",
+    "timestamp": "2016-01-14T18:42:30.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Morrowind.",
+    "timestamp": "2016-01-14T18:42:30.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Mournhold (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-14T18:42:45.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Blacklight (mmacfreier) was reinforced by mmacfreier with 4 troops.",
+    "timestamp": "2016-01-14T18:42:47.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Mournhold (mmacfreier) attacked Cheydinhal (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:43:05.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Mournhold (mmacfreier) occupied Cheydinhal with 1 troop.",
+    "timestamp": "2016-01-14T18:43:13.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Narsis (mmacfreier) was fortified from Blacklight (mmacfreier) with 3 troops.",
+    "timestamp": "2016-01-14T18:43:27.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-14T18:43:27.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-14T18:43:27.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-14T18:44:33.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 5 troops for 15 territories.",
+    "timestamp": "2016-01-14T18:44:33.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 3 troops for holding Argonia.",
+    "timestamp": "2016-01-14T18:44:33.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Orcrest (kwren) was reinforced by kwren with 16 troops.",
+    "timestamp": "2016-01-14T18:44:42.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Orcrest (kwren) attacked Riverhold (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T18:44:46.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Orcrest (kwren) occupied Riverhold with 15 troops.",
+    "timestamp": "2016-01-14T18:44:47.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Riverhold (kwren) attacked Skingrad (tanleach1001) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-14T18:44:51.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Riverhold (kwren) occupied Skingrad with 1 troop.",
+    "timestamp": "2016-01-14T18:44:53.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Riverhold (kwren) attacked Arenthia (tanleach1001) conquering it, killing 3, losing 4.",
+    "timestamp": "2016-01-14T18:44:59.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Riverhold (kwren) occupied Arenthia with 9 troops.",
+    "timestamp": "2016-01-14T18:45:00.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Arenthia (kwren) attacked Falinesti (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T18:45:10.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Arenthia (kwren) occupied Falinesti with 7 troops.",
+    "timestamp": "2016-01-14T18:45:11.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Falinesti (kwren) attacked Woodhearth (tanleach1001) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-14T18:45:16.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Falinesti (kwren) occupied Woodhearth with 4 troops.",
+    "timestamp": "2016-01-14T18:45:18.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Woodhearth (kwren) attacked Skywatch (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:45:20.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Woodhearth (kwren) occupied Skywatch with 1 troop.",
+    "timestamp": "2016-01-14T18:45:26.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Dune (kwren) was fortified from Woodhearth (kwren) with 2 troops.",
+    "timestamp": "2016-01-14T18:45:32.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-14T18:45:32.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-14T18:45:32.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Round 17 started.",
+    "timestamp": "2016-01-14T18:45:32.000Z",
+    "player": "unknown",
+    "round": 10
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-14T18:45:41.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "tanleach1001 received 11 troops for 34 territories.",
+    "timestamp": "2016-01-14T18:45:41.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding High Rock.",
+    "timestamp": "2016-01-14T18:45:41.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "tanleach1001 received 4 troops for holding Hammerfell.",
+    "timestamp": "2016-01-14T18:45:41.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "tanleach1001 received 2 troops on Lillandril",
+    "timestamp": "2016-01-14T18:45:45.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Silvenar (tanleach1001) was reinforced by tanleach1001 with 17 troops.",
+    "timestamp": "2016-01-14T18:50:17.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Winterhold (tanleach1001) was reinforced by tanleach1001 with 9 troops.",
+    "timestamp": "2016-01-14T18:50:21.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Winterhold (tanleach1001) attacked Windhelm (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:50:24.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Winterhold (tanleach1001) occupied Windhelm with 9 troops.",
+    "timestamp": "2016-01-14T18:50:26.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Windhelm (tanleach1001) attacked Riften (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:50:29.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Windhelm (tanleach1001) occupied Riften with 8 troops.",
+    "timestamp": "2016-01-14T18:50:31.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Silvenar (tanleach1001) attacked Dune (kwren) conquering it, killing 3, losing 6.",
+    "timestamp": "2016-01-14T18:50:45.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Silvenar (tanleach1001) occupied Dune with 1 troop.",
+    "timestamp": "2016-01-14T18:50:51.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Silvenar (tanleach1001) attacked Arenthia (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T18:51:00.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Silvenar (tanleach1001) occupied Arenthia with 1 troop.",
+    "timestamp": "2016-01-14T18:51:03.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Silvenar (tanleach1001) attacked Falinesti (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T18:51:25.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Silvenar (tanleach1001) occupied Falinesti with 1 troop.",
+    "timestamp": "2016-01-14T18:51:32.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Silvenar (tanleach1001) attacked Woodhearth (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:51:36.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Silvenar (tanleach1001) occupied Woodhearth with 4 troops.",
+    "timestamp": "2016-01-14T18:51:41.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Woodhearth (tanleach1001) attacked Skywatch (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:51:46.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Woodhearth (tanleach1001) occupied Skywatch with 1 troop.",
+    "timestamp": "2016-01-14T18:51:50.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Arenthia (tanleach1001) was fortified from Markarth (tanleach1001) with 4 troops.",
+    "timestamp": "2016-01-14T18:52:25.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-14T18:52:25.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-14T18:52:25.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-14T18:54:19.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received 3 troops for 9 territories.",
+    "timestamp": "2016-01-14T18:54:19.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Morrowind.",
+    "timestamp": "2016-01-14T18:54:19.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Blacklight (mmacfreier) was reinforced by mmacfreier with 15 troops.",
+    "timestamp": "2016-01-14T18:57:04.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Blacklight (mmacfreier) attacked Riften (tanleach1001) conquering it, killing 8, losing 8.",
+    "timestamp": "2016-01-14T18:57:14.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Blacklight (mmacfreier) occupied Riften with 14 troops.",
+    "timestamp": "2016-01-14T18:57:16.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Riften (mmacfreier) attacked Falkreath (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:57:20.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Riften (mmacfreier) occupied Falkreath with 13 troops.",
+    "timestamp": "2016-01-14T18:57:22.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Falkreath (mmacfreier) attacked Dragonstar (tanleach1001) conquering it, killing 2, losing 0.",
+    "timestamp": "2016-01-14T18:57:25.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Falkreath (mmacfreier) occupied Dragonstar with 12 troops.",
+    "timestamp": "2016-01-14T18:57:27.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Dragonstar (mmacfreier) attacked Jehanna (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:57:31.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Dragonstar (mmacfreier) occupied Jehanna with 11 troops.",
+    "timestamp": "2016-01-14T18:57:37.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Jehanna (mmacfreier) attacked Northpoint (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:57:42.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Jehanna (mmacfreier) occupied Northpoint with 10 troops.",
+    "timestamp": "2016-01-14T18:57:44.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Northpoint (mmacfreier) attacked Wayrest (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:57:47.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Northpoint (mmacfreier) occupied Wayrest with 9 troops.",
+    "timestamp": "2016-01-14T18:57:49.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Wayrest (mmacfreier) attacked Camlorn (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:57:52.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Wayrest (mmacfreier) occupied Camlorn with 8 troops.",
+    "timestamp": "2016-01-14T18:57:54.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Camlorn (mmacfreier) attacked Daggerfall (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T18:57:57.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Camlorn (mmacfreier) occupied Daggerfall with 7 troops.",
+    "timestamp": "2016-01-14T18:58:03.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Blacklight (mmacfreier) was fortified from Daggerfall (mmacfreier) with 6 troops.",
+    "timestamp": "2016-01-14T18:58:15.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-14T18:58:15.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-14T18:58:15.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-14T18:58:26.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "kwren received 5 troops for 16 territories.",
+    "timestamp": "2016-01-14T18:58:26.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "kwren received 3 troops for holding Argonia.",
+    "timestamp": "2016-01-14T18:58:26.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Torval (kwren) was reinforced by kwren with 8 troops.",
+    "timestamp": "2016-01-14T18:58:32.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Torval (kwren) attacked Dune (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T18:58:37.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Torval (kwren) occupied Dune with 7 troops.",
+    "timestamp": "2016-01-14T18:58:40.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Dune (kwren) attacked Haven (tanleach1001) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-14T18:59:18.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Dune (kwren) occupied Haven with 1 troop.",
+    "timestamp": "2016-01-14T18:59:21.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Riverhold (kwren) was fortified from Blackrose (kwren) with 2 troops.",
+    "timestamp": "2016-01-14T18:59:31.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-14T18:59:31.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-14T18:59:31.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Round 18 started.",
+    "timestamp": "2016-01-14T18:59:31.000Z",
+    "player": "unknown",
+    "round": 11
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-14T18:59:42.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "tanleach1001 received 10 troops for 31 territories.",
+    "timestamp": "2016-01-14T18:59:42.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Summerset Isles.",
+    "timestamp": "2016-01-14T18:59:42.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "Elinhir (tanleach1001) was reinforced by tanleach1001 with 9 troops.",
+    "timestamp": "2016-01-14T19:00:41.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "Elden Root (tanleach1001) was reinforced by tanleach1001 with 4 troops.",
+    "timestamp": "2016-01-14T19:01:04.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "Elden Root (tanleach1001) attacked Haven (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:01:08.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "Elden Root (tanleach1001) occupied Haven with 5 troops.",
+    "timestamp": "2016-01-14T19:01:23.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "Haven (tanleach1001) attacked Torval (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:01:27.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "Haven (tanleach1001) occupied Torval with 1 troop.",
+    "timestamp": "2016-01-14T19:01:34.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "Elinhir (tanleach1001) attacked Dragonstar (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:01:43.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "Elinhir (tanleach1001) occupied Dragonstar with 5 troops.",
+    "timestamp": "2016-01-14T19:01:53.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "Dragonstar (tanleach1001) attacked Jehanna (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:01:59.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "Dragonstar (tanleach1001) occupied Jehanna with 1 troop.",
+    "timestamp": "2016-01-14T19:02:02.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "Lillandril (tanleach1001) was fortified from Woodhearth (tanleach1001) with 2 troops.",
+    "timestamp": "2016-01-14T19:02:33.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-14T19:02:34.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-14T19:02:34.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-14T19:02:45.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 5 troops for 15 territories.",
+    "timestamp": "2016-01-14T19:02:45.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Morrowind.",
+    "timestamp": "2016-01-14T19:02:45.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Daggerfall (mmacfreier) was reinforced by mmacfreier with 9 troops.",
+    "timestamp": "2016-01-14T19:02:59.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Daggerfall (mmacfreier) attacked Sentinel (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:03:03.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Daggerfall (mmacfreier) occupied Sentinel with 1 troop.",
+    "timestamp": "2016-01-14T19:03:08.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Daggerfall (mmacfreier) attacked Lillandril (tanleach1001) conquering it, killing 5, losing 6.",
+    "timestamp": "2016-01-14T19:03:18.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Daggerfall (mmacfreier) occupied Lillandril with 1 troop.",
+    "timestamp": "2016-01-14T19:03:25.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-14T19:03:32.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-14T19:03:32.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-14T19:03:46.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "kwren received 5 troops for 16 territories.",
+    "timestamp": "2016-01-14T19:03:46.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "kwren received 3 troops for holding Argonia.",
+    "timestamp": "2016-01-14T19:03:46.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Dune (kwren) was reinforced by kwren with 8 troops.",
+    "timestamp": "2016-01-14T19:03:54.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Dune (kwren) attacked Haven (tanleach1001) conquering it, killing 4, losing 4.",
+    "timestamp": "2016-01-14T19:04:03.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Dune (kwren) occupied Haven with 1 troop.",
+    "timestamp": "2016-01-14T19:04:06.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Dune (kwren) attacked Torval (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:04:10.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Dune (kwren) occupied Torval with 1 troop.",
+    "timestamp": "2016-01-14T19:04:14.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Dune (kwren) was fortified from Gideon (kwren) with 4 troops.",
+    "timestamp": "2016-01-14T19:04:30.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-14T19:04:30.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-14T19:04:30.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Round 19 started.",
+    "timestamp": "2016-01-14T19:04:30.000Z",
+    "player": "unknown",
+    "round": 12
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-14T19:05:33.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "tanleach1001 received 10 troops for 31 territories.",
+    "timestamp": "2016-01-14T19:05:33.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "tanleach1001 received 2 troops on Bruma",
+    "timestamp": "2016-01-14T19:05:38.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "Arenthia (tanleach1001) was reinforced by tanleach1001 with 15 troops.",
+    "timestamp": "2016-01-14T19:05:59.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "Cloudrest (tanleach1001) was reinforced by tanleach1001 with 3 troops.",
+    "timestamp": "2016-01-14T19:06:04.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "Cloudrest (tanleach1001) attacked Lillandril (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:06:07.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "Cloudrest (tanleach1001) occupied Lillandril with 3 troops.",
+    "timestamp": "2016-01-14T19:06:09.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "Arenthia (tanleach1001) attacked Dune (kwren) conquering it, killing 10, losing 4.",
+    "timestamp": "2016-01-14T19:06:24.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "Arenthia (tanleach1001) occupied Dune with 8 troops.",
+    "timestamp": "2016-01-14T19:07:30.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "Dune (tanleach1001) attacked Haven (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T19:07:38.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "Dune (tanleach1001) occupied Haven with 6 troops.",
+    "timestamp": "2016-01-14T19:08:08.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "Lillandril (tanleach1001) was fortified from Elinhir (tanleach1001) with 2 troops.",
+    "timestamp": "2016-01-14T19:09:13.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-14T19:09:13.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-14T19:09:13.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-14T19:15:24.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "mmacfreier received 5 troops for 16 territories.",
+    "timestamp": "2016-01-14T19:15:24.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Morrowind.",
+    "timestamp": "2016-01-14T19:15:24.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Riften (mmacfreier) was reinforced by mmacfreier with 17 troops.",
+    "timestamp": "2016-01-14T19:15:41.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Riften (mmacfreier) attacked Windhelm (tanleach1001) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-14T19:15:47.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Riften (mmacfreier) occupied Windhelm with 11 troops.",
+    "timestamp": "2016-01-14T19:15:54.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Windhelm (mmacfreier) attacked Winterhold (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:15:57.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Windhelm (mmacfreier) occupied Winterhold with 10 troops.",
+    "timestamp": "2016-01-14T19:15:58.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Winterhold (mmacfreier) attacked Dawnstar (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:16:02.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Winterhold (mmacfreier) occupied Dawnstar with 9 troops.",
+    "timestamp": "2016-01-14T19:16:04.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Dawnstar (mmacfreier) attacked Morthal (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:16:09.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Dawnstar (mmacfreier) occupied Morthal with 8 troops.",
+    "timestamp": "2016-01-14T19:16:11.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Morthal (mmacfreier) attacked Whiterun (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:16:14.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Morthal (mmacfreier) occupied Whiterun with 1 troop.",
+    "timestamp": "2016-01-14T19:16:17.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Morthal (mmacfreier) attacked Solitude (tanleach1001) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-14T19:16:24.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Morthal (mmacfreier) occupied Solitude with 4 troops.",
+    "timestamp": "2016-01-14T19:16:26.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Solitude (mmacfreier) attacked Markarth (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:16:28.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Solitude (mmacfreier) occupied Markarth with 3 troops.",
+    "timestamp": "2016-01-14T19:16:30.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Markarth (mmacfreier) attacked Jehanna (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:16:49.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Markarth (mmacfreier) occupied Jehanna with 1 troop.",
+    "timestamp": "2016-01-14T19:16:53.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Falkreath (mmacfreier) was fortified from Narsis (mmacfreier) with 2 troops.",
+    "timestamp": "2016-01-14T19:17:10.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-14T19:17:10.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-14T19:17:10.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-14T19:17:26.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "kwren received 5 troops for 16 territories.",
+    "timestamp": "2016-01-14T19:17:26.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "kwren received 3 troops for holding Argonia.",
+    "timestamp": "2016-01-14T19:17:26.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "kwren received 2 troops on Bravil",
+    "timestamp": "2016-01-14T19:17:29.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "kwren received 2 troops on Imperial City",
+    "timestamp": "2016-01-14T19:17:29.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Imperial City (kwren) was reinforced by kwren with 16 troops.",
+    "timestamp": "2016-01-14T19:17:36.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Imperial City (kwren) attacked Chorrol (tanleach1001) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-01-14T19:17:42.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Imperial City (kwren) occupied Chorrol with 15 troops.",
+    "timestamp": "2016-01-14T19:17:44.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Chorrol (kwren) attacked Kwatch (tanleach1001) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-14T19:17:49.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Chorrol (kwren) occupied Kwatch with 12 troops.",
+    "timestamp": "2016-01-14T19:17:51.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Kwatch (kwren) attacked Elinhir (tanleach1001) conquering it, killing 3, losing 4.",
+    "timestamp": "2016-01-14T19:17:58.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Kwatch (kwren) occupied Elinhir with 1 troop.",
+    "timestamp": "2016-01-14T19:18:02.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Kwatch (kwren) attacked Anvil (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:18:05.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Kwatch (kwren) occupied Anvil with 6 troops.",
+    "timestamp": "2016-01-14T19:18:06.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Anvil (kwren) attacked Firsthold (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T19:18:11.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Anvil (kwren) occupied Firsthold with 4 troops.",
+    "timestamp": "2016-01-14T19:18:13.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Firsthold (kwren) attacked Skywatch (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T19:18:17.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Firsthold (kwren) occupied Skywatch with 2 troops.",
+    "timestamp": "2016-01-14T19:18:19.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Skywatch (kwren) attacked Woodhearth (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:18:22.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Riverhold (kwren) attacked Dune (tanleach1001) killing 0, losing 2.",
+    "timestamp": "2016-01-14T19:18:30.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Gideon (kwren) was fortified from Bravil (kwren) with 2 troops.",
+    "timestamp": "2016-01-14T19:18:39.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-14T19:18:39.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-14T19:18:39.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Round 20 started.",
+    "timestamp": "2016-01-14T19:18:39.000Z",
+    "player": "unknown",
+    "round": 13
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-14T19:18:55.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "tanleach1001 received 6 troops for 19 territories.",
+    "timestamp": "2016-01-14T19:18:55.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "Cloudrest (tanleach1001) was reinforced by tanleach1001 with 6 troops.",
+    "timestamp": "2016-01-14T19:21:23.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "Cloudrest (tanleach1001) attacked Skywatch (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:21:32.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "Cloudrest (tanleach1001) occupied Skywatch with 6 troops.",
+    "timestamp": "2016-01-14T19:21:36.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "Skywatch (tanleach1001) attacked Woodhearth (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:21:46.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "Skywatch (tanleach1001) occupied Woodhearth with 1 troop.",
+    "timestamp": "2016-01-14T19:21:49.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "Skywatch (tanleach1001) attacked Firsthold (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:21:52.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "Skywatch (tanleach1001) occupied Firsthold with 4 troops.",
+    "timestamp": "2016-01-14T19:21:53.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "Lillandril (tanleach1001) was fortified from Dragonstar (tanleach1001) with 3 troops.",
+    "timestamp": "2016-01-14T19:22:16.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-14T19:22:16.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-14T19:22:16.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-14T19:25:35.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "mmacfreier received 8 troops for 24 territories.",
+    "timestamp": "2016-01-14T19:25:35.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Morrowind.",
+    "timestamp": "2016-01-14T19:25:35.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "mmacfreier received 5 troops for holding Skyrim.",
+    "timestamp": "2016-01-14T19:25:35.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding High Rock.",
+    "timestamp": "2016-01-14T19:25:35.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Falkreath (mmacfreier) was reinforced by mmacfreier with 20 troops.",
+    "timestamp": "2016-01-14T19:25:58.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Falkreath (mmacfreier) attacked Bruma (tanleach1001) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-14T19:26:02.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Falkreath (mmacfreier) occupied Bruma with 21 troops.",
+    "timestamp": "2016-01-14T19:26:04.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Bruma (mmacfreier) attacked Elinhir (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:26:07.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Bruma (mmacfreier) occupied Elinhir with 20 troops.",
+    "timestamp": "2016-01-14T19:26:08.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Elinhir (mmacfreier) attacked Rihad (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T19:26:14.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Elinhir (mmacfreier) occupied Rihad with 1 troop.",
+    "timestamp": "2016-01-14T19:26:17.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Elinhir (mmacfreier) attacked Dragonstar (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T19:26:21.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Elinhir (mmacfreier) occupied Dragonstar with 16 troops.",
+    "timestamp": "2016-01-14T19:26:23.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Dragonstar (mmacfreier) attacked Skaven (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:26:26.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Dragonstar (mmacfreier) occupied Skaven with 15 troops.",
+    "timestamp": "2016-01-14T19:26:27.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Skaven (mmacfreier) attacked Taneth (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T19:26:32.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Skaven (mmacfreier) occupied Taneth with 13 troops.",
+    "timestamp": "2016-01-14T19:26:33.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Taneth (mmacfreier) attacked Gilane (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:26:36.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Taneth (mmacfreier) occupied Gilane with 12 troops.",
+    "timestamp": "2016-01-14T19:26:38.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Gilane (mmacfreier) attacked Hegathe (tanleach1001) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-14T19:26:44.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Gilane (mmacfreier) occupied Hegathe with 9 troops.",
+    "timestamp": "2016-01-14T19:26:45.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Falkreath (mmacfreier) was fortified from Markarth (mmacfreier) with 1 troop.",
+    "timestamp": "2016-01-14T19:27:01.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-14T19:27:01.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-14T19:27:01.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-14T19:33:47.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "kwren received 6 troops for 19 territories.",
+    "timestamp": "2016-01-14T19:33:47.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "kwren received 3 troops for holding Argonia.",
+    "timestamp": "2016-01-14T19:33:47.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Riverhold (kwren) was reinforced by kwren with 9 troops.",
+    "timestamp": "2016-01-14T19:33:58.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Riverhold (kwren) attacked Dune (tanleach1001) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-01-14T19:34:04.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Riverhold (kwren) occupied Dune with 6 troops.",
+    "timestamp": "2016-01-14T19:34:05.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-14T19:34:13.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-14T19:34:13.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Round 21 started.",
+    "timestamp": "2016-01-14T19:34:13.000Z",
+    "player": "unknown",
+    "round": 14
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-14T19:34:19.000Z",
+    "player": "tanleach1001",
+    "round": 14
+  },
+  {
+    "message": "tanleach1001 received 4 troops for 14 territories.",
+    "timestamp": "2016-01-14T19:34:19.000Z",
+    "player": "tanleach1001",
+    "round": 14
+  },
+  {
+    "message": "tanleach1001 received 4 troops for holding Valenwood.",
+    "timestamp": "2016-01-14T19:34:19.000Z",
+    "player": "tanleach1001",
+    "round": 14
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Summerset Isles.",
+    "timestamp": "2016-01-14T19:34:19.000Z",
+    "player": "tanleach1001",
+    "round": 14
+  },
+  {
+    "message": "Lillandril (tanleach1001) was reinforced by tanleach1001 with 4 troops.",
+    "timestamp": "2016-01-14T19:36:06.000Z",
+    "player": "tanleach1001",
+    "round": 14
+  },
+  {
+    "message": "Arenthia (tanleach1001) was reinforced by tanleach1001 with 6 troops.",
+    "timestamp": "2016-01-14T19:36:23.000Z",
+    "player": "tanleach1001",
+    "round": 14
+  },
+  {
+    "message": "Firsthold (tanleach1001) was reinforced by tanleach1001 with 1 troop.",
+    "timestamp": "2016-01-14T19:36:26.000Z",
+    "player": "tanleach1001",
+    "round": 14
+  },
+  {
+    "message": "Arenthia (tanleach1001) attacked Dune (kwren) conquering it, killing 6, losing 9.",
+    "timestamp": "2016-01-14T19:36:37.000Z",
+    "player": "tanleach1001",
+    "round": 14
+  },
+  {
+    "message": "Arenthia (tanleach1001) occupied Dune with 1 troop.",
+    "timestamp": "2016-01-14T19:36:40.000Z",
+    "player": "tanleach1001",
+    "round": 14
+  },
+  {
+    "message": "Lillandril (tanleach1001) attacked Daggerfall (mmacfreier) killing 0, losing 4.",
+    "timestamp": "2016-01-14T19:36:46.000Z",
+    "player": "tanleach1001",
+    "round": 14
+  },
+  {
+    "message": "Lillandril (tanleach1001) was fortified from Elden Root (tanleach1001) with 3 troops.",
+    "timestamp": "2016-01-14T19:37:02.000Z",
+    "player": "tanleach1001",
+    "round": 14
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-14T19:37:02.000Z",
+    "player": "tanleach1001",
+    "round": 14
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-14T19:37:02.000Z",
+    "player": "tanleach1001",
+    "round": 14
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-14T19:37:12.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "mmacfreier received 10 troops for 32 territories.",
+    "timestamp": "2016-01-14T19:37:12.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Morrowind.",
+    "timestamp": "2016-01-14T19:37:12.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "mmacfreier received 5 troops for holding Skyrim.",
+    "timestamp": "2016-01-14T19:37:12.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding High Rock.",
+    "timestamp": "2016-01-14T19:37:12.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Hammerfell.",
+    "timestamp": "2016-01-14T19:37:12.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Hegathe (mmacfreier) was reinforced by mmacfreier with 26 troops.",
+    "timestamp": "2016-01-14T19:37:19.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Hegathe (mmacfreier) attacked Lillandril (tanleach1001) conquering it, killing 11, losing 6.",
+    "timestamp": "2016-01-14T19:37:32.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Hegathe (mmacfreier) occupied Lillandril with 28 troops.",
+    "timestamp": "2016-01-14T19:37:41.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Lillandril (mmacfreier) attacked Cloudrest (tanleach1001) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-14T19:37:55.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Lillandril (mmacfreier) occupied Cloudrest with 25 troops.",
+    "timestamp": "2016-01-14T19:37:57.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Cloudrest (mmacfreier) attacked Shimmerene (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:38:00.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Cloudrest (mmacfreier) occupied Shimmerene with 24 troops.",
+    "timestamp": "2016-01-14T19:38:02.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Shimmerene (mmacfreier) attacked Alinor (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:38:04.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Shimmerene (mmacfreier) occupied Alinor with 1 troop.",
+    "timestamp": "2016-01-14T19:38:09.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Shimmerene (mmacfreier) attacked Dusk (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:38:12.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Shimmerene (mmacfreier) occupied Dusk with 1 troop.",
+    "timestamp": "2016-01-14T19:38:16.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Shimmerene (mmacfreier) attacked Skywatch (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:38:19.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Shimmerene (mmacfreier) occupied Skywatch with 21 troops.",
+    "timestamp": "2016-01-14T19:38:22.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Skywatch (mmacfreier) attacked Firsthold (tanleach1001) conquering it, killing 5, losing 1.",
+    "timestamp": "2016-01-14T19:38:30.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Skywatch (mmacfreier) occupied Firsthold with 1 troop.",
+    "timestamp": "2016-01-14T19:38:33.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Skywatch (mmacfreier) attacked Woodhearth (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T19:38:38.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Skywatch (mmacfreier) occupied Woodhearth with 17 troops.",
+    "timestamp": "2016-01-14T19:38:40.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Woodhearth (mmacfreier) attacked Falinesti (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:38:50.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Woodhearth (mmacfreier) occupied Falinesti with 1 troop.",
+    "timestamp": "2016-01-14T19:38:55.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Woodhearth (mmacfreier) attacked Elden Root (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T19:39:00.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Woodhearth (mmacfreier) occupied Elden Root with 14 troops.",
+    "timestamp": "2016-01-14T19:39:09.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Elden Root (mmacfreier) attacked Silvenar (tanleach1001) conquering it, killing 5, losing 1.",
+    "timestamp": "2016-01-14T19:39:16.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Elden Root (mmacfreier) occupied Silvenar with 1 troop.",
+    "timestamp": "2016-01-14T19:39:28.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Elden Root (mmacfreier) attacked Haven (tanleach1001) killing 3, losing 7.",
+    "timestamp": "2016-01-14T19:39:36.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Elinhir (mmacfreier) was fortified from Elden Root (mmacfreier) with 4 troops.",
+    "timestamp": "2016-01-14T19:39:49.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-14T19:39:49.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-14T19:39:49.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-14T19:40:18.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "kwren received 6 troops for 19 territories.",
+    "timestamp": "2016-01-14T19:40:18.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "kwren received 3 troops for holding Argonia.",
+    "timestamp": "2016-01-14T19:40:18.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "Stormhold (kwren) was reinforced by kwren with 2 troops.",
+    "timestamp": "2016-01-14T19:40:24.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "Anvil (kwren) was reinforced by kwren with 7 troops.",
+    "timestamp": "2016-01-14T19:40:38.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "Anvil (kwren) attacked Firsthold (mmacfreier) conquering it, killing 1, losing 6.",
+    "timestamp": "2016-01-14T19:40:47.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "Riverhold (kwren) was fortified from Gideon (kwren) with 9 troops.",
+    "timestamp": "2016-01-14T19:40:59.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-14T19:40:59.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-14T19:40:59.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "Round 22 started.",
+    "timestamp": "2016-01-14T19:40:59.000Z",
+    "player": "unknown",
+    "round": 15
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-14T19:41:05.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 4 territories.",
+    "timestamp": "2016-01-14T19:41:05.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Arenthia (tanleach1001) was reinforced by tanleach1001 with 3 troops.",
+    "timestamp": "2016-01-14T19:42:12.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Arenthia (tanleach1001) attacked Falinesti (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:42:15.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Arenthia (tanleach1001) occupied Falinesti with 6 troops.",
+    "timestamp": "2016-01-14T19:42:17.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Falinesti (tanleach1001) attacked Woodhearth (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:42:20.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Falinesti (tanleach1001) occupied Woodhearth with 5 troops.",
+    "timestamp": "2016-01-14T19:42:21.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Woodhearth (tanleach1001) attacked Skywatch (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T19:42:26.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Woodhearth (tanleach1001) occupied Skywatch with 3 troops.",
+    "timestamp": "2016-01-14T19:42:28.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Skywatch (tanleach1001) attacked Cloudrest (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:44:08.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Skywatch (tanleach1001) occupied Cloudrest with 2 troops.",
+    "timestamp": "2016-01-14T19:44:09.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Cloudrest (tanleach1001) attacked Lillandril (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:44:13.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-14T19:44:29.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-14T19:44:29.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-14T19:47:02.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "mmacfreier received 12 troops for 37 territories.",
+    "timestamp": "2016-01-14T19:47:02.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Morrowind.",
+    "timestamp": "2016-01-14T19:47:02.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "mmacfreier received 5 troops for holding Skyrim.",
+    "timestamp": "2016-01-14T19:47:02.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding High Rock.",
+    "timestamp": "2016-01-14T19:47:02.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Hammerfell.",
+    "timestamp": "2016-01-14T19:47:02.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Daggerfall (mmacfreier) was reinforced by mmacfreier with 28 troops.",
+    "timestamp": "2016-01-14T19:47:12.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Daggerfall (mmacfreier) attacked Lillandril (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:47:15.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Daggerfall (mmacfreier) occupied Lillandril with 29 troops.",
+    "timestamp": "2016-01-14T19:47:17.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Lillandril (mmacfreier) attacked Cloudrest (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:47:22.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Lillandril (mmacfreier) occupied Cloudrest with 1 troop.",
+    "timestamp": "2016-01-14T19:47:26.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Lillandril (mmacfreier) attacked Firsthold (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T19:47:51.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Lillandril (mmacfreier) occupied Firsthold with 26 troops.",
+    "timestamp": "2016-01-14T19:47:54.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Firsthold (mmacfreier) attacked Skywatch (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T19:47:59.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Firsthold (mmacfreier) occupied Skywatch with 24 troops.",
+    "timestamp": "2016-01-14T19:48:01.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Skywatch (mmacfreier) attacked Woodhearth (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:48:04.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Skywatch (mmacfreier) occupied Woodhearth with 23 troops.",
+    "timestamp": "2016-01-14T19:48:06.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Woodhearth (mmacfreier) attacked Falinesti (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T19:48:10.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Woodhearth (mmacfreier) occupied Falinesti with 21 troops.",
+    "timestamp": "2016-01-14T19:48:13.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Falinesti (mmacfreier) attacked Arenthia (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:48:18.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Falinesti (mmacfreier) occupied Arenthia with 20 troops.",
+    "timestamp": "2016-01-14T19:48:20.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Arenthia (mmacfreier) attacked Dune (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:48:23.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Arenthia (mmacfreier) occupied Dune with 19 troops.",
+    "timestamp": "2016-01-14T19:48:25.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Dune (mmacfreier) attacked Haven (tanleach1001) conquering it, killing 3, losing 5.",
+    "timestamp": "2016-01-14T19:48:33.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Dune (mmacfreier) occupied Haven with 13 troops.",
+    "timestamp": "2016-01-14T19:48:35.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Haven (mmacfreier) attacked Southpoint (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:48:37.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "tanleach1001 was defeated by mmacfreier.",
+    "timestamp": "2016-01-14T19:48:38.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Haven (mmacfreier) occupied Southpoint with 1 troop.",
+    "timestamp": "2016-01-14T19:48:40.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "mmacfreier received 2 troops on Tear",
+    "timestamp": "2016-01-14T19:49:06.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "mmacfreier received 2 troops on Alinor",
+    "timestamp": "2016-01-14T19:49:06.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "mmacfreier received 2 troops on Dune",
+    "timestamp": "2016-01-14T19:49:06.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "mmacfreier received 2 troops on Windhelm",
+    "timestamp": "2016-01-14T19:49:12.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "mmacfreier received 2 troops on Mournhold",
+    "timestamp": "2016-01-14T19:49:12.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Elinhir (mmacfreier) was reinforced by mmacfreier with 16 troops.",
+    "timestamp": "2016-01-14T19:49:23.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Elinhir (mmacfreier) attacked Kwatch (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T19:49:28.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Elinhir (mmacfreier) occupied Kwatch with 19 troops.",
+    "timestamp": "2016-01-14T19:49:29.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Kwatch (mmacfreier) attacked Anvil (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T19:49:33.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Kwatch (mmacfreier) occupied Anvil with 1 troop.",
+    "timestamp": "2016-01-14T19:49:36.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Kwatch (mmacfreier) attacked Chorrol (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T19:49:40.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Kwatch (mmacfreier) occupied Chorrol with 15 troops.",
+    "timestamp": "2016-01-14T19:49:42.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Chorrol (mmacfreier) attacked Imperial City (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:49:45.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Chorrol (mmacfreier) occupied Imperial City with 1 troop.",
+    "timestamp": "2016-01-14T19:49:49.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Chorrol (mmacfreier) attacked Skingrad (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T19:49:54.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Chorrol (mmacfreier) occupied Skingrad with 12 troops.",
+    "timestamp": "2016-01-14T19:49:56.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Skingrad (mmacfreier) attacked Riverhold (kwren) conquering it, killing 10, losing 8.",
+    "timestamp": "2016-01-14T19:50:06.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Skingrad (mmacfreier) occupied Riverhold with 3 troops.",
+    "timestamp": "2016-01-14T19:50:08.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Dune (mmacfreier) attacked Orcrest (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T19:50:17.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Haven (mmacfreier) attacked Torval (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-14T19:50:23.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Haven (mmacfreier) occupied Torval with 9 troops.",
+    "timestamp": "2016-01-14T19:50:25.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Torval (mmacfreier) attacked Senchal (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:50:28.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Torval (mmacfreier) occupied Senchal with 1 troop.",
+    "timestamp": "2016-01-14T19:50:31.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Torval (mmacfreier) attacked Corinthe (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:50:34.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Torval (mmacfreier) occupied Corinthe with 7 troops.",
+    "timestamp": "2016-01-14T19:50:35.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Corinthe (mmacfreier) attacked Rimmen (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:50:39.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Corinthe (mmacfreier) occupied Rimmen with 6 troops.",
+    "timestamp": "2016-01-14T19:50:42.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Rimmen (mmacfreier) attacked Leyawiin (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:50:47.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Rimmen (mmacfreier) occupied Leyawiin with 5 troops.",
+    "timestamp": "2016-01-14T19:50:49.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Leyawiin (mmacfreier) attacked Gideon (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T19:50:54.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Leyawiin (mmacfreier) occupied Gideon with 1 troop.",
+    "timestamp": "2016-01-14T19:50:59.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Leyawiin (mmacfreier) attacked Bravil (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T19:51:03.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Bravil (mmacfreier) was fortified from Riften (mmacfreier) with 4 troops.",
+    "timestamp": "2016-01-14T19:51:20.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-14T19:51:20.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-14T19:51:20.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-14T19:57:48.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "kwren received 3 troops for 5 territories.",
+    "timestamp": "2016-01-14T19:57:48.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "Stormhold (kwren) was reinforced by kwren with 3 troops.",
+    "timestamp": "2016-01-14T19:57:53.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "Stormhold (kwren) attacked Narsis (mmacfreier) conquering it, killing 4, losing 2.",
+    "timestamp": "2016-01-14T19:57:59.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "Stormhold (kwren) occupied Narsis with 10 troops.",
+    "timestamp": "2016-01-14T19:58:06.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "Narsis (kwren) attacked Bravil (mmacfreier) conquering it, killing 5, losing 4.",
+    "timestamp": "2016-01-14T19:58:10.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "Narsis (kwren) occupied Bravil with 5 troops.",
+    "timestamp": "2016-01-14T19:58:12.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "Bravil (kwren) attacked Rimmen (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:58:14.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "Bravil (kwren) occupied Rimmen with 4 troops.",
+    "timestamp": "2016-01-14T19:58:16.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "Rimmen (kwren) attacked Orcrest (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T19:58:18.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "Rimmen (kwren) occupied Orcrest with 3 troops.",
+    "timestamp": "2016-01-14T19:58:20.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "Orcrest (kwren) attacked Dune (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T19:58:26.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-14T19:58:30.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-14T19:58:30.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "Round 23 started.",
+    "timestamp": "2016-01-14T19:58:30.000Z",
+    "player": "unknown",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-14T21:13:00.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier received 18 troops for 56 territories.",
+    "timestamp": "2016-01-14T21:13:01.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier received 5 troops for holding Skyrim.",
+    "timestamp": "2016-01-14T21:13:01.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Hammerfell.",
+    "timestamp": "2016-01-14T21:13:01.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding High Rock.",
+    "timestamp": "2016-01-14T21:13:01.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding Summerset Isles.",
+    "timestamp": "2016-01-14T21:13:01.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Valenwood.",
+    "timestamp": "2016-01-14T21:13:01.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "Riverhold (mmacfreier) was reinforced by mmacfreier with 37 troops.",
+    "timestamp": "2016-01-14T21:13:08.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "Riverhold (mmacfreier) attacked Dune (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T21:13:12.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "Riverhold (mmacfreier) occupied Dune with 39 troops.",
+    "timestamp": "2016-01-14T21:13:13.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "Dune (mmacfreier) attacked Orcrest (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T21:13:17.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "Dune (mmacfreier) occupied Orcrest with 38 troops.",
+    "timestamp": "2016-01-14T21:13:18.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "Orcrest (mmacfreier) attacked Rimmen (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T21:13:23.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "Orcrest (mmacfreier) occupied Rimmen with 36 troops.",
+    "timestamp": "2016-01-14T21:13:25.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "Rimmen (mmacfreier) attacked Bravil (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T21:13:28.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "Rimmen (mmacfreier) occupied Bravil with 35 troops.",
+    "timestamp": "2016-01-14T21:13:30.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "Bravil (mmacfreier) attacked Stormhold (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T21:13:35.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "Bravil (mmacfreier) occupied Stormhold with 34 troops.",
+    "timestamp": "2016-01-14T21:13:36.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "Mournhold (mmacfreier) attacked Narsis (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T21:13:40.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "Mournhold (mmacfreier) occupied Narsis with 6 troops.",
+    "timestamp": "2016-01-14T21:13:42.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "Narsis (mmacfreier) attacked Thorn (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T21:13:45.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "Narsis (mmacfreier) occupied Thorn with 5 troops.",
+    "timestamp": "2016-01-14T21:13:46.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "Thorn (mmacfreier) attacked Archon (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-14T21:13:53.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "Thorn (mmacfreier) occupied Archon with 2 troops.",
+    "timestamp": "2016-01-14T21:13:54.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "Stormhold (mmacfreier) attacked Helstrom (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T21:13:57.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "Stormhold (mmacfreier) occupied Helstrom with 33 troops.",
+    "timestamp": "2016-01-14T21:13:59.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "Helstrom (mmacfreier) attacked Blackrose (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-14T21:14:04.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "kwren was defeated by mmacfreier.",
+    "timestamp": "2016-01-14T21:14:04.000Z",
+    "player": "kwren",
+    "round": 16
+  },
+  {
+    "message": "Game finished.",
+    "timestamp": "2016-01-14T21:14:04.000Z",
+    "player": "unknown",
+    "round": 16
+  },
+  {
+    "message": "jobratt lost 28 rating.",
+    "timestamp": "2016-01-14T21:14:04.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "jobratt received 20 tokens.",
+    "timestamp": "2016-01-14T21:14:04.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "tanleach1001 lost 19 rating.",
+    "timestamp": "2016-01-14T21:14:04.000Z",
+    "player": "tanleach1001",
+    "round": 16
+  },
+  {
+    "message": "tanleach1001 received 20 tokens.",
+    "timestamp": "2016-01-14T21:14:04.000Z",
+    "player": "tanleach1001",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier won the game.",
+    "timestamp": "2016-01-14T21:14:04.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier received 97 rating.",
+    "timestamp": "2016-01-14T21:14:04.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier received 20 tokens.",
+    "timestamp": "2016-01-14T21:14:04.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "ryanbmilbourne lost 18 rating.",
+    "timestamp": "2016-01-14T21:14:04.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "ryanbmilbourne received 20 tokens.",
+    "timestamp": "2016-01-14T21:14:04.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "gcochard lost 14 rating.",
+    "timestamp": "2016-01-14T21:14:04.000Z",
+    "player": "gcochard",
+    "round": 16
+  },
+  {
+    "message": "gcochard received 20 tokens.",
+    "timestamp": "2016-01-14T21:14:04.000Z",
+    "player": "gcochard",
+    "round": 16
+  },
+  {
+    "message": "kwren lost 18 rating.",
+    "timestamp": "2016-01-14T21:14:04.000Z",
+    "player": "kwren",
+    "round": 16
+  },
+  {
+    "message": "kwren received 20 tokens.",
+    "timestamp": "2016-01-14T21:14:04.000Z",
+    "player": "kwren",
+    "round": 16
+  },
+  {
+    "message": "ryanbmilbourne received 8 troops for turning in cards Daggerfall, Ald’ Ruhn, and Cheydinhal.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "jobratt received 8 troops for turning in cards Jehanna, Firsthold, and Senchal.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "tanleach1001 received 8 troops for turning in cards Woodhearth, Rimmen, and Solitude.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "tanleach1001",
+    "round": 16
+  },
+  {
+    "message": "jobratt received 8 troops for turning in cards Northpoint, Alinor, and Whiterun.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier received 8 troops for turning in cards Dune, Orcrest, and Chorrol.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier received 8 troops for turning in cards Mournhold, Bruma, and Kwatch.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "gcochard received 8 troops for turning in cards Shimmerene, Archon, and Bravil.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "gcochard",
+    "round": 16
+  },
+  {
+    "message": "kwren received 8 troops for turning in cards Riverhold, Blackrose, and Skingrad.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 16
+  },
+  {
+    "message": "tanleach1001 received 8 troops for turning in cards Vivec, Arenthia, and Hegathe.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "tanleach1001",
+    "round": 16
+  },
+  {
+    "message": "tanleach1001 received 8 troops for turning in cards Tear, Blacklight, and Rihad.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "tanleach1001",
+    "round": 16
+  },
+  {
+    "message": "tanleach1001 received 8 troops for turning in cards Thorn, Winterhold, and Sentinel.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "tanleach1001",
+    "round": 16
+  },
+  {
+    "message": "kwren received 8 troops for turning in cards Cloudrest, Torval, and Markarth.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier received 8 troops for turning in cards Narsis, Taneth, and Solitude.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "kwren received 8 troops for turning in cards Skaven, Dragonstar, and Necrom.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 16
+  },
+  {
+    "message": "tanleach1001 received 8 troops for turning in cards Lillandril, Gideon, and Rimmen.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "tanleach1001",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier received 8 troops for turning in cards Skywatch, Anvil, and Blackrose.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "tanleach1001 received 8 troops for turning in cards Sentinel, Bruma, and Balmora.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "tanleach1001",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier received 8 troops for turning in cards Skingrad, Firsthold, and Shimmerene.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "kwren received 8 troops for turning in cards Bravil, Woodhearth, and Imperial City.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier received 8 troops for turning in cards Tear, Alinor, and Dune.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier received 8 troops for turning in cards Kwatch, Windhelm, and Mournhold.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  }
+]

--- a/data/603750.json
+++ b/data/603750.json
@@ -1,0 +1,4892 @@
+[
+  {
+    "message": "Game created.",
+    "timestamp": "2016-01-14T21:37:20.000Z",
+    "player": "unknown",
+    "round": 0
+  },
+  {
+    "message": "mmacfreier joined the game.",
+    "timestamp": "2016-01-14T21:37:20.000Z",
+    "player": "mmacfreier",
+    "round": 0
+  },
+  {
+    "message": "jobratt joined the game.",
+    "timestamp": "2016-01-14T21:40:40.000Z",
+    "player": "jobratt",
+    "round": 0
+  },
+  {
+    "message": "ryanbmilbourne joined the game.",
+    "timestamp": "2016-01-14T21:41:12.000Z",
+    "player": "ryanbmilbourne",
+    "round": 0
+  },
+  {
+    "message": "kwren joined the game.",
+    "timestamp": "2016-01-14T21:48:14.000Z",
+    "player": "kwren",
+    "round": 0
+  },
+  {
+    "message": "gcochard joined the game.",
+    "timestamp": "2016-01-14T22:27:46.000Z",
+    "player": "gcochard",
+    "round": 0
+  },
+  {
+    "message": "Game started.",
+    "timestamp": "2016-01-14T22:27:46.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-14T22:42:16.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "ryanbmilbourne received 4 troops for 13 territories.",
+    "timestamp": "2016-01-14T22:42:16.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Rif Dimashq (ryanbmilbourne) was reinforced by ryanbmilbourne with 4 troops.",
+    "timestamp": "2016-01-14T22:42:51.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Rif Dimashq (ryanbmilbourne) attacked Lebanon (gcochard) killing 2, losing 6.",
+    "timestamp": "2016-01-14T22:43:04.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Rif Dimashq (ryanbmilbourne) was fortified from Adana (ryanbmilbourne) with 2 troops.",
+    "timestamp": "2016-01-14T22:43:18.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-14T22:43:18.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-14T22:45:51.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard received 4 troops for 13 territories.",
+    "timestamp": "2016-01-14T22:45:51.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Aquitaine (gcochard) was reinforced by gcochard with 4 troops.",
+    "timestamp": "2016-01-14T22:46:42.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Aquitaine (gcochard) attacked Catalonia (jobratt) conquering it, killing 3, losing 4.",
+    "timestamp": "2016-01-14T22:46:57.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Aquitaine (gcochard) occupied Catalonia with 2 troops.",
+    "timestamp": "2016-01-14T22:46:58.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Catalonia (gcochard) was fortified from Norte (gcochard) with 2 troops.",
+    "timestamp": "2016-01-14T22:47:18.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-14T22:47:18.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-14T22:47:18.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-14T23:02:24.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren received 4 troops for 13 territories.",
+    "timestamp": "2016-01-14T23:02:24.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren received 1 troop for holding Tunisia.",
+    "timestamp": "2016-01-14T23:02:24.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Kebili (kwren) was reinforced by kwren with 2 troops.",
+    "timestamp": "2016-01-14T23:02:29.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Siliana (kwren) was reinforced by kwren with 2 troops.",
+    "timestamp": "2016-01-14T23:02:34.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Kebili (kwren) was reinforced by kwren with 1 troop.",
+    "timestamp": "2016-01-14T23:02:41.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Antalya (kwren) attacked Adana (ryanbmilbourne) killing 0, losing 2.",
+    "timestamp": "2016-01-14T23:02:47.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Tokat (kwren) attacked Adana (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T23:02:50.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Tokat (kwren) occupied Adana with 1 troop.",
+    "timestamp": "2016-01-14T23:02:56.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Siliana (kwren) was fortified from Béchar (kwren) with 2 troops.",
+    "timestamp": "2016-01-14T23:03:17.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-14T23:03:17.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-14T23:03:17.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-14T23:24:31.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier received 4 troops for 13 territories.",
+    "timestamp": "2016-01-14T23:24:31.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Jufra (mmacfreier) was reinforced by mmacfreier with 4 troops.",
+    "timestamp": "2016-01-14T23:25:08.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Jufra (mmacfreier) attacked Illizi (gcochard) killing 1, losing 6.",
+    "timestamp": "2016-01-14T23:25:15.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Morocco (mmacfreier) attacked Béchar (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-14T23:25:20.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Morocco (mmacfreier) occupied Béchar with 2 troops.",
+    "timestamp": "2016-01-14T23:25:22.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Jufra (mmacfreier) was fortified from Matruh (mmacfreier) with 2 troops.",
+    "timestamp": "2016-01-14T23:25:42.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-14T23:25:42.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-14T23:25:42.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-14T23:39:42.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "jobratt received 4 troops for 12 territories.",
+    "timestamp": "2016-01-14T23:39:42.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Lorraine (jobratt) was reinforced by jobratt with 4 troops.",
+    "timestamp": "2016-01-14T23:39:45.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Lorraine (jobratt) attacked Picardie (ryanbmilbourne) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-14T23:40:06.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Lorraine (jobratt) occupied Picardie with 6 troops.",
+    "timestamp": "2016-01-14T23:40:13.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Centre (jobratt) was fortified from Milan (jobratt) with 2 troops.",
+    "timestamp": "2016-01-14T23:40:37.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-14T23:40:37.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-14T23:40:37.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Round 2 started.",
+    "timestamp": "2016-01-14T23:40:37.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-15T16:33:25.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 11 territories.",
+    "timestamp": "2016-01-15T16:33:25.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Rif Dimashq (ryanbmilbourne) was reinforced by ryanbmilbourne with 2 troops.",
+    "timestamp": "2016-01-15T16:33:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Extremadura (ryanbmilbourne) was reinforced by ryanbmilbourne with 1 troop.",
+    "timestamp": "2016-01-15T16:33:51.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Extremadura (ryanbmilbourne) attacked Norte (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T16:34:01.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Extremadura (ryanbmilbourne) occupied Norte with 3 troops.",
+    "timestamp": "2016-01-15T16:34:03.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Rif Dimashq (ryanbmilbourne) attacked Lebanon (gcochard) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-15T16:34:17.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Rif Dimashq (ryanbmilbourne) occupied Lebanon with 2 troops.",
+    "timestamp": "2016-01-15T16:34:21.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Lebanon (ryanbmilbourne) was fortified from Al-Hasakah (ryanbmilbourne) with 1 troop.",
+    "timestamp": "2016-01-15T16:34:48.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-15T16:34:48.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-15T16:34:48.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-15T17:24:20.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "gcochard received 4 troops for 12 territories.",
+    "timestamp": "2016-01-15T17:24:20.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Palestine (gcochard) was reinforced by gcochard with 4 troops.",
+    "timestamp": "2016-01-15T17:24:30.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Palestine (gcochard) attacked Sinai (kwren) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-15T17:24:35.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Palestine (gcochard) occupied Sinai with 5 troops.",
+    "timestamp": "2016-01-15T17:24:38.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Sirte (gcochard) was fortified from Misratah (gcochard) with 2 troops.",
+    "timestamp": "2016-01-15T17:25:17.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-15T17:25:17.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-15T17:25:17.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-15T17:33:30.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "kwren received 4 troops for 12 territories.",
+    "timestamp": "2016-01-15T17:33:30.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "kwren received 1 troop for holding Tunisia.",
+    "timestamp": "2016-01-15T17:33:30.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Siliana (kwren) was reinforced by kwren with 5 troops.",
+    "timestamp": "2016-01-15T17:33:49.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Siliana (kwren) attacked Batna (ryanbmilbourne) conquering it, killing 3, losing 4.",
+    "timestamp": "2016-01-15T17:33:57.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Siliana (kwren) occupied Batna with 7 troops.",
+    "timestamp": "2016-01-15T17:33:59.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Batna (kwren) attacked Tiaret (mmacfreier) killing 0, losing 4.",
+    "timestamp": "2016-01-15T17:34:04.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "El Bayadh (kwren) attacked Morocco (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T17:34:11.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "El Bayadh (kwren) occupied Morocco with 1 troop.",
+    "timestamp": "2016-01-15T17:34:16.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Siliana (kwren) was fortified from Sicily (kwren) with 2 troops.",
+    "timestamp": "2016-01-15T17:34:46.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-15T17:34:46.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-15T17:34:46.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-15T17:35:35.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier received 4 troops for 13 territories.",
+    "timestamp": "2016-01-15T17:35:35.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Jufra (mmacfreier) was reinforced by mmacfreier with 4 troops.",
+    "timestamp": "2016-01-15T17:35:40.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Jufra (mmacfreier) attacked Illizi (gcochard) conquering it, killing 2, losing 2.",
+    "timestamp": "2016-01-15T17:35:46.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Jufra (mmacfreier) occupied Illizi with 4 troops.",
+    "timestamp": "2016-01-15T17:35:49.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Béchar (mmacfreier) was fortified from E. Kufrah (mmacfreier) with 2 troops.",
+    "timestamp": "2016-01-15T17:36:08.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-15T17:36:08.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-15T17:36:08.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-15T18:34:35.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "jobratt received 4 troops for 13 territories.",
+    "timestamp": "2016-01-15T18:34:35.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Centre (jobratt) was reinforced by jobratt with 4 troops.",
+    "timestamp": "2016-01-15T18:34:38.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Centre (jobratt) attacked Brittany (ryanbmilbourne) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-15T18:34:44.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Centre (jobratt) occupied Brittany with 7 troops.",
+    "timestamp": "2016-01-15T18:34:51.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Brittany (jobratt) attacked Aquitaine (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T18:35:00.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Brittany (jobratt) occupied Aquitaine with 1 troop.",
+    "timestamp": "2016-01-15T18:35:17.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Centre (jobratt) was fortified from Picardie (jobratt) with 5 troops.",
+    "timestamp": "2016-01-15T18:35:26.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-15T18:35:26.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-15T18:35:26.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Round 3 started.",
+    "timestamp": "2016-01-15T18:35:26.000Z",
+    "player": "unknown",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-15T18:44:29.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 11 territories.",
+    "timestamp": "2016-01-15T18:44:29.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne received 1 troop for holding Portugal.",
+    "timestamp": "2016-01-15T18:44:29.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Lebanon (ryanbmilbourne) was reinforced by ryanbmilbourne with 4 troops.",
+    "timestamp": "2016-01-15T18:44:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Lebanon (ryanbmilbourne) attacked Cyprus (jobratt) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-15T18:44:52.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Lebanon (ryanbmilbourne) occupied Cyprus with 1 troop.",
+    "timestamp": "2016-01-15T18:44:56.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Lebanon (ryanbmilbourne) attacked Palestine (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T18:45:00.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Lebanon (ryanbmilbourne) occupied Palestine with 1 troop.",
+    "timestamp": "2016-01-15T18:45:11.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Alentejo (ryanbmilbourne) attacked Morocco (kwren) killing 0, losing 1.",
+    "timestamp": "2016-01-15T18:45:16.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Western Sahara (ryanbmilbourne) attacked Morocco (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T18:45:25.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Western Sahara (ryanbmilbourne) occupied Morocco with 2 troops.",
+    "timestamp": "2016-01-15T18:45:30.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Rif Dimashq (ryanbmilbourne) was fortified from Lebanon (ryanbmilbourne) with 4 troops.",
+    "timestamp": "2016-01-15T18:46:18.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-15T18:46:18.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-15T18:46:18.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-15T18:52:11.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard received 3 troops for 10 territories.",
+    "timestamp": "2016-01-15T18:52:11.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Catalonia (gcochard) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-01-15T18:52:17.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Catalonia (gcochard) attacked Valencia (mmacfreier) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-15T18:52:22.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Catalonia (gcochard) occupied Valencia with 1 troop.",
+    "timestamp": "2016-01-15T18:52:31.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Andalusia (gcochard) attacked Extremadura (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T18:52:35.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Andalusia (gcochard) occupied Extremadura with 2 troops.",
+    "timestamp": "2016-01-15T18:52:43.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Farafra (gcochard) was fortified from New Valley (gcochard) with 2 troops.",
+    "timestamp": "2016-01-15T18:53:05.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-15T18:53:05.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-15T18:53:05.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-15T19:02:22.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren received 4 troops for 13 territories.",
+    "timestamp": "2016-01-15T19:02:22.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren received 1 troop for holding Tunisia.",
+    "timestamp": "2016-01-15T19:02:22.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Batna (kwren) was reinforced by kwren with 4 troops.",
+    "timestamp": "2016-01-15T19:02:32.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Ouargla (kwren) was reinforced by kwren with 1 troop.",
+    "timestamp": "2016-01-15T19:02:38.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Batna (kwren) attacked Tiaret (mmacfreier) killing 0, losing 6.",
+    "timestamp": "2016-01-15T19:02:44.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "W. Murzuq (kwren) attacked Jufra (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T19:02:51.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "W. Murzuq (kwren) occupied Jufra with 1 troop.",
+    "timestamp": "2016-01-15T19:03:03.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Batna (kwren) was fortified from W. Murzuq (kwren) with 1 troop.",
+    "timestamp": "2016-01-15T19:03:13.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-15T19:03:13.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-15T19:03:13.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-15T19:03:31.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier received 4 troops for 12 territories.",
+    "timestamp": "2016-01-15T19:03:31.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding South Algeria.",
+    "timestamp": "2016-01-15T19:03:31.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Tiaret (mmacfreier) was reinforced by mmacfreier with 7 troops.",
+    "timestamp": "2016-01-15T19:04:01.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Tiaret (mmacfreier) attacked Batna (kwren) conquering it, killing 2, losing 0.",
+    "timestamp": "2016-01-15T19:04:05.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Tiaret (mmacfreier) occupied Batna with 9 troops.",
+    "timestamp": "2016-01-15T19:04:07.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Batna (mmacfreier) attacked Ouargla (kwren) conquering it, killing 4, losing 5.",
+    "timestamp": "2016-01-15T19:04:19.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Batna (mmacfreier) occupied Ouargla with 3 troops.",
+    "timestamp": "2016-01-15T19:04:22.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Illizi (mmacfreier) was fortified from Tamanrasset (mmacfreier) with 2 troops.",
+    "timestamp": "2016-01-15T19:04:37.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-15T19:04:37.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-15T19:04:37.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-15T19:22:55.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt received 4 troops for 14 territories.",
+    "timestamp": "2016-01-15T19:22:55.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt received 3 troops for holding North France.",
+    "timestamp": "2016-01-15T19:22:55.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Burgundy (jobratt) was reinforced by jobratt with 7 troops.",
+    "timestamp": "2016-01-15T19:23:41.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Burgundy (jobratt) attacked Auvergne (mmacfreier) conquering it, killing 3, losing 3.",
+    "timestamp": "2016-01-15T19:23:58.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Burgundy (jobratt) occupied Auvergne with 1 troop.",
+    "timestamp": "2016-01-15T19:24:15.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Aquitaine (jobratt) was fortified from Burgundy (jobratt) with 3 troops.",
+    "timestamp": "2016-01-15T19:24:49.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-15T19:24:49.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-15T19:24:49.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Round 4 started.",
+    "timestamp": "2016-01-15T19:24:49.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-15T19:26:06.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne received 4 troops for 13 territories.",
+    "timestamp": "2016-01-15T19:26:06.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for holding East Region.",
+    "timestamp": "2016-01-15T19:26:06.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne received 1 troop for holding Morocco.",
+    "timestamp": "2016-01-15T19:26:06.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne received 1 troop for holding Portugal.",
+    "timestamp": "2016-01-15T19:26:06.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "Al-Hasakah (ryanbmilbourne) was reinforced by ryanbmilbourne with 9 troops.",
+    "timestamp": "2016-01-15T19:27:19.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "Al-Hasakah (ryanbmilbourne) attacked Adana (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-15T19:27:25.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "Al-Hasakah (ryanbmilbourne) occupied Adana with 1 troop.",
+    "timestamp": "2016-01-15T19:27:34.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "Corsica (ryanbmilbourne) attacked Milan (jobratt) killing 0, losing 1.",
+    "timestamp": "2016-01-15T19:27:49.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "Morocco (ryanbmilbourne) was fortified from Norte (ryanbmilbourne) with 2 troops.",
+    "timestamp": "2016-01-15T19:28:02.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-15T19:28:02.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-15T19:28:02.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-15T19:28:12.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard received 4 troops for 12 territories.",
+    "timestamp": "2016-01-15T19:28:12.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard received 3 troops for holding Spain.",
+    "timestamp": "2016-01-15T19:28:12.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Bosnia (gcochard) was reinforced by gcochard with 7 troops.",
+    "timestamp": "2016-01-15T19:28:36.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Bosnia (gcochard) attacked Croatia (kwren) killing 0, losing 9.",
+    "timestamp": "2016-01-15T19:28:45.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Sirte (gcochard) attacked Jufra (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T19:29:01.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Sirte (gcochard) occupied Jufra with 4 troops.",
+    "timestamp": "2016-01-15T19:29:04.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Farafra (gcochard) attacked Matruh (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T19:35:54.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Farafra (gcochard) occupied Matruh with 4 troops.",
+    "timestamp": "2016-01-15T19:36:06.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Catalonia (gcochard) was fortified from Extremadura (gcochard) with 1 troop.",
+    "timestamp": "2016-01-15T19:36:22.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-15T19:36:22.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-15T19:36:22.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-15T19:37:24.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "kwren received 3 troops for 10 territories.",
+    "timestamp": "2016-01-15T19:37:24.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "kwren received 1 troop for holding Tunisia.",
+    "timestamp": "2016-01-15T19:37:24.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Kebili (kwren) was reinforced by kwren with 4 troops.",
+    "timestamp": "2016-01-15T19:37:28.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Kebili (kwren) attacked Ouargla (mmacfreier) conquering it, killing 3, losing 4.",
+    "timestamp": "2016-01-15T19:37:37.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Kebili (kwren) occupied Ouargla with 5 troops.",
+    "timestamp": "2016-01-15T19:37:39.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Ouargla (kwren) attacked Batna (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T19:37:43.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Ouargla (kwren) occupied Batna with 4 troops.",
+    "timestamp": "2016-01-15T19:37:45.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Batna (kwren) attacked Tiaret (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T19:37:48.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Batna (kwren) occupied Tiaret with 1 troop.",
+    "timestamp": "2016-01-15T19:37:55.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Kebili (kwren) was fortified from Batna (kwren) with 2 troops.",
+    "timestamp": "2016-01-15T19:38:02.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-15T19:38:02.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-15T19:38:02.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-15T19:38:31.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier received 3 troops for 9 territories.",
+    "timestamp": "2016-01-15T19:38:31.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding South Algeria.",
+    "timestamp": "2016-01-15T19:38:31.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Darnah (mmacfreier) was reinforced by mmacfreier with 6 troops.",
+    "timestamp": "2016-01-15T19:38:40.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Darnah (mmacfreier) attacked Jufra (gcochard) conquering it, killing 4, losing 1.",
+    "timestamp": "2016-01-15T19:38:51.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Darnah (mmacfreier) occupied Jufra with 7 troops.",
+    "timestamp": "2016-01-15T19:38:53.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Jufra (mmacfreier) attacked Sirte (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T19:38:58.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Jufra (mmacfreier) occupied Sirte with 1 troop.",
+    "timestamp": "2016-01-15T19:39:00.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Jufra (mmacfreier) attacked Misratah (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T19:39:03.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Jufra (mmacfreier) occupied Misratah with 1 troop.",
+    "timestamp": "2016-01-15T19:39:07.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Darnah (mmacfreier) was fortified from Jufra (mmacfreier) with 4 troops.",
+    "timestamp": "2016-01-15T19:39:29.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-15T19:39:29.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-15T19:39:29.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-15T19:49:02.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "jobratt received 5 troops for 15 territories.",
+    "timestamp": "2016-01-15T19:49:02.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "jobratt received 3 troops for holding North France.",
+    "timestamp": "2016-01-15T19:49:02.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "jobratt received 1 troop for holding South France.",
+    "timestamp": "2016-01-15T19:49:02.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "E. Murzuq (jobratt) was reinforced by jobratt with 9 troops.",
+    "timestamp": "2016-01-15T19:51:17.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "E. Murzuq (jobratt) attacked Jufra (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-15T19:51:22.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "E. Murzuq (jobratt) occupied Jufra with 10 troops.",
+    "timestamp": "2016-01-15T19:52:05.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Jufra (jobratt) attacked Ouargla (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-15T19:52:10.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Jufra (jobratt) occupied Ouargla with 1 troop.",
+    "timestamp": "2016-01-15T19:53:16.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Jufra (jobratt) attacked Misratah (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T19:53:33.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Jufra (jobratt) occupied Misratah with 7 troops.",
+    "timestamp": "2016-01-15T19:53:34.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Rhône-Alpes (jobratt) was fortified from Burgundy (jobratt) with 2 troops.",
+    "timestamp": "2016-01-15T19:53:50.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-15T19:53:50.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-15T19:53:50.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Round 5 started.",
+    "timestamp": "2016-01-15T19:53:50.000Z",
+    "player": "unknown",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-15T21:09:37.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne received 4 troops for 14 territories.",
+    "timestamp": "2016-01-15T21:09:37.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for holding East Region.",
+    "timestamp": "2016-01-15T21:09:37.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne received 1 troop for holding Morocco.",
+    "timestamp": "2016-01-15T21:09:37.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne received 1 troop for holding Portugal.",
+    "timestamp": "2016-01-15T21:09:37.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Corsica (ryanbmilbourne) was reinforced by ryanbmilbourne with 1 troop.",
+    "timestamp": "2016-01-15T21:10:28.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Adana (ryanbmilbourne) was reinforced by ryanbmilbourne with 8 troops.",
+    "timestamp": "2016-01-15T21:10:32.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Corsica (ryanbmilbourne) attacked Milan (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-15T21:10:40.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Adana (ryanbmilbourne) attacked Antalya (kwren) killing 0, losing 1.",
+    "timestamp": "2016-01-15T21:10:53.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Adana (ryanbmilbourne) attacked Tokat (kwren) conquering it, killing 2, losing 0.",
+    "timestamp": "2016-01-15T21:10:58.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Adana (ryanbmilbourne) occupied Tokat with 1 troop.",
+    "timestamp": "2016-01-15T21:11:16.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Adana (ryanbmilbourne) attacked Antalya (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-15T21:11:22.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Adana (ryanbmilbourne) occupied Antalya with 1 troop.",
+    "timestamp": "2016-01-15T21:11:35.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Al-Hasakah (ryanbmilbourne) was fortified from Rif Dimashq (ryanbmilbourne) with 4 troops.",
+    "timestamp": "2016-01-15T21:11:56.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-15T21:11:56.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-15T21:11:56.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-15T21:14:21.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "gcochard received 3 troops for 11 territories.",
+    "timestamp": "2016-01-15T21:14:21.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "gcochard received 3 troops for holding Spain.",
+    "timestamp": "2016-01-15T21:14:21.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Sinai (gcochard) was reinforced by gcochard with 6 troops.",
+    "timestamp": "2016-01-15T21:14:38.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Sinai (gcochard) attacked Suez (jobratt) conquering it, killing 3, losing 5.",
+    "timestamp": "2016-01-15T21:14:45.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Sinai (gcochard) occupied Suez with 5 troops.",
+    "timestamp": "2016-01-15T21:14:47.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Suez (gcochard) attacked Minya (jobratt) killing 2, losing 0.",
+    "timestamp": "2016-01-15T21:15:08.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Matruh (gcochard) attacked Minya (jobratt) killing 0, losing 3.",
+    "timestamp": "2016-01-15T21:15:16.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Suez (gcochard) attacked Minya (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T21:15:20.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Suez (gcochard) occupied Minya with 1 troop.",
+    "timestamp": "2016-01-15T21:15:23.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Matruh (gcochard) was fortified from Suez (gcochard) with 3 troops.",
+    "timestamp": "2016-01-15T21:15:32.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-15T21:15:32.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-15T21:15:32.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-15T21:46:13.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received 3 troops for 10 territories.",
+    "timestamp": "2016-01-15T21:46:13.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received 1 troop for holding Tunisia.",
+    "timestamp": "2016-01-15T21:46:13.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Siliana (kwren) was reinforced by kwren with 4 troops.",
+    "timestamp": "2016-01-15T21:46:21.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Siliana (kwren) attacked Ouargla (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T21:46:26.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Siliana (kwren) occupied Ouargla with 6 troops.",
+    "timestamp": "2016-01-15T21:46:27.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Ouargla (kwren) attacked Jufra (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-15T21:46:32.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Ouargla (kwren) occupied Jufra with 1 troop.",
+    "timestamp": "2016-01-15T21:46:43.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Croatia (kwren) attacked Bosnia (gcochard) killing 0, losing 2.",
+    "timestamp": "2016-01-15T21:47:30.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-15T21:47:37.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-15T21:47:37.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-15T22:02:48.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier received 3 troops for 10 territories.",
+    "timestamp": "2016-01-15T22:02:48.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding South Algeria.",
+    "timestamp": "2016-01-15T22:02:48.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Darnah (mmacfreier) was reinforced by mmacfreier with 6 troops.",
+    "timestamp": "2016-01-15T22:03:20.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Darnah (mmacfreier) attacked E. Murzuq (jobratt) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-15T22:03:27.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Darnah (mmacfreier) occupied E. Murzuq with 8 troops.",
+    "timestamp": "2016-01-15T22:03:29.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "E. Murzuq (mmacfreier) attacked W. Kufrah (ryanbmilbourne) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-15T22:03:33.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "E. Murzuq (mmacfreier) occupied W. Kufrah with 1 troop.",
+    "timestamp": "2016-01-15T22:03:35.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "E. Murzuq (mmacfreier) attacked W. Murzuq (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T22:03:39.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "E. Murzuq (mmacfreier) occupied W. Murzuq with 5 troops.",
+    "timestamp": "2016-01-15T22:03:44.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "W. Murzuq (mmacfreier) attacked Jufra (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T22:03:47.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "W. Murzuq (mmacfreier) occupied Jufra with 4 troops.",
+    "timestamp": "2016-01-15T22:03:49.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-15T22:04:11.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-15T22:04:11.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-15T22:11:01.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "jobratt received 4 troops for 12 territories.",
+    "timestamp": "2016-01-15T22:11:01.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "jobratt received 3 troops for holding North France.",
+    "timestamp": "2016-01-15T22:11:01.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "jobratt received 1 troop for holding South France.",
+    "timestamp": "2016-01-15T22:11:01.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Rhône-Alpes (jobratt) was reinforced by jobratt with 4 troops.",
+    "timestamp": "2016-01-15T22:11:35.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Kirklareli (jobratt) was reinforced by jobratt with 4 troops.",
+    "timestamp": "2016-01-15T22:11:38.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Rhône-Alpes (jobratt) attacked Milan (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T22:11:44.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Rhône-Alpes (jobratt) occupied Milan with 8 troops.",
+    "timestamp": "2016-01-15T22:11:49.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Kirklareli (jobratt) attacked Tokat (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T22:11:54.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Kirklareli (jobratt) occupied Tokat with 1 troop.",
+    "timestamp": "2016-01-15T22:12:01.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Misratah (jobratt) attacked Sirte (mmacfreier) killing 0, losing 1.",
+    "timestamp": "2016-01-15T22:20:19.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Milan (jobratt) was fortified from Centre (jobratt) with 5 troops.",
+    "timestamp": "2016-01-15T22:20:38.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-15T22:20:38.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-15T22:20:38.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Round 6 started.",
+    "timestamp": "2016-01-15T22:20:38.000Z",
+    "player": "unknown",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-15T22:21:33.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne received 4 troops for 14 territories.",
+    "timestamp": "2016-01-15T22:21:33.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for holding East Region.",
+    "timestamp": "2016-01-15T22:21:33.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne received 1 troop for holding Morocco.",
+    "timestamp": "2016-01-15T22:21:33.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne received 1 troop for holding Portugal.",
+    "timestamp": "2016-01-15T22:21:33.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Al-Hasakah (ryanbmilbourne) was reinforced by ryanbmilbourne with 9 troops.",
+    "timestamp": "2016-01-15T22:21:55.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Al-Hasakah (ryanbmilbourne) attacked Mardin (Neutral) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-15T22:22:02.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Al-Hasakah (ryanbmilbourne) occupied Mardin with 20 troops.",
+    "timestamp": "2016-01-15T22:22:04.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Mardin (ryanbmilbourne) attacked Van (gcochard) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-15T22:22:15.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Mardin (ryanbmilbourne) occupied Van with 19 troops.",
+    "timestamp": "2016-01-15T22:22:17.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Van (ryanbmilbourne) attacked Erzurum (kwren) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-15T22:22:21.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Van (ryanbmilbourne) occupied Erzurum with 17 troops.",
+    "timestamp": "2016-01-15T22:22:22.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Erzurum (ryanbmilbourne) attacked Tokat (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-15T22:22:29.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Erzurum (ryanbmilbourne) occupied Tokat with 15 troops.",
+    "timestamp": "2016-01-15T22:22:31.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Tokat (ryanbmilbourne) attacked Kirklareli (jobratt) conquering it, killing 6, losing 1.",
+    "timestamp": "2016-01-15T22:22:37.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Tokat (ryanbmilbourne) occupied Kirklareli with 13 troops.",
+    "timestamp": "2016-01-15T22:22:39.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Kirklareli (ryanbmilbourne) attacked Greece (jobratt) conquering it, killing 3, losing 3.",
+    "timestamp": "2016-01-15T22:22:44.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Kirklareli (ryanbmilbourne) occupied Greece with 9 troops.",
+    "timestamp": "2016-01-15T22:22:49.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Adana (ryanbmilbourne) attacked Izmir (gcochard) killing 1, losing 4.",
+    "timestamp": "2016-01-15T22:22:55.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Greece (ryanbmilbourne) attacked Izmir (gcochard) conquering it, killing 2, losing 1.",
+    "timestamp": "2016-01-15T22:23:00.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Greece (ryanbmilbourne) occupied Izmir with 1 troop.",
+    "timestamp": "2016-01-15T22:23:20.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Greece (ryanbmilbourne) was fortified from Albania (ryanbmilbourne) with 2 troops.",
+    "timestamp": "2016-01-15T22:23:33.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-15T22:23:33.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-15T22:23:33.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-15T22:23:39.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "gcochard received 3 troops for 11 territories.",
+    "timestamp": "2016-01-15T22:23:39.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "gcochard received 2 troops for holding North Egypt.",
+    "timestamp": "2016-01-15T22:23:39.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "gcochard received 3 troops for holding Spain.",
+    "timestamp": "2016-01-15T22:23:39.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "gcochard received 2 troops on Minya",
+    "timestamp": "2016-01-15T22:24:07.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Bosnia (gcochard) was reinforced by gcochard with 6 troops.",
+    "timestamp": "2016-01-15T22:24:18.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Minya (gcochard) was reinforced by gcochard with 6 troops.",
+    "timestamp": "2016-01-15T22:24:24.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Minya (gcochard) attacked Red Sea (jobratt) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-15T22:24:30.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Minya (gcochard) occupied Red Sea with 8 troops.",
+    "timestamp": "2016-01-15T22:24:31.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Red Sea (gcochard) attacked Kharga (mmacfreier) conquering it, killing 3, losing 4.",
+    "timestamp": "2016-01-15T22:24:39.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Red Sea (gcochard) occupied Kharga with 3 troops.",
+    "timestamp": "2016-01-15T22:24:41.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Bosnia (gcochard) attacked Croatia (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-15T22:25:11.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Bosnia (gcochard) occupied Croatia with 4 troops.",
+    "timestamp": "2016-01-15T22:25:13.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Croatia (gcochard) attacked Slovenia (mmacfreier) killing 0, losing 3.",
+    "timestamp": "2016-01-15T22:25:32.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Farafra (gcochard) was fortified from Kharga (gcochard) with 2 troops.",
+    "timestamp": "2016-01-15T22:25:55.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-15T22:25:55.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-15T22:25:55.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-15T22:41:52.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 3 troops for 8 territories.",
+    "timestamp": "2016-01-15T22:41:52.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 1 troop for holding Tunisia.",
+    "timestamp": "2016-01-15T22:41:52.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 3 troops for holding North Algeria.",
+    "timestamp": "2016-01-15T22:41:52.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "El Bayadh (kwren) was reinforced by kwren with 2 troops.",
+    "timestamp": "2016-01-15T22:42:20.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Ouargla (kwren) was reinforced by kwren with 2 troops.",
+    "timestamp": "2016-01-15T22:42:24.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Kebili (kwren) was reinforced by kwren with 3 troops.",
+    "timestamp": "2016-01-15T22:42:28.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Sicily (kwren) was reinforced by kwren with 6 troops.",
+    "timestamp": "2016-01-15T22:42:31.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Sicily (kwren) attacked Naples (mmacfreier) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-15T22:42:35.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Sicily (kwren) occupied Naples with 1 troop.",
+    "timestamp": "2016-01-15T22:42:47.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Sicily (kwren) was fortified from Sardinia (kwren) with 2 troops.",
+    "timestamp": "2016-01-15T22:42:55.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-15T22:42:55.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-15T22:42:55.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-15T22:48:03.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier received 4 troops for 12 territories.",
+    "timestamp": "2016-01-15T22:48:03.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding South Libya.",
+    "timestamp": "2016-01-15T22:48:03.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding South Algeria.",
+    "timestamp": "2016-01-15T22:48:03.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier received 2 troops on Sirte",
+    "timestamp": "2016-01-15T22:48:17.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "E. Kufrah (mmacfreier) was reinforced by mmacfreier with 6 troops.",
+    "timestamp": "2016-01-15T22:48:34.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Jufra (mmacfreier) was reinforced by mmacfreier with 12 troops.",
+    "timestamp": "2016-01-15T22:48:37.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Jufra (mmacfreier) attacked Misratah (jobratt) conquering it, killing 6, losing 7.",
+    "timestamp": "2016-01-15T22:48:47.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Jufra (mmacfreier) occupied Misratah with 1 troop.",
+    "timestamp": "2016-01-15T22:48:50.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Darnah (mmacfreier) was fortified from Jufra (mmacfreier) with 7 troops.",
+    "timestamp": "2016-01-15T22:48:56.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-15T22:48:56.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-15T22:48:56.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-15T22:52:48.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "jobratt received 3 troops for 9 territories.",
+    "timestamp": "2016-01-15T22:52:48.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "jobratt received 3 troops for holding North France.",
+    "timestamp": "2016-01-15T22:52:48.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "jobratt received 1 troop for holding South France.",
+    "timestamp": "2016-01-15T22:52:48.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Milan (jobratt) was reinforced by jobratt with 15 troops.",
+    "timestamp": "2016-01-15T22:53:17.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Milan (jobratt) attacked Corsica (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T22:53:25.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Milan (jobratt) occupied Corsica with 16 troops.",
+    "timestamp": "2016-01-15T22:53:55.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Corsica (jobratt) attacked Sardinia (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T22:53:58.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Corsica (jobratt) occupied Sardinia with 15 troops.",
+    "timestamp": "2016-01-15T22:54:00.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Sardinia (jobratt) attacked Naples (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T22:54:03.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Sardinia (jobratt) occupied Naples with 14 troops.",
+    "timestamp": "2016-01-15T22:54:12.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Naples (jobratt) attacked Greece (ryanbmilbourne) killing 2, losing 8.",
+    "timestamp": "2016-01-15T22:57:46.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Naples (jobratt) was fortified from Milan (jobratt) with 4 troops.",
+    "timestamp": "2016-01-15T22:58:31.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-15T22:58:31.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-15T22:58:31.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Round 7 started.",
+    "timestamp": "2016-01-15T22:58:31.000Z",
+    "player": "unknown",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-15T22:58:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne received 6 troops for 20 territories.",
+    "timestamp": "2016-01-15T22:58:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne received 1 troop for holding Montenegro-Albania-Greece.",
+    "timestamp": "2016-01-15T22:58:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for holding West Turkey.",
+    "timestamp": "2016-01-15T22:58:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne received 2 troops for holding East Turkey.",
+    "timestamp": "2016-01-15T22:58:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for holding East Region.",
+    "timestamp": "2016-01-15T22:58:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne received 1 troop for holding Morocco.",
+    "timestamp": "2016-01-15T22:58:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne received 1 troop for holding Portugal.",
+    "timestamp": "2016-01-15T22:58:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne received 2 troops on Tokat",
+    "timestamp": "2016-01-15T22:58:53.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne received 2 troops on Western Sahara",
+    "timestamp": "2016-01-15T22:58:53.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Greece (ryanbmilbourne) was reinforced by ryanbmilbourne with 25 troops.",
+    "timestamp": "2016-01-15T22:59:31.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Greece (ryanbmilbourne) attacked Naples (jobratt) conquering it, killing 10, losing 5.",
+    "timestamp": "2016-01-15T22:59:37.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Greece (ryanbmilbourne) occupied Naples with 26 troops.",
+    "timestamp": "2016-01-15T22:59:38.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Naples (ryanbmilbourne) attacked Sardinia (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T22:59:44.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Naples (ryanbmilbourne) occupied Sardinia with 25 troops.",
+    "timestamp": "2016-01-15T22:59:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Sardinia (ryanbmilbourne) attacked Corsica (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T22:59:50.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Sardinia (ryanbmilbourne) occupied Corsica with 24 troops.",
+    "timestamp": "2016-01-15T22:59:52.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Corsica (ryanbmilbourne) attacked Milan (jobratt) conquering it, killing 8, losing 8.",
+    "timestamp": "2016-01-15T22:59:59.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Corsica (ryanbmilbourne) occupied Milan with 15 troops.",
+    "timestamp": "2016-01-15T23:00:03.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Milan (ryanbmilbourne) attacked Rhône-Alpes (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:00:12.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Milan (ryanbmilbourne) occupied Rhône-Alpes with 14 troops.",
+    "timestamp": "2016-01-15T23:00:15.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Rhône-Alpes (ryanbmilbourne) attacked Burgundy (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:00:18.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Rhône-Alpes (ryanbmilbourne) occupied Burgundy with 1 troop.",
+    "timestamp": "2016-01-15T23:00:32.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Greece (ryanbmilbourne) was fortified from Rhône-Alpes (ryanbmilbourne) with 12 troops.",
+    "timestamp": "2016-01-15T23:00:49.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-15T23:00:49.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-15T23:00:49.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-15T23:04:31.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "gcochard received 4 troops for 14 territories.",
+    "timestamp": "2016-01-15T23:04:31.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "gcochard received 2 troops for holding North Egypt.",
+    "timestamp": "2016-01-15T23:04:31.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "gcochard received 3 troops for holding South Egypt.",
+    "timestamp": "2016-01-15T23:04:31.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "gcochard received 3 troops for holding Spain.",
+    "timestamp": "2016-01-15T23:04:31.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Croatia (gcochard) was reinforced by gcochard with 12 troops.",
+    "timestamp": "2016-01-15T23:04:35.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Croatia (gcochard) attacked Slovenia (mmacfreier) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-15T23:04:40.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Croatia (gcochard) occupied Slovenia with 12 troops.",
+    "timestamp": "2016-01-15T23:04:41.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Slovenia (gcochard) attacked Milan (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:06:22.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Slovenia (gcochard) occupied Milan with 11 troops.",
+    "timestamp": "2016-01-15T23:06:24.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Milan (gcochard) attacked Rhône-Alpes (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-15T23:06:30.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Milan (gcochard) occupied Rhône-Alpes with 9 troops.",
+    "timestamp": "2016-01-15T23:06:32.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Rhône-Alpes (gcochard) attacked Auvergne (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-15T23:06:36.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Rhône-Alpes (gcochard) occupied Auvergne with 7 troops.",
+    "timestamp": "2016-01-15T23:06:38.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Auvergne (gcochard) attacked Centre (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:06:42.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Auvergne (gcochard) occupied Centre with 6 troops.",
+    "timestamp": "2016-01-15T23:06:44.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Centre (gcochard) attacked Brittany (jobratt) killing 4, losing 5.",
+    "timestamp": "2016-01-15T23:06:55.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "New Valley (gcochard) was fortified from Matruh (gcochard) with 3 troops.",
+    "timestamp": "2016-01-15T23:07:13.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-15T23:07:13.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-15T23:07:13.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-15T23:08:18.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren received 3 troops for 7 territories.",
+    "timestamp": "2016-01-15T23:08:18.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren received 1 troop for holding Tunisia.",
+    "timestamp": "2016-01-15T23:08:18.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren received 3 troops for holding North Algeria.",
+    "timestamp": "2016-01-15T23:08:18.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "El Bayadh (kwren) was reinforced by kwren with 15 troops.",
+    "timestamp": "2016-01-15T23:08:25.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "El Bayadh (kwren) attacked Morocco (ryanbmilbourne) conquering it, killing 4, losing 7.",
+    "timestamp": "2016-01-15T23:08:34.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "El Bayadh (kwren) occupied Morocco with 11 troops.",
+    "timestamp": "2016-01-15T23:08:39.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Morocco (kwren) attacked Western Sahara (ryanbmilbourne) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-15T23:08:44.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Morocco (kwren) occupied Western Sahara with 1 troop.",
+    "timestamp": "2016-01-15T23:08:49.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Morocco (kwren) attacked Alentejo (ryanbmilbourne) conquering it, killing 2, losing 0.",
+    "timestamp": "2016-01-15T23:08:53.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Morocco (kwren) occupied Alentejo with 1 troop.",
+    "timestamp": "2016-01-15T23:08:57.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Morocco (kwren) attacked Andalusia (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:09:00.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Morocco (kwren) occupied Andalusia with 8 troops.",
+    "timestamp": "2016-01-15T23:09:05.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Andalusia (kwren) attacked Valencia (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:09:08.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Andalusia (kwren) occupied Valencia with 1 troop.",
+    "timestamp": "2016-01-15T23:09:15.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Andalusia (kwren) attacked Extremadura (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:09:18.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Andalusia (kwren) occupied Extremadura with 6 troops.",
+    "timestamp": "2016-01-15T23:09:19.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Extremadura (kwren) attacked Norte (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:09:22.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Extremadura (kwren) occupied Norte with 5 troops.",
+    "timestamp": "2016-01-15T23:09:24.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "El Bayadh (kwren) was fortified from Norte (kwren) with 4 troops.",
+    "timestamp": "2016-01-15T23:09:37.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-15T23:09:37.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-15T23:09:37.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-15T23:12:08.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier received 4 troops for 12 territories.",
+    "timestamp": "2016-01-15T23:12:08.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding South Libya.",
+    "timestamp": "2016-01-15T23:12:08.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding South Algeria.",
+    "timestamp": "2016-01-15T23:12:08.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding North Libya.",
+    "timestamp": "2016-01-15T23:12:08.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Adrar (mmacfreier) was reinforced by mmacfreier with 10 troops.",
+    "timestamp": "2016-01-15T23:12:36.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "E. Kufrah (mmacfreier) was reinforced by mmacfreier with 11 troops.",
+    "timestamp": "2016-01-15T23:12:41.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Adrar (mmacfreier) attacked Western Sahara (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:12:46.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Adrar (mmacfreier) occupied Western Sahara with 12 troops.",
+    "timestamp": "2016-01-15T23:12:48.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Western Sahara (mmacfreier) attacked Morocco (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:12:51.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Western Sahara (mmacfreier) occupied Morocco with 11 troops.",
+    "timestamp": "2016-01-15T23:12:53.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "E. Kufrah (mmacfreier) attacked Matruh (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:13:00.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "E. Kufrah (mmacfreier) occupied Matruh with 1 troop.",
+    "timestamp": "2016-01-15T23:13:03.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "E. Kufrah (mmacfreier) attacked New Valley (gcochard) conquering it, killing 4, losing 0.",
+    "timestamp": "2016-01-15T23:13:07.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "E. Kufrah (mmacfreier) occupied New Valley with 1 troop.",
+    "timestamp": "2016-01-15T23:13:25.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "E. Kufrah (mmacfreier) attacked Farafra (gcochard) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-15T23:13:29.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "E. Kufrah (mmacfreier) occupied Farafra with 10 troops.",
+    "timestamp": "2016-01-15T23:13:38.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Farafra (mmacfreier) attacked Kharga (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:13:40.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Farafra (mmacfreier) occupied Kharga with 9 troops.",
+    "timestamp": "2016-01-15T23:13:42.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Kharga (mmacfreier) attacked Red Sea (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:13:45.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Kharga (mmacfreier) occupied Red Sea with 8 troops.",
+    "timestamp": "2016-01-15T23:13:47.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Red Sea (mmacfreier) attacked Minya (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:13:49.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Red Sea (mmacfreier) occupied Minya with 7 troops.",
+    "timestamp": "2016-01-15T23:13:51.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Minya (mmacfreier) attacked Suez (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:13:53.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Minya (mmacfreier) occupied Suez with 6 troops.",
+    "timestamp": "2016-01-15T23:13:55.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Suez (mmacfreier) attacked Sinai (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:13:58.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Suez (mmacfreier) occupied Sinai with 5 troops.",
+    "timestamp": "2016-01-15T23:14:00.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Darnah (mmacfreier) was fortified from Sirte (mmacfreier) with 2 troops.",
+    "timestamp": "2016-01-15T23:14:24.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-15T23:14:24.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-15T23:14:24.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-15T23:25:37.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "jobratt received 3 troops for 4 territories.",
+    "timestamp": "2016-01-15T23:25:37.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Aquitaine (jobratt) was reinforced by jobratt with 11 troops.",
+    "timestamp": "2016-01-15T23:25:57.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Aquitaine (jobratt) attacked Centre (gcochard) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-15T23:26:02.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Aquitaine (jobratt) occupied Centre with 12 troops.",
+    "timestamp": "2016-01-15T23:26:03.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Centre (jobratt) attacked Burgundy (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:26:05.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Centre (jobratt) occupied Burgundy with 11 troops.",
+    "timestamp": "2016-01-15T23:26:08.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Burgundy (jobratt) attacked Rhône-Alpes (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:26:10.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Burgundy (jobratt) occupied Rhône-Alpes with 10 troops.",
+    "timestamp": "2016-01-15T23:26:14.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Rhône-Alpes (jobratt) attacked Auvergne (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:26:17.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Rhône-Alpes (jobratt) occupied Auvergne with 1 troop.",
+    "timestamp": "2016-01-15T23:26:24.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Aquitaine (jobratt) was fortified from Brittany (jobratt) with 1 troop.",
+    "timestamp": "2016-01-15T23:26:29.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-15T23:26:29.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-15T23:26:29.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Round 8 started.",
+    "timestamp": "2016-01-15T23:26:29.000Z",
+    "player": "unknown",
+    "round": 8
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-15T23:26:44.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "ryanbmilbourne received 6 troops for 19 territories.",
+    "timestamp": "2016-01-15T23:26:44.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "ryanbmilbourne received 1 troop for holding Montenegro-Albania-Greece.",
+    "timestamp": "2016-01-15T23:26:44.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for holding West Turkey.",
+    "timestamp": "2016-01-15T23:26:44.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "ryanbmilbourne received 2 troops for holding East Turkey.",
+    "timestamp": "2016-01-15T23:26:44.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for holding East Region.",
+    "timestamp": "2016-01-15T23:26:44.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Greece (ryanbmilbourne) was reinforced by ryanbmilbourne with 4 troops.",
+    "timestamp": "2016-01-15T23:29:17.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Montenegro (ryanbmilbourne) was reinforced by ryanbmilbourne with 11 troops.",
+    "timestamp": "2016-01-15T23:29:26.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Montenegro (ryanbmilbourne) attacked Bosnia (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-15T23:29:31.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Montenegro (ryanbmilbourne) occupied Bosnia with 12 troops.",
+    "timestamp": "2016-01-15T23:29:33.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Bosnia (ryanbmilbourne) attacked Croatia (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:29:36.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Bosnia (ryanbmilbourne) occupied Croatia with 11 troops.",
+    "timestamp": "2016-01-15T23:29:38.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Croatia (ryanbmilbourne) attacked Slovenia (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:29:40.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Croatia (ryanbmilbourne) occupied Slovenia with 10 troops.",
+    "timestamp": "2016-01-15T23:29:42.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-15T23:29:53.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-15T23:29:53.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-15T23:43:43.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "gcochard received 3 troops for 2 territories.",
+    "timestamp": "2016-01-15T23:43:44.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "Catalonia (gcochard) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-01-15T23:43:54.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "Catalonia (gcochard) attacked Valencia (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:43:58.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "Catalonia (gcochard) occupied Valencia with 9 troops.",
+    "timestamp": "2016-01-15T23:44:00.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "Valencia (gcochard) attacked Extremadura (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-15T23:44:07.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "Valencia (gcochard) occupied Extremadura with 7 troops.",
+    "timestamp": "2016-01-15T23:44:08.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "Extremadura (gcochard) attacked Norte (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:44:13.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "Extremadura (gcochard) occupied Norte with 1 troop.",
+    "timestamp": "2016-01-15T23:44:16.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "Extremadura (gcochard) attacked Alentejo (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:44:21.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "Extremadura (gcochard) occupied Alentejo with 1 troop.",
+    "timestamp": "2016-01-15T23:44:25.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "Extremadura (gcochard) attacked Andalusia (kwren) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-01-15T23:44:33.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-15T23:44:51.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-15T23:44:51.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-15T23:45:12.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received 3 troops for 7 territories.",
+    "timestamp": "2016-01-15T23:45:12.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received 1 troop for holding Tunisia.",
+    "timestamp": "2016-01-15T23:45:12.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received 3 troops for holding North Algeria.",
+    "timestamp": "2016-01-15T23:45:12.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Sicily (kwren) was reinforced by kwren with 7 troops.",
+    "timestamp": "2016-01-15T23:45:21.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Sicily (kwren) attacked Naples (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:45:26.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Sicily (kwren) occupied Naples with 5 troops.",
+    "timestamp": "2016-01-15T23:45:38.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Naples (kwren) attacked Milan (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:45:41.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Naples (kwren) occupied Milan with 4 troops.",
+    "timestamp": "2016-01-15T23:45:51.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Sicily (kwren) was fortified from Ouargla (kwren) with 5 troops.",
+    "timestamp": "2016-01-15T23:46:03.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-15T23:46:03.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-15T23:46:03.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-15T23:46:35.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier received 7 troops for 22 territories.",
+    "timestamp": "2016-01-15T23:46:35.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding South Libya.",
+    "timestamp": "2016-01-15T23:46:35.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding South Algeria.",
+    "timestamp": "2016-01-15T23:46:35.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding North Libya.",
+    "timestamp": "2016-01-15T23:46:35.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier received 1 troop for holding Morocco.",
+    "timestamp": "2016-01-15T23:46:35.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding South Egypt.",
+    "timestamp": "2016-01-15T23:46:35.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier received 2 troops for holding North Egypt.",
+    "timestamp": "2016-01-15T23:46:35.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Sinai (mmacfreier) was reinforced by mmacfreier with 5 troops.",
+    "timestamp": "2016-01-15T23:46:53.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Morocco (mmacfreier) was reinforced by mmacfreier with 17 troops.",
+    "timestamp": "2016-01-15T23:46:57.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Morocco (mmacfreier) attacked Andalusia (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-15T23:47:01.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Morocco (mmacfreier) occupied Andalusia with 26 troops.",
+    "timestamp": "2016-01-15T23:47:03.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Andalusia (mmacfreier) attacked Extremadura (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:47:08.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Andalusia (mmacfreier) occupied Extremadura with 25 troops.",
+    "timestamp": "2016-01-15T23:47:11.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Extremadura (mmacfreier) attacked Alentejo (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:47:15.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Extremadura (mmacfreier) occupied Alentejo with 1 troop.",
+    "timestamp": "2016-01-15T23:47:18.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Extremadura (mmacfreier) attacked Norte (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-15T23:47:24.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Extremadura (mmacfreier) occupied Norte with 1 troop.",
+    "timestamp": "2016-01-15T23:47:28.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Extremadura (mmacfreier) attacked Valencia (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:47:31.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Extremadura (mmacfreier) occupied Valencia with 1 troop.",
+    "timestamp": "2016-01-15T23:47:35.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Extremadura (mmacfreier) attacked Catalonia (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:47:39.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "gcochard was defeated by mmacfreier.",
+    "timestamp": "2016-01-15T23:47:39.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "Extremadura (mmacfreier) occupied Catalonia with 20 troops.",
+    "timestamp": "2016-01-15T23:47:41.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier received 2 troops on Kharga",
+    "timestamp": "2016-01-15T23:48:34.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier received 2 troops on Darnah",
+    "timestamp": "2016-01-15T23:48:34.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Morocco (mmacfreier) was reinforced by mmacfreier with 5 troops.",
+    "timestamp": "2016-01-15T23:48:58.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Darnah (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-15T23:49:06.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Catalonia (mmacfreier) attacked Aquitaine (jobratt) conquering it, killing 2, losing 0.",
+    "timestamp": "2016-01-15T23:49:22.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Catalonia (mmacfreier) occupied Aquitaine with 19 troops.",
+    "timestamp": "2016-01-15T23:49:24.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Aquitaine (mmacfreier) attacked Brittany (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:49:27.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Aquitaine (mmacfreier) occupied Brittany with 18 troops.",
+    "timestamp": "2016-01-15T23:49:28.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Brittany (mmacfreier) attacked Centre (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:49:31.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Brittany (mmacfreier) occupied Centre with 17 troops.",
+    "timestamp": "2016-01-15T23:49:33.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Centre (mmacfreier) attacked Picardie (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:49:36.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Centre (mmacfreier) occupied Picardie with 1 troop.",
+    "timestamp": "2016-01-15T23:49:40.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Centre (mmacfreier) attacked Auvergne (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:49:42.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Centre (mmacfreier) occupied Auvergne with 15 troops.",
+    "timestamp": "2016-01-15T23:49:46.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Auvergne (mmacfreier) attacked Burgundy (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:49:49.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Auvergne (mmacfreier) occupied Burgundy with 14 troops.",
+    "timestamp": "2016-01-15T23:49:51.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Burgundy (mmacfreier) attacked Lorraine (jobratt) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-15T23:49:56.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Burgundy (mmacfreier) occupied Lorraine with 1 troop.",
+    "timestamp": "2016-01-15T23:49:59.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Burgundy (mmacfreier) attacked Rhône-Alpes (jobratt) killing 8, losing 10.",
+    "timestamp": "2016-01-15T23:50:12.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Jufra (mmacfreier) was fortified from E. Kufrah (mmacfreier) with 5 troops.",
+    "timestamp": "2016-01-15T23:50:42.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-15T23:50:42.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-15T23:50:42.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-15T23:52:17.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "jobratt received 3 troops for 1 territory.",
+    "timestamp": "2016-01-15T23:52:17.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Rhône-Alpes (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-01-15T23:52:31.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Rhône-Alpes (jobratt) attacked Burgundy (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-15T23:52:34.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Rhône-Alpes (jobratt) occupied Burgundy with 1 troop.",
+    "timestamp": "2016-01-15T23:52:37.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-15T23:52:41.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-15T23:52:41.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Round 9 started.",
+    "timestamp": "2016-01-15T23:52:41.000Z",
+    "player": "unknown",
+    "round": 9
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-15T23:53:03.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "ryanbmilbourne received 7 troops for 21 territories.",
+    "timestamp": "2016-01-15T23:53:03.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "ryanbmilbourne received 1 troop for holding Montenegro-Albania-Greece.",
+    "timestamp": "2016-01-15T23:53:03.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for holding West Turkey.",
+    "timestamp": "2016-01-15T23:53:03.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "ryanbmilbourne received 2 troops for holding East Turkey.",
+    "timestamp": "2016-01-15T23:53:03.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for holding East Region.",
+    "timestamp": "2016-01-15T23:53:03.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "ryanbmilbourne received 1 troop for holding Slovenia-Croatia-Bosnia.",
+    "timestamp": "2016-01-15T23:53:03.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "Palestine (ryanbmilbourne) was reinforced by ryanbmilbourne with 16 troops.",
+    "timestamp": "2016-01-15T23:53:49.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "Greece (ryanbmilbourne) was reinforced by ryanbmilbourne with 1 troop.",
+    "timestamp": "2016-01-15T23:53:51.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "Greece (ryanbmilbourne) attacked Naples (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-15T23:53:57.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "Greece (ryanbmilbourne) occupied Naples with 1 troop.",
+    "timestamp": "2016-01-15T23:54:10.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "Greece (ryanbmilbourne) was fortified from Tokat (ryanbmilbourne) with 2 troops.",
+    "timestamp": "2016-01-15T23:54:59.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-15T23:54:59.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-15T23:54:59.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-16T00:01:27.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 3 troops for 8 territories.",
+    "timestamp": "2016-01-16T00:01:27.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 1 troop for holding Tunisia.",
+    "timestamp": "2016-01-16T00:01:27.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 3 troops for holding North Algeria.",
+    "timestamp": "2016-01-16T00:01:27.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Milan (kwren) was reinforced by kwren with 7 troops.",
+    "timestamp": "2016-01-16T00:01:36.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Milan (kwren) attacked Rhône-Alpes (jobratt) conquering it, killing 3, losing 4.",
+    "timestamp": "2016-01-16T00:01:42.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Milan (kwren) occupied Rhône-Alpes with 6 troops.",
+    "timestamp": "2016-01-16T00:01:51.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Rhône-Alpes (kwren) attacked Burgundy (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-16T00:01:55.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "jobratt was defeated by kwren.",
+    "timestamp": "2016-01-16T00:01:55.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Rhône-Alpes (kwren) occupied Burgundy with 1 troop.",
+    "timestamp": "2016-01-16T00:02:14.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Sicily (kwren) was reinforced by kwren with 8 troops.",
+    "timestamp": "2016-01-16T00:02:46.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Sicily (kwren) attacked Naples (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:02:50.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Sicily (kwren) occupied Naples with 1 troop.",
+    "timestamp": "2016-01-16T00:02:55.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Sicily (kwren) was fortified from Rhône-Alpes (kwren) with 3 troops.",
+    "timestamp": "2016-01-16T00:03:01.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-16T00:03:01.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-16T00:03:01.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-16T00:15:04.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier received 11 troops for 34 territories.",
+    "timestamp": "2016-01-16T00:15:04.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding South Libya.",
+    "timestamp": "2016-01-16T00:15:04.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding South Algeria.",
+    "timestamp": "2016-01-16T00:15:04.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding North Libya.",
+    "timestamp": "2016-01-16T00:15:04.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier received 1 troop for holding Morocco.",
+    "timestamp": "2016-01-16T00:15:04.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding South Egypt.",
+    "timestamp": "2016-01-16T00:15:04.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier received 2 troops for holding North Egypt.",
+    "timestamp": "2016-01-16T00:15:04.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier received 1 troop for holding Portugal.",
+    "timestamp": "2016-01-16T00:15:04.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding Spain.",
+    "timestamp": "2016-01-16T00:15:04.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier received 2 troops on Tamanrasset",
+    "timestamp": "2016-01-16T00:15:12.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Misratah (mmacfreier) was reinforced by mmacfreier with 6 troops.",
+    "timestamp": "2016-01-16T00:15:36.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Darnah (mmacfreier) was reinforced by mmacfreier with 10 troops.",
+    "timestamp": "2016-01-16T00:15:44.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Sinai (mmacfreier) was reinforced by mmacfreier with 22 troops.",
+    "timestamp": "2016-01-16T00:15:47.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Sinai (mmacfreier) attacked Palestine (ryanbmilbourne) conquering it, killing 17, losing 10.",
+    "timestamp": "2016-01-16T00:16:04.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Sinai (mmacfreier) occupied Palestine with 21 troops.",
+    "timestamp": "2016-01-16T00:16:05.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Palestine (mmacfreier) attacked Lebanon (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:16:08.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Palestine (mmacfreier) occupied Lebanon with 20 troops.",
+    "timestamp": "2016-01-16T00:16:09.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Lebanon (mmacfreier) attacked Cyprus (ryanbmilbourne) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-16T00:16:14.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Lebanon (mmacfreier) occupied Cyprus with 1 troop.",
+    "timestamp": "2016-01-16T00:16:17.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Lebanon (mmacfreier) attacked Rif Dimashq (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-16T00:16:21.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Lebanon (mmacfreier) occupied Rif Dimashq with 15 troops.",
+    "timestamp": "2016-01-16T00:16:22.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Rif Dimashq (mmacfreier) attacked Al-Hasakah (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:16:25.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Rif Dimashq (mmacfreier) occupied Al-Hasakah with 14 troops.",
+    "timestamp": "2016-01-16T00:16:26.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Al-Hasakah (mmacfreier) attacked Mardin (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:16:29.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Al-Hasakah (mmacfreier) occupied Mardin with 13 troops.",
+    "timestamp": "2016-01-16T00:16:31.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Mardin (mmacfreier) attacked Van (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:16:33.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Mardin (mmacfreier) occupied Van with 12 troops.",
+    "timestamp": "2016-01-16T00:16:38.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Van (mmacfreier) attacked Erzurum (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:16:40.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Van (mmacfreier) occupied Erzurum with 11 troops.",
+    "timestamp": "2016-01-16T00:16:42.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Erzurum (mmacfreier) attacked Tokat (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-16T00:16:48.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Erzurum (mmacfreier) occupied Tokat with 9 troops.",
+    "timestamp": "2016-01-16T00:16:49.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Tokat (mmacfreier) attacked Adana (ryanbmilbourne) conquering it, killing 1, losing 4.",
+    "timestamp": "2016-01-16T00:16:57.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Tokat (mmacfreier) occupied Adana with 4 troops.",
+    "timestamp": "2016-01-16T00:16:59.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Darnah (mmacfreier) attacked Greece (ryanbmilbourne) conquering it, killing 17, losing 11.",
+    "timestamp": "2016-01-16T00:17:23.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Darnah (mmacfreier) occupied Greece with 13 troops.",
+    "timestamp": "2016-01-16T00:17:25.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Adana (mmacfreier) attacked Antalya (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:17:29.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Adana (mmacfreier) occupied Antalya with 3 troops.",
+    "timestamp": "2016-01-16T00:17:32.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Antalya (mmacfreier) attacked Izmir (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-16T00:17:37.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Greece (mmacfreier) attacked Kirklareli (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:17:44.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Greece (mmacfreier) occupied Kirklareli with 1 troop.",
+    "timestamp": "2016-01-16T00:17:46.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Greece (mmacfreier) attacked Albania (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:17:49.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Greece (mmacfreier) occupied Albania with 11 troops.",
+    "timestamp": "2016-01-16T00:17:51.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Albania (mmacfreier) attacked Montenegro (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:17:54.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Albania (mmacfreier) occupied Montenegro with 10 troops.",
+    "timestamp": "2016-01-16T00:17:55.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Montenegro (mmacfreier) attacked Bosnia (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-16T00:18:00.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Montenegro (mmacfreier) occupied Bosnia with 8 troops.",
+    "timestamp": "2016-01-16T00:18:02.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Bosnia (mmacfreier) attacked Croatia (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:18:04.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Bosnia (mmacfreier) occupied Croatia with 7 troops.",
+    "timestamp": "2016-01-16T00:18:06.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Greece (mmacfreier) was fortified from Kharga (mmacfreier) with 2 troops.",
+    "timestamp": "2016-01-16T00:18:42.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-16T00:18:42.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-16T00:18:42.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Round 10 started.",
+    "timestamp": "2016-01-16T00:18:42.000Z",
+    "player": "unknown",
+    "round": 10
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-16T00:19:10.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 3 territories.",
+    "timestamp": "2016-01-16T00:19:10.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "Slovenia (ryanbmilbourne) was reinforced by ryanbmilbourne with 11 troops.",
+    "timestamp": "2016-01-16T00:19:28.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "Slovenia (ryanbmilbourne) attacked Milan (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-16T00:19:35.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "Slovenia (ryanbmilbourne) occupied Milan with 18 troops.",
+    "timestamp": "2016-01-16T00:19:37.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "Sardinia (ryanbmilbourne) was fortified from Milan (ryanbmilbourne) with 17 troops.",
+    "timestamp": "2016-01-16T00:19:48.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-16T00:19:48.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-16T00:19:48.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-16T00:22:03.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "kwren received 3 troops for 10 territories.",
+    "timestamp": "2016-01-16T00:22:03.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "kwren received 1 troop for holding Tunisia.",
+    "timestamp": "2016-01-16T00:22:03.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "kwren received 3 troops for holding North Algeria.",
+    "timestamp": "2016-01-16T00:22:03.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Burgundy (kwren) was reinforced by kwren with 7 troops.",
+    "timestamp": "2016-01-16T00:22:19.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Burgundy (kwren) attacked Auvergne (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-16T00:22:24.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Burgundy (kwren) occupied Auvergne with 6 troops.",
+    "timestamp": "2016-01-16T00:22:25.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Auvergne (kwren) attacked Aquitaine (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:22:28.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Auvergne (kwren) occupied Aquitaine with 5 troops.",
+    "timestamp": "2016-01-16T00:22:29.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Aquitaine (kwren) attacked Catalonia (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:22:32.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Aquitaine (kwren) occupied Catalonia with 4 troops.",
+    "timestamp": "2016-01-16T00:22:33.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Catalonia (kwren) attacked Norte (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:22:37.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Catalonia (kwren) occupied Norte with 3 troops.",
+    "timestamp": "2016-01-16T00:22:39.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Sicily (kwren) was fortified from Kebili (kwren) with 5 troops.",
+    "timestamp": "2016-01-16T00:22:49.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-16T00:22:49.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-16T00:22:49.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-16T00:24:33.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received 16 troops for 48 territories.",
+    "timestamp": "2016-01-16T00:24:33.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding South Libya.",
+    "timestamp": "2016-01-16T00:24:33.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding South Algeria.",
+    "timestamp": "2016-01-16T00:24:33.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding North Libya.",
+    "timestamp": "2016-01-16T00:24:33.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received 1 troop for holding Morocco.",
+    "timestamp": "2016-01-16T00:24:33.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding South Egypt.",
+    "timestamp": "2016-01-16T00:24:33.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received 2 troops for holding North Egypt.",
+    "timestamp": "2016-01-16T00:24:33.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding East Region.",
+    "timestamp": "2016-01-16T00:24:33.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received 2 troops for holding East Turkey.",
+    "timestamp": "2016-01-16T00:24:33.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding West Turkey.",
+    "timestamp": "2016-01-16T00:24:33.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received 1 troop for holding Montenegro-Albania-Greece.",
+    "timestamp": "2016-01-16T00:24:33.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Croatia (mmacfreier) was reinforced by mmacfreier with 40 troops.",
+    "timestamp": "2016-01-16T00:24:38.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Croatia (mmacfreier) attacked Slovenia (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-16T00:24:43.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Croatia (mmacfreier) occupied Slovenia with 45 troops.",
+    "timestamp": "2016-01-16T00:24:45.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Slovenia (mmacfreier) attacked Milan (ryanbmilbourne) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-16T00:24:51.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Slovenia (mmacfreier) occupied Milan with 42 troops.",
+    "timestamp": "2016-01-16T00:24:58.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Milan (mmacfreier) attacked Corsica (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:25:10.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Milan (mmacfreier) occupied Corsica with 30 troops.",
+    "timestamp": "2016-01-16T00:25:33.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Corsica (mmacfreier) attacked Sardinia (ryanbmilbourne) conquering it, killing 18, losing 8.",
+    "timestamp": "2016-01-16T00:25:50.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "ryanbmilbourne was defeated by mmacfreier.",
+    "timestamp": "2016-01-16T00:25:50.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "Corsica (mmacfreier) occupied Sardinia with 21 troops.",
+    "timestamp": "2016-01-16T00:25:52.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received 2 troops on W. Murzuq",
+    "timestamp": "2016-01-16T00:26:06.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received 2 troops on Extremadura",
+    "timestamp": "2016-01-16T00:26:06.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received 2 troops on Mardin",
+    "timestamp": "2016-01-16T00:26:06.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Milan (mmacfreier) was reinforced by mmacfreier with 8 troops.",
+    "timestamp": "2016-01-16T00:26:12.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Milan (mmacfreier) attacked Rhône-Alpes (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-16T00:26:21.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Milan (mmacfreier) occupied Rhône-Alpes with 17 troops.",
+    "timestamp": "2016-01-16T00:26:23.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Rhône-Alpes (mmacfreier) attacked Burgundy (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:26:26.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Rhône-Alpes (mmacfreier) occupied Burgundy with 1 troop.",
+    "timestamp": "2016-01-16T00:26:30.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Rhône-Alpes (mmacfreier) attacked Auvergne (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-16T00:26:35.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Rhône-Alpes (mmacfreier) occupied Auvergne with 14 troops.",
+    "timestamp": "2016-01-16T00:26:37.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Auvergne (mmacfreier) attacked Aquitaine (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:26:40.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Auvergne (mmacfreier) occupied Aquitaine with 13 troops.",
+    "timestamp": "2016-01-16T00:26:41.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Aquitaine (mmacfreier) attacked Catalonia (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:26:45.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Aquitaine (mmacfreier) occupied Catalonia with 12 troops.",
+    "timestamp": "2016-01-16T00:26:47.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Extremadura (mmacfreier) attacked Norte (kwren) killing 1, losing 2.",
+    "timestamp": "2016-01-16T00:26:51.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Catalonia (mmacfreier) attacked Norte (kwren) conquering it, killing 2, losing 5.",
+    "timestamp": "2016-01-16T00:27:01.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Catalonia (mmacfreier) occupied Norte with 6 troops.",
+    "timestamp": "2016-01-16T00:27:03.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Sardinia (mmacfreier) attacked Naples (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:27:06.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Sardinia (mmacfreier) occupied Naples with 20 troops.",
+    "timestamp": "2016-01-16T00:27:12.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Naples (mmacfreier) attacked Sicily (kwren) killing 22, losing 19.",
+    "timestamp": "2016-01-16T00:28:07.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Naples (mmacfreier) was fortified from Norte (mmacfreier) with 5 troops.",
+    "timestamp": "2016-01-16T00:28:22.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-16T00:28:22.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-16T00:28:22.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Round 11 started.",
+    "timestamp": "2016-01-16T00:28:22.000Z",
+    "player": "unknown",
+    "round": 11
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-16T00:28:31.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "kwren received 3 troops for 7 territories.",
+    "timestamp": "2016-01-16T00:28:31.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "kwren received 1 troop for holding Tunisia.",
+    "timestamp": "2016-01-16T00:28:31.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "kwren received 3 troops for holding North Algeria.",
+    "timestamp": "2016-01-16T00:28:31.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Sicily (kwren) was reinforced by kwren with 7 troops.",
+    "timestamp": "2016-01-16T00:28:34.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Sicily (kwren) attacked Naples (mmacfreier) conquering it, killing 6, losing 7.",
+    "timestamp": "2016-01-16T00:28:39.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Sicily (kwren) occupied Naples with 7 troops.",
+    "timestamp": "2016-01-16T00:28:45.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Naples (kwren) attacked Greece (mmacfreier) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-16T00:28:53.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Naples (kwren) occupied Greece with 5 troops.",
+    "timestamp": "2016-01-16T00:28:55.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Greece (kwren) attacked Izmir (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:28:58.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Greece (kwren) occupied Izmir with 4 troops.",
+    "timestamp": "2016-01-16T00:28:59.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Izmir (kwren) attacked Adana (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:29:02.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Izmir (kwren) occupied Adana with 3 troops.",
+    "timestamp": "2016-01-16T00:29:04.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Adana (kwren) attacked Tokat (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-16T00:29:10.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "El Bayadh (kwren) attacked Béchar (mmacfreier) killing 0, losing 4.",
+    "timestamp": "2016-01-16T00:29:16.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-16T00:29:27.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-16T00:29:27.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-16T00:29:40.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 18 troops for 54 territories.",
+    "timestamp": "2016-01-16T00:29:40.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding South Libya.",
+    "timestamp": "2016-01-16T00:29:40.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding South Algeria.",
+    "timestamp": "2016-01-16T00:29:40.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding North Libya.",
+    "timestamp": "2016-01-16T00:29:40.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 1 troop for holding Morocco.",
+    "timestamp": "2016-01-16T00:29:40.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding South Egypt.",
+    "timestamp": "2016-01-16T00:29:40.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 2 troops for holding North Egypt.",
+    "timestamp": "2016-01-16T00:29:40.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding East Region.",
+    "timestamp": "2016-01-16T00:29:40.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 1 troop for holding Slovenia-Croatia-Bosnia.",
+    "timestamp": "2016-01-16T00:29:40.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding North France.",
+    "timestamp": "2016-01-16T00:29:40.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 1 troop for holding South France.",
+    "timestamp": "2016-01-16T00:29:40.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding Spain.",
+    "timestamp": "2016-01-16T00:29:40.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 1 troop for holding Portugal.",
+    "timestamp": "2016-01-16T00:29:40.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Mardin (mmacfreier) was reinforced by mmacfreier with 45 troops.",
+    "timestamp": "2016-01-16T00:29:47.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Mardin (mmacfreier) attacked Tokat (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:29:50.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Mardin (mmacfreier) occupied Tokat with 47 troops.",
+    "timestamp": "2016-01-16T00:29:53.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Tokat (mmacfreier) attacked Adana (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-16T00:30:00.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Tokat (mmacfreier) occupied Adana with 45 troops.",
+    "timestamp": "2016-01-16T00:30:02.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Adana (mmacfreier) attacked Izmir (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-16T00:30:07.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Adana (mmacfreier) occupied Izmir with 43 troops.",
+    "timestamp": "2016-01-16T00:30:08.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Izmir (mmacfreier) attacked Greece (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:30:12.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Izmir (mmacfreier) occupied Greece with 42 troops.",
+    "timestamp": "2016-01-16T00:30:14.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Greece (mmacfreier) attacked Naples (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:30:17.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Greece (mmacfreier) occupied Naples with 41 troops.",
+    "timestamp": "2016-01-16T00:30:19.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Naples (mmacfreier) attacked Sicily (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:30:22.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Naples (mmacfreier) occupied Sicily with 40 troops.",
+    "timestamp": "2016-01-16T00:30:24.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Sicily (mmacfreier) attacked Siliana (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:30:27.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Sicily (mmacfreier) occupied Siliana with 39 troops.",
+    "timestamp": "2016-01-16T00:30:28.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Siliana (mmacfreier) attacked Batna (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:30:32.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Siliana (mmacfreier) occupied Batna with 38 troops.",
+    "timestamp": "2016-01-16T00:30:34.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Batna (mmacfreier) attacked Tiaret (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:30:37.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Batna (mmacfreier) occupied Tiaret with 37 troops.",
+    "timestamp": "2016-01-16T00:30:39.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Tiaret (mmacfreier) attacked El Bayadh (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-16T00:30:43.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Tiaret (mmacfreier) occupied El Bayadh with 36 troops.",
+    "timestamp": "2016-01-16T00:30:45.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "El Bayadh (mmacfreier) attacked Ouargla (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-16T00:30:49.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "El Bayadh (mmacfreier) occupied Ouargla with 34 troops.",
+    "timestamp": "2016-01-16T00:30:51.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Ouargla (mmacfreier) attacked Kebili (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-16T00:30:56.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "kwren was defeated by mmacfreier.",
+    "timestamp": "2016-01-16T00:30:56.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Game finished.",
+    "timestamp": "2016-01-16T00:30:56.000Z",
+    "player": "unknown",
+    "round": 11
+  },
+  {
+    "message": "ryanbmilbourne lost 17 rating.",
+    "timestamp": "2016-01-16T00:30:56.000Z",
+    "player": "ryanbmilbourne",
+    "round": 11
+  },
+  {
+    "message": "ryanbmilbourne received 20 tokens.",
+    "timestamp": "2016-01-16T00:30:56.000Z",
+    "player": "ryanbmilbourne",
+    "round": 11
+  },
+  {
+    "message": "gcochard lost 14 rating.",
+    "timestamp": "2016-01-16T00:30:56.000Z",
+    "player": "gcochard",
+    "round": 11
+  },
+  {
+    "message": "gcochard received 20 tokens.",
+    "timestamp": "2016-01-16T00:30:56.000Z",
+    "player": "gcochard",
+    "round": 11
+  },
+  {
+    "message": "kwren lost 17 rating.",
+    "timestamp": "2016-01-16T00:30:57.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "kwren received 20 tokens.",
+    "timestamp": "2016-01-16T00:30:57.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier won the game.",
+    "timestamp": "2016-01-16T00:30:57.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 75 rating.",
+    "timestamp": "2016-01-16T00:30:57.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 20 tokens.",
+    "timestamp": "2016-01-16T00:30:57.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "jobratt lost 27 rating.",
+    "timestamp": "2016-01-16T00:30:57.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "jobratt received 20 tokens.",
+    "timestamp": "2016-01-16T00:30:57.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "gcochard received 4 troops for turning in cards Al-Hasakah, Minya, and Tiaret.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "gcochard",
+    "round": 11
+  },
+  {
+    "message": "kwren received 6 troops for turning in cards Antalya, Matruh, and Jufra.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 8 troops for turning in cards Auvergne, Rif Dimashq, and Sirte.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "jobratt received 8 troops for turning in cards E. Murzuq, Adrar, and Alentejo.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "ryanbmilbourne received 8 troops for turning in cards Corsica, Tokat, and Western Sahara.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "ryanbmilbourne",
+    "round": 11
+  },
+  {
+    "message": "kwren received 8 troops for turning in cards Lorraine, Kirklareli, and Catalonia.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 8 troops for turning in cards Van, Lebanon, and Slovenia.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "jobratt received 8 troops for turning in cards Sardinia, Erzurum, and Sinai.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 8 troops for turning in cards Kharga, Darnah, and Adana.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "kwren received 8 troops for turning in cards Valencia, Izmir, and Andalusia.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 8 troops for turning in cards Tamanrasset, Sicily, and Burgundy.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "ryanbmilbourne received 8 troops for turning in cards Rhône-Alpes, Albania, and Bosnia.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "ryanbmilbourne",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 8 troops for turning in cards W. Murzuq, Extremadura, and Mardin.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  }
+]

--- a/data/604831.json
+++ b/data/604831.json
@@ -1,0 +1,7748 @@
+[
+  {
+    "message": "Game created.",
+    "timestamp": "2016-01-18T18:05:12.000Z",
+    "player": "unknown",
+    "round": 0
+  },
+  {
+    "message": "mmacfreier joined the game.",
+    "timestamp": "2016-01-18T18:05:12.000Z",
+    "player": "mmacfreier",
+    "round": 0
+  },
+  {
+    "message": "tanleach1001 joined the game.",
+    "timestamp": "2016-01-18T18:10:04.000Z",
+    "player": "tanleach1001",
+    "round": 0
+  },
+  {
+    "message": "jobratt joined the game.",
+    "timestamp": "2016-01-18T18:14:32.000Z",
+    "player": "jobratt",
+    "round": 0
+  },
+  {
+    "message": "gcochard joined the game.",
+    "timestamp": "2016-01-18T18:20:38.000Z",
+    "player": "gcochard",
+    "round": 0
+  },
+  {
+    "message": "kwren joined the game.",
+    "timestamp": "2016-01-18T18:22:07.000Z",
+    "player": "kwren",
+    "round": 0
+  },
+  {
+    "message": "ryanbmilbourne joined the game.",
+    "timestamp": "2016-01-18T18:43:48.000Z",
+    "player": "ryanbmilbourne",
+    "round": 0
+  },
+  {
+    "message": "Game started.",
+    "timestamp": "2016-01-18T18:43:48.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-18T18:44:06.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "jobratt received 3 troops for 10 territories.",
+    "timestamp": "2016-01-18T18:44:06.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Culd (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-01-18T18:44:44.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Culd (jobratt) attacked Cei (mmacfreier) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-01-18T18:44:51.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Culd (jobratt) occupied Cei with 1 troop.",
+    "timestamp": "2016-01-18T18:45:00.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-18T18:46:11.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-18T18:46:11.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-18T19:55:19.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 10 territories.",
+    "timestamp": "2016-01-18T19:55:19.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Doustmon (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-18T19:55:43.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Cid (ryanbmilbourne) attacked Cei (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-18T19:55:49.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Cid (ryanbmilbourne) occupied Cei with 1 troop.",
+    "timestamp": "2016-01-18T19:55:55.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Doustmon (ryanbmilbourne) attacked Dune (tanleach1001) killing 1, losing 3.",
+    "timestamp": "2016-01-18T19:56:06.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Wun (ryanbmilbourne) was fortified from Wa (ryanbmilbourne) with 2 troops.",
+    "timestamp": "2016-01-18T19:56:28.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-18T19:56:28.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-18T19:56:28.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-18T20:06:20.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier received 3 troops for 9 territories.",
+    "timestamp": "2016-01-18T20:06:20.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Oatgol (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-18T20:06:34.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Clutch (mmacfreier) attacked Fulcon (kwren) killing 0, losing 2.",
+    "timestamp": "2016-01-18T20:06:38.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Oatgol (mmacfreier) attacked Odpewn (tanleach1001) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-18T20:06:50.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Oatgol (mmacfreier) occupied Odpewn with 1 troop.",
+    "timestamp": "2016-01-18T20:07:02.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Odpewn (mmacfreier) was fortified from Ottel (mmacfreier) with 2 troops.",
+    "timestamp": "2016-01-18T20:07:24.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-18T20:07:24.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-18T20:07:24.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-18T20:07:40.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren received 3 troops for 10 territories.",
+    "timestamp": "2016-01-18T20:07:40.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Fulcon (kwren) was reinforced by kwren with 1 troop.",
+    "timestamp": "2016-01-18T20:08:01.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Tripoc (kwren) was reinforced by kwren with 1 troop.",
+    "timestamp": "2016-01-18T20:08:05.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Taulk (kwren) was reinforced by kwren with 1 troop.",
+    "timestamp": "2016-01-18T20:08:08.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Fulcon (kwren) attacked Clutch (mmacfreier) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-18T20:08:14.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Eglo (kwren) was fortified from Elitt (kwren) with 2 troops.",
+    "timestamp": "2016-01-18T20:08:34.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-18T20:08:34.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-18T20:08:34.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-18T20:08:41.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 9 territories.",
+    "timestamp": "2016-01-18T20:08:41.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Dri (tanleach1001) was reinforced by tanleach1001 with 3 troops.",
+    "timestamp": "2016-01-18T20:09:02.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Dri (tanleach1001) attacked Du (mmacfreier) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-01-18T20:09:08.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Dri (tanleach1001) occupied Du with 3 troops.",
+    "timestamp": "2016-01-18T20:09:10.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Spork (tanleach1001) was fortified from Sulodoop (tanleach1001) with 2 troops.",
+    "timestamp": "2016-01-18T20:09:58.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-18T20:09:58.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-18T20:09:58.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-18T20:10:32.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard received 3 troops for 10 territories.",
+    "timestamp": "2016-01-18T20:10:32.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Flinn (gcochard) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-01-18T20:10:45.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Flinn (gcochard) attacked Fado (kwren) killing 0, losing 2.",
+    "timestamp": "2016-01-18T20:10:52.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Flinn (gcochard) attacked Fulcon (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-18T20:10:59.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Echo (gcochard) was fortified from Traln (gcochard) with 2 troops.",
+    "timestamp": "2016-01-18T20:11:09.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-18T20:11:09.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-18T20:11:09.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Round 2 started.",
+    "timestamp": "2016-01-18T20:11:09.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-18T20:13:04.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "jobratt received 3 troops for 10 territories.",
+    "timestamp": "2016-01-18T20:13:04.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Culd (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-01-18T20:13:09.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Culd (jobratt) attacked Cei (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-18T20:13:14.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Culd (jobratt) occupied Cei with 1 troop.",
+    "timestamp": "2016-01-18T20:13:23.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Culd (jobratt) attacked Cid (ryanbmilbourne) conquering it, killing 2, losing 1.",
+    "timestamp": "2016-01-18T20:13:40.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Culd (jobratt) occupied Cid with 1 troop.",
+    "timestamp": "2016-01-18T20:13:43.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Octa (jobratt) attacked Ord (gcochard) killing 1, losing 2.",
+    "timestamp": "2016-01-18T20:13:54.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "So (jobratt) was fortified from Walkon (jobratt) with 2 troops.",
+    "timestamp": "2016-01-18T20:15:15.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-18T20:15:15.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-18T20:15:15.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-18T20:16:50.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 9 territories.",
+    "timestamp": "2016-01-18T20:16:50.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Doustmon (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-18T20:17:02.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Doustmon (ryanbmilbourne) attacked Dune (tanleach1001) killing 0, losing 4.",
+    "timestamp": "2016-01-18T20:17:07.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Wun (ryanbmilbourne) attacked Whist (tanleach1001) killing 2, losing 3.",
+    "timestamp": "2016-01-18T20:17:25.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Eong (ryanbmilbourne) attacked Elitt (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-18T20:17:38.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Eong (ryanbmilbourne) occupied Elitt with 2 troops.",
+    "timestamp": "2016-01-18T20:17:51.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Co (ryanbmilbourne) attacked Sulodoop (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-18T20:17:55.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Co (ryanbmilbourne) occupied Sulodoop with 2 troops.",
+    "timestamp": "2016-01-18T20:17:59.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Wun (ryanbmilbourne) attacked Whist (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-18T20:18:10.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Don (ryanbmilbourne) was fortified from Doustmon (ryanbmilbourne) with 1 troop.",
+    "timestamp": "2016-01-18T20:18:31.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-18T20:18:31.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-18T20:18:31.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-18T21:03:37.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier received 3 troops for 8 territories.",
+    "timestamp": "2016-01-18T21:03:37.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Oatgol (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-18T21:03:52.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Oatgol (mmacfreier) attacked Oshgrind (tanleach1001) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-18T21:03:57.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Oatgol (mmacfreier) occupied Oshgrind with 1 troop.",
+    "timestamp": "2016-01-18T21:04:00.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Oatgol (mmacfreier) attacked Octa (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-18T21:04:05.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Oatgol (mmacfreier) occupied Octa with 4 troops.",
+    "timestamp": "2016-01-18T21:04:06.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Octa (mmacfreier) attacked Ord (gcochard) killing 0, losing 2.",
+    "timestamp": "2016-01-18T21:04:10.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Octa (mmacfreier) was fortified from Odpewn (mmacfreier) with 2 troops.",
+    "timestamp": "2016-01-18T21:04:19.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-18T21:04:19.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-18T21:04:19.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-18T21:04:59.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "kwren received 3 troops for 9 territories.",
+    "timestamp": "2016-01-18T21:04:59.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Taulk (kwren) was reinforced by kwren with 2 troops.",
+    "timestamp": "2016-01-18T21:05:06.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Tripoc (kwren) was reinforced by kwren with 1 troop.",
+    "timestamp": "2016-01-18T21:05:09.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Tripoc (kwren) attacked Traln (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-18T21:05:12.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Tripoc (kwren) occupied Traln with 4 troops.",
+    "timestamp": "2016-01-18T21:05:14.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Vabon (kwren) attacked Dune (tanleach1001) killing 0, losing 2.",
+    "timestamp": "2016-01-18T21:05:23.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Welk (kwren) attacked Engrash (gcochard) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-18T21:05:36.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Eglo (kwren) was fortified from Woxan (kwren) with 2 troops.",
+    "timestamp": "2016-01-18T21:05:59.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-18T21:05:59.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-18T21:05:59.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-18T21:06:05.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 7 territories.",
+    "timestamp": "2016-01-18T21:06:05.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Du (tanleach1001) was reinforced by tanleach1001 with 3 troops.",
+    "timestamp": "2016-01-18T21:06:22.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Du (tanleach1001) attacked Doustmon (ryanbmilbourne) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-18T21:06:29.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Du (tanleach1001) occupied Doustmon with 2 troops.",
+    "timestamp": "2016-01-18T21:06:57.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Doustmon (tanleach1001) was fortified from Dune (tanleach1001) with 1 troop.",
+    "timestamp": "2016-01-18T21:08:24.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-18T21:08:24.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-18T21:08:24.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-18T21:08:51.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "gcochard received 3 troops for 9 territories.",
+    "timestamp": "2016-01-18T21:08:51.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Finch (gcochard) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-01-18T21:09:48.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Finch (gcochard) attacked Onbri (jobratt) killing 1, losing 5.",
+    "timestamp": "2016-01-18T21:09:58.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Trax (gcochard) attacked Teld (mmacfreier) killing 0, losing 2.",
+    "timestamp": "2016-01-18T21:10:03.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Ord (gcochard) attacked Ottel (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-18T21:10:16.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Sart (gcochard) was fortified from Sache (gcochard) with 2 troops.",
+    "timestamp": "2016-01-18T21:10:30.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-18T21:10:30.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-18T21:10:30.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Round 3 started.",
+    "timestamp": "2016-01-18T21:10:30.000Z",
+    "player": "unknown",
+    "round": 3
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-18T21:13:49.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt received 3 troops for 11 territories.",
+    "timestamp": "2016-01-18T21:13:49.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Culd (jobratt) was reinforced by jobratt with 2 troops.",
+    "timestamp": "2016-01-18T21:13:55.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Cal (jobratt) was reinforced by jobratt with 1 troop.",
+    "timestamp": "2016-01-18T21:13:57.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Cal (jobratt) attacked Co (ryanbmilbourne) killing 0, losing 3.",
+    "timestamp": "2016-01-18T21:14:02.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Culd (jobratt) attacked Clutch (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-18T21:14:05.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Culd (jobratt) occupied Clutch with 3 troops.",
+    "timestamp": "2016-01-18T21:14:07.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "So (jobratt) attacked Setha (ryanbmilbourne) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-18T21:14:35.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "So (jobratt) occupied Setha with 4 troops.",
+    "timestamp": "2016-01-18T21:14:39.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Setha (jobratt) was fortified from Off (jobratt) with 2 troops.",
+    "timestamp": "2016-01-18T21:14:49.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-18T21:14:49.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-18T21:14:49.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-18T21:16:18.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 10 territories.",
+    "timestamp": "2016-01-18T21:16:18.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Don (ryanbmilbourne) was reinforced by ryanbmilbourne with 2 troops.",
+    "timestamp": "2016-01-18T21:16:44.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Vhown (ryanbmilbourne) was reinforced by ryanbmilbourne with 1 troop.",
+    "timestamp": "2016-01-18T21:16:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Vhown (ryanbmilbourne) attacked Vabon (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-18T21:16:54.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Vhown (ryanbmilbourne) occupied Vabon with 3 troops.",
+    "timestamp": "2016-01-18T21:16:55.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-18T21:17:19.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-18T21:17:19.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-18T21:17:31.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier received 3 troops for 9 territories.",
+    "timestamp": "2016-01-18T21:17:31.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Octa (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-18T21:17:43.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Octa (mmacfreier) attacked Ord (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-18T21:17:46.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Octa (mmacfreier) occupied Ord with 6 troops.",
+    "timestamp": "2016-01-18T21:17:48.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Ord (mmacfreier) attacked Ottel (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-18T21:17:51.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Ord (mmacfreier) occupied Ottel with 1 troop.",
+    "timestamp": "2016-01-18T21:18:06.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Ord (mmacfreier) attacked Off (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-18T21:18:08.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Ord (mmacfreier) occupied Off with 4 troops.",
+    "timestamp": "2016-01-18T21:18:10.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Emb (mmacfreier) was fortified from Enbrum (mmacfreier) with 2 troops.",
+    "timestamp": "2016-01-18T21:18:29.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-18T21:18:29.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-18T21:18:29.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-18T21:18:37.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren received 3 troops for 9 territories.",
+    "timestamp": "2016-01-18T21:18:37.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Taulk (kwren) was reinforced by kwren with 3 troops.",
+    "timestamp": "2016-01-18T21:18:41.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Taulk (kwren) attacked Trax (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-18T21:18:46.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Taulk (kwren) occupied Trax with 7 troops.",
+    "timestamp": "2016-01-18T21:18:51.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Trax (kwren) attacked Teld (mmacfreier) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-18T21:18:56.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Trax (kwren) occupied Teld with 6 troops.",
+    "timestamp": "2016-01-18T21:18:57.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Teld (kwren) attacked Tuloe (tanleach1001) killing 0, losing 2.",
+    "timestamp": "2016-01-18T21:19:00.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Eglo (kwren) attacked Enbrum (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-18T21:19:18.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Eglo (kwren) occupied Enbrum with 5 troops.",
+    "timestamp": "2016-01-18T21:19:22.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Vreen (kwren) attacked Du (tanleach1001) conquering it, killing 2, losing 0.",
+    "timestamp": "2016-01-18T21:19:32.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Vreen (kwren) occupied Du with 1 troop.",
+    "timestamp": "2016-01-18T21:19:41.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Fado (kwren) attacked Flinn (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-18T21:19:44.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Fado (kwren) occupied Flinn with 2 troops.",
+    "timestamp": "2016-01-18T21:19:46.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Flinn (kwren) attacked Fulcon (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-18T21:19:50.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-18T21:21:12.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-18T21:21:12.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-18T21:21:29.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 7 territories.",
+    "timestamp": "2016-01-18T21:21:29.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Dune (tanleach1001) was reinforced by tanleach1001 with 1 troop.",
+    "timestamp": "2016-01-18T21:21:43.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Doustmon (tanleach1001) was reinforced by tanleach1001 with 2 troops.",
+    "timestamp": "2016-01-18T21:21:47.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Doustmon (tanleach1001) attacked Du (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-18T21:21:51.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Doustmon (tanleach1001) occupied Du with 4 troops.",
+    "timestamp": "2016-01-18T21:22:07.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Doustmon (tanleach1001) was fortified from Du (tanleach1001) with 2 troops.",
+    "timestamp": "2016-01-18T21:22:31.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-18T21:22:31.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-18T21:22:31.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-18T21:47:38.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard received 3 troops for 5 territories.",
+    "timestamp": "2016-01-18T21:47:38.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Echo (gcochard) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-01-18T21:47:47.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Echo (gcochard) attacked Enbrum (kwren) killing 3, losing 7.",
+    "timestamp": "2016-01-18T21:47:57.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Vua (gcochard) attacked Welk (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-18T21:48:06.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-18T21:48:33.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-18T21:48:33.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Round 4 started.",
+    "timestamp": "2016-01-18T21:48:33.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-18T21:59:44.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "jobratt received 4 troops for 12 territories.",
+    "timestamp": "2016-01-18T21:59:45.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Cal (jobratt) was reinforced by jobratt with 4 troops.",
+    "timestamp": "2016-01-18T21:59:57.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Cal (jobratt) attacked Co (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-18T22:00:00.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Cal (jobratt) occupied Co with 4 troops.",
+    "timestamp": "2016-01-18T22:00:04.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-18T22:01:51.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-18T22:01:51.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-18T22:02:45.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 10 territories.",
+    "timestamp": "2016-01-18T22:02:45.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "Vhown (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-18T22:03:17.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "Vhown (ryanbmilbourne) attacked Vua (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-18T22:03:23.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "Vhown (ryanbmilbourne) occupied Vua with 2 troops.",
+    "timestamp": "2016-01-18T22:03:25.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "Vua (ryanbmilbourne) attacked Welk (gcochard) killing 0, losing 1.",
+    "timestamp": "2016-01-18T22:03:28.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) attacked Eglo (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-18T22:03:43.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) occupied Eglo with 2 troops.",
+    "timestamp": "2016-01-18T22:03:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "Vua (ryanbmilbourne) was fortified from Vabon (ryanbmilbourne) with 2 troops.",
+    "timestamp": "2016-01-18T22:03:59.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-18T22:03:59.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-18T22:03:59.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-18T22:08:05.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier received 3 troops for 10 territories.",
+    "timestamp": "2016-01-18T22:08:05.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Oshgrind (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-18T22:08:13.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Oshgrind (mmacfreier) attacked Onbri (jobratt) killing 1, losing 3.",
+    "timestamp": "2016-01-18T22:08:24.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Ohma (mmacfreier) attacked Walkon (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-18T22:08:30.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Ohma (mmacfreier) occupied Walkon with 1 troop.",
+    "timestamp": "2016-01-18T22:08:32.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Ottel (mmacfreier) was fortified from Off (mmacfreier) with 3 troops.",
+    "timestamp": "2016-01-18T22:08:40.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-18T22:08:40.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-18T22:08:40.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-18T22:09:55.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "kwren received 4 troops for 12 territories.",
+    "timestamp": "2016-01-18T22:09:55.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Teld (kwren) was reinforced by kwren with 4 troops.",
+    "timestamp": "2016-01-18T22:10:14.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Teld (kwren) attacked Tuloe (tanleach1001) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-18T22:10:21.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Teld (kwren) occupied Tuloe with 7 troops.",
+    "timestamp": "2016-01-18T22:10:29.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Enbrum (kwren) attacked Echo (gcochard) killing 0, losing 1.",
+    "timestamp": "2016-01-18T22:10:32.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Traln (kwren) was fortified from Tuloe (kwren) with 1 troop.",
+    "timestamp": "2016-01-18T22:10:49.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-18T22:10:49.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-18T22:10:49.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-18T22:11:02.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 7 territories.",
+    "timestamp": "2016-01-18T22:11:02.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Vy (tanleach1001) was reinforced by tanleach1001 with 3 troops.",
+    "timestamp": "2016-01-18T22:11:20.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Vy (tanleach1001) attacked Vhown (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-18T22:11:25.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Vy (tanleach1001) occupied Vhown with 4 troops.",
+    "timestamp": "2016-01-18T22:11:27.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Vhown (tanleach1001) attacked Vabon (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-18T22:11:31.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Vhown (tanleach1001) occupied Vabon with 2 troops.",
+    "timestamp": "2016-01-18T22:11:33.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Fud (tanleach1001) attacked Fado (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-18T22:11:41.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Fud (tanleach1001) occupied Fado with 2 troops.",
+    "timestamp": "2016-01-18T22:12:08.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Du (tanleach1001) was fortified from Vabon (tanleach1001) with 1 troop.",
+    "timestamp": "2016-01-18T22:12:19.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-18T22:12:19.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-18T22:12:19.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-18T23:18:41.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard received 3 troops for 5 territories.",
+    "timestamp": "2016-01-18T23:18:41.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Sart (gcochard) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-01-18T23:18:53.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Sart (gcochard) attacked Elitt (ryanbmilbourne) conquering it, killing 2, losing 3.",
+    "timestamp": "2016-01-18T23:19:03.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Sart (gcochard) occupied Elitt with 1 troop.",
+    "timestamp": "2016-01-18T23:19:08.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Sache (gcochard) was fortified from Sart (gcochard) with 3 troops.",
+    "timestamp": "2016-01-18T23:19:28.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-18T23:19:28.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-18T23:19:28.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Round 5 started.",
+    "timestamp": "2016-01-18T23:19:28.000Z",
+    "player": "unknown",
+    "round": 5
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-19T01:13:22.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "jobratt received 4 troops for 12 territories.",
+    "timestamp": "2016-01-19T01:13:22.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "jobratt received 2 troops for holding C Region.",
+    "timestamp": "2016-01-19T01:13:22.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Setha (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-01-19T01:13:46.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Onbri (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-01-19T01:13:50.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Setha (jobratt) attacked Sucana (Neutral) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-19T01:14:01.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Setha (jobratt) occupied Sucana with 7 troops.",
+    "timestamp": "2016-01-19T01:14:07.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Sucana (jobratt) attacked Sulodoop (ryanbmilbourne) conquering it, killing 2, losing 1.",
+    "timestamp": "2016-01-19T01:14:14.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Sucana (jobratt) occupied Sulodoop with 5 troops.",
+    "timestamp": "2016-01-19T01:14:17.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Clutch (jobratt) was fortified from Co (jobratt) with 2 troops.",
+    "timestamp": "2016-01-19T01:14:51.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-19T01:14:51.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-19T01:14:51.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-19T06:27:12.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 8 territories.",
+    "timestamp": "2016-01-19T06:27:12.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne received 2 troops on Don",
+    "timestamp": "2016-01-19T06:27:17.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Vua (ryanbmilbourne) was reinforced by ryanbmilbourne with 2 troops.",
+    "timestamp": "2016-01-19T06:27:41.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Wa (ryanbmilbourne) was reinforced by ryanbmilbourne with 5 troops.",
+    "timestamp": "2016-01-19T06:27:45.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Wa (ryanbmilbourne) attacked Walkon (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T06:27:50.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Wa (ryanbmilbourne) occupied Walkon with 5 troops.",
+    "timestamp": "2016-01-19T06:27:52.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Vua (ryanbmilbourne) attacked Welk (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T06:27:57.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Vua (ryanbmilbourne) occupied Welk with 4 troops.",
+    "timestamp": "2016-01-19T06:27:59.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Walkon (ryanbmilbourne) attacked So (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T06:28:30.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Walkon (ryanbmilbourne) occupied So with 1 troop.",
+    "timestamp": "2016-01-19T06:28:36.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-19T06:29:24.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-19T06:29:24.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-19T17:02:20.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier received 3 troops for 10 territories.",
+    "timestamp": "2016-01-19T17:02:20.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Ottel (mmacfreier) was reinforced by mmacfreier with 9 troops.",
+    "timestamp": "2016-01-19T17:02:36.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Ottel (mmacfreier) attacked Onbri (jobratt) conquering it, killing 4, losing 2.",
+    "timestamp": "2016-01-19T17:02:41.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Ottel (mmacfreier) occupied Onbri with 10 troops.",
+    "timestamp": "2016-01-19T17:02:42.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Off (mmacfreier) was fortified from Onbri (mmacfreier) with 4 troops.",
+    "timestamp": "2016-01-19T17:03:09.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-19T17:03:09.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-19T17:03:09.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-19T17:40:24.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received 4 troops for 12 territories.",
+    "timestamp": "2016-01-19T17:40:24.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received 2 troops for holding T Region.",
+    "timestamp": "2016-01-19T17:40:24.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Traln (kwren) was reinforced by kwren with 5 troops.",
+    "timestamp": "2016-01-19T17:40:35.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Tuloe (kwren) was reinforced by kwren with 9 troops.",
+    "timestamp": "2016-01-19T17:40:51.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Tuloe (kwren) attacked Vahn (mmacfreier) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-19T17:40:56.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Tuloe (kwren) occupied Vahn with 13 troops.",
+    "timestamp": "2016-01-19T17:40:59.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Vahn (kwren) attacked Vabon (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T17:41:03.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Vahn (kwren) occupied Vabon with 12 troops.",
+    "timestamp": "2016-01-19T17:41:05.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Vabon (kwren) attacked Dune (tanleach1001) conquering it, killing 2, losing 0.",
+    "timestamp": "2016-01-19T17:41:08.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Vabon (kwren) occupied Dune with 1 troop.",
+    "timestamp": "2016-01-19T17:41:13.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Tuloe (kwren) was fortified from Vabon (kwren) with 10 troops.",
+    "timestamp": "2016-01-19T17:41:22.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-19T17:41:22.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-19T17:41:22.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-19T18:04:12.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 8 territories.",
+    "timestamp": "2016-01-19T18:04:12.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Du (tanleach1001) was reinforced by tanleach1001 with 11 troops.",
+    "timestamp": "2016-01-19T18:04:28.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Du (tanleach1001) attacked Don (ryanbmilbourne) conquering it, killing 8, losing 4.",
+    "timestamp": "2016-01-19T18:04:41.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Du (tanleach1001) occupied Don with 1 troop.",
+    "timestamp": "2016-01-19T18:05:05.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Du (tanleach1001) attacked Dune (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-19T18:05:16.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Du (tanleach1001) occupied Dune with 4 troops.",
+    "timestamp": "2016-01-19T18:05:29.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Spork (tanleach1001) attacked Setha (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-19T18:05:39.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Spork (tanleach1001) occupied Setha with 3 troops.",
+    "timestamp": "2016-01-19T18:06:52.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Fado (tanleach1001) was fortified from Setha (tanleach1001) with 2 troops.",
+    "timestamp": "2016-01-19T18:14:04.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-19T18:14:05.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-19T18:14:05.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-19T18:23:07.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "gcochard received 3 troops for 5 territories.",
+    "timestamp": "2016-01-19T18:23:07.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Sache (gcochard) was reinforced by gcochard with 11 troops.",
+    "timestamp": "2016-01-19T18:23:31.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Sache (gcochard) attacked Sulodoop (jobratt) conquering it, killing 5, losing 5.",
+    "timestamp": "2016-01-19T18:23:41.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Sache (gcochard) occupied Sulodoop with 9 troops.",
+    "timestamp": "2016-01-19T18:23:48.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Sulodoop (gcochard) attacked Sucana (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T18:23:51.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Sulodoop (gcochard) occupied Sucana with 1 troop.",
+    "timestamp": "2016-01-19T18:23:56.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Sulodoop (gcochard) attacked Spork (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T18:24:00.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Sulodoop (gcochard) occupied Spork with 5 troops.",
+    "timestamp": "2016-01-19T18:24:05.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Spork (gcochard) attacked Spot (jobratt) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-19T18:24:33.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Spork (gcochard) occupied Spot with 1 troop.",
+    "timestamp": "2016-01-19T18:24:37.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Sulodoop (gcochard) was fortified from Spork (gcochard) with 2 troops.",
+    "timestamp": "2016-01-19T18:25:13.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-19T18:25:13.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-19T18:25:13.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Round 6 started.",
+    "timestamp": "2016-01-19T18:25:13.000Z",
+    "player": "unknown",
+    "round": 6
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-19T18:30:52.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "jobratt received 3 troops for 8 territories.",
+    "timestamp": "2016-01-19T18:30:52.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "jobratt received 2 troops for holding C Region.",
+    "timestamp": "2016-01-19T18:30:52.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Co (jobratt) was reinforced by jobratt with 13 troops.",
+    "timestamp": "2016-01-19T18:41:36.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Co (jobratt) attacked Sulodoop (gcochard) conquering it, killing 5, losing 2.",
+    "timestamp": "2016-01-19T18:41:48.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Co (jobratt) occupied Sulodoop with 12 troops.",
+    "timestamp": "2016-01-19T18:41:54.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Sulodoop (jobratt) attacked Sache (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T18:42:20.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Sulodoop (jobratt) occupied Sache with 1 troop.",
+    "timestamp": "2016-01-19T18:42:32.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Sulodoop (jobratt) attacked Sucana (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T18:45:06.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Sulodoop (jobratt) occupied Sucana with 1 troop.",
+    "timestamp": "2016-01-19T18:45:15.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Sulodoop (jobratt) attacked Spork (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T18:45:17.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Sulodoop (jobratt) occupied Spork with 1 troop.",
+    "timestamp": "2016-01-19T18:45:20.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Clutch (jobratt) was fortified from Sulodoop (jobratt) with 2 troops.",
+    "timestamp": "2016-01-19T18:45:32.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-19T18:45:32.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-19T18:45:32.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-19T19:34:14.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 10 territories.",
+    "timestamp": "2016-01-19T19:34:14.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Walkon (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-19T19:35:02.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Walkon (ryanbmilbourne) attacked Ohma (mmacfreier) conquering it, killing 2, losing 0.",
+    "timestamp": "2016-01-19T19:35:19.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Walkon (ryanbmilbourne) occupied Ohma with 1 troop.",
+    "timestamp": "2016-01-19T19:35:26.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Walkon (ryanbmilbourne) attacked Woxan (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T19:35:30.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Walkon (ryanbmilbourne) occupied Woxan with 1 troop.",
+    "timestamp": "2016-01-19T19:35:40.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Walkon (ryanbmilbourne) was fortified from Eglo (ryanbmilbourne) with 1 troop.",
+    "timestamp": "2016-01-19T19:35:52.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-19T19:35:52.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-19T19:35:52.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-19T19:36:30.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier received 3 troops for 9 territories.",
+    "timestamp": "2016-01-19T19:36:30.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Off (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-19T19:36:36.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Off (mmacfreier) attacked Ohma (ryanbmilbourne) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-19T19:36:42.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Off (mmacfreier) occupied Ohma with 5 troops.",
+    "timestamp": "2016-01-19T19:36:45.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-19T19:36:55.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-19T19:36:55.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-19T19:37:53.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 4 troops for 13 territories.",
+    "timestamp": "2016-01-19T19:37:53.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 2 troops for holding T Region.",
+    "timestamp": "2016-01-19T19:37:53.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Traln (kwren) was reinforced by kwren with 1 troop.",
+    "timestamp": "2016-01-19T19:38:39.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Vahn (kwren) was reinforced by kwren with 5 troops.",
+    "timestamp": "2016-01-19T19:38:42.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Vahn (kwren) attacked Vy (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T19:38:46.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Vahn (kwren) occupied Vy with 1 troop.",
+    "timestamp": "2016-01-19T19:38:51.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Vahn (kwren) attacked Vhown (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T19:38:53.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Vahn (kwren) occupied Vhown with 1 troop.",
+    "timestamp": "2016-01-19T19:38:59.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Vahn (kwren) was fortified from Tuloe (kwren) with 10 troops.",
+    "timestamp": "2016-01-19T19:39:06.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-19T19:39:07.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-19T19:39:07.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-19T19:39:33.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 8 territories.",
+    "timestamp": "2016-01-19T19:39:33.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 received 2 troops for holding D Region.",
+    "timestamp": "2016-01-19T19:39:33.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Setha (tanleach1001) was reinforced by tanleach1001 with 2 troops.",
+    "timestamp": "2016-01-19T19:40:41.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Fado (tanleach1001) was reinforced by tanleach1001 with 3 troops.",
+    "timestamp": "2016-01-19T19:40:44.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Fado (tanleach1001) attacked Flinn (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-19T19:40:48.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Fado (tanleach1001) occupied Flinn with 1 troop.",
+    "timestamp": "2016-01-19T19:40:59.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Setha (tanleach1001) attacked Off (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T19:41:03.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Setha (tanleach1001) occupied Off with 1 troop.",
+    "timestamp": "2016-01-19T19:41:08.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-19T19:46:43.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-19T19:46:43.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-19T20:47:49.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "gcochard received 3 troops for 5 territories.",
+    "timestamp": "2016-01-19T20:47:49.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Sart (gcochard) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-01-19T20:47:57.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Sart (gcochard) attacked Sache (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T20:48:00.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Sart (gcochard) occupied Sache with 1 troop.",
+    "timestamp": "2016-01-19T20:48:05.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Spot (gcochard) was fortified from Sart (gcochard) with 2 troops.",
+    "timestamp": "2016-01-19T20:48:15.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-19T20:48:15.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-19T20:48:15.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Round 7 started.",
+    "timestamp": "2016-01-19T20:48:15.000Z",
+    "player": "unknown",
+    "round": 7
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-19T21:00:25.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "jobratt received 3 troops for 11 territories.",
+    "timestamp": "2016-01-19T21:00:26.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "jobratt received 2 troops for holding C Region.",
+    "timestamp": "2016-01-19T21:00:26.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Ewenn (jobratt) was reinforced by jobratt with 5 troops.",
+    "timestamp": "2016-01-19T21:00:33.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Spork (jobratt) was reinforced by jobratt with 8 troops.",
+    "timestamp": "2016-01-19T21:00:43.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Ewenn (jobratt) attacked Engrash (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T21:00:50.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Ewenn (jobratt) occupied Engrash with 7 troops.",
+    "timestamp": "2016-01-19T21:00:54.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Engrash (jobratt) attacked Woxan (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T21:00:57.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Engrash (jobratt) occupied Woxan with 1 troop.",
+    "timestamp": "2016-01-19T21:01:10.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Spork (jobratt) attacked Spot (gcochard) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-19T21:02:31.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Spork (jobratt) occupied Spot with 1 troop.",
+    "timestamp": "2016-01-19T21:02:42.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Sulodoop (jobratt) attacked Sache (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T21:02:44.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Sulodoop (jobratt) occupied Sache with 6 troops.",
+    "timestamp": "2016-01-19T21:03:29.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Sache (jobratt) attacked Sart (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T21:03:31.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Sache (jobratt) occupied Sart with 5 troops.",
+    "timestamp": "2016-01-19T21:03:33.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Sart (jobratt) attacked Elitt (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T21:03:36.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Sart (jobratt) occupied Elitt with 4 troops.",
+    "timestamp": "2016-01-19T21:03:38.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Engrash (jobratt) attacked Eong (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T21:04:22.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Engrash (jobratt) occupied Eong with 5 troops.",
+    "timestamp": "2016-01-19T21:04:26.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Sucana (jobratt) was fortified from Eong (jobratt) with 4 troops.",
+    "timestamp": "2016-01-19T21:05:29.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-19T21:05:29.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-19T21:05:29.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-19T21:55:57.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 9 territories.",
+    "timestamp": "2016-01-19T21:55:57.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Walkon (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-19T21:56:14.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Walkon (ryanbmilbourne) attacked Ohma (mmacfreier) conquering it, killing 5, losing 3.",
+    "timestamp": "2016-01-19T21:56:22.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Walkon (ryanbmilbourne) occupied Ohma with 1 troop.",
+    "timestamp": "2016-01-19T21:56:42.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Walkon (ryanbmilbourne) attacked Woxan (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-19T21:56:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Walkon (ryanbmilbourne) occupied Woxan with 1 troop.",
+    "timestamp": "2016-01-19T21:57:00.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Walkon (ryanbmilbourne) was fortified from Welk (ryanbmilbourne) with 1 troop.",
+    "timestamp": "2016-01-19T21:57:18.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-19T21:57:18.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-19T21:57:18.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-19T22:01:39.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier received 3 troops for 8 territories.",
+    "timestamp": "2016-01-19T22:01:39.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Ord (mmacfreier) was reinforced by mmacfreier with 11 troops.",
+    "timestamp": "2016-01-19T22:01:46.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Ord (mmacfreier) attacked Off (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T22:01:49.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Ord (mmacfreier) occupied Off with 11 troops.",
+    "timestamp": "2016-01-19T22:01:51.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Off (mmacfreier) attacked Ohma (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T22:01:53.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Off (mmacfreier) occupied Ohma with 10 troops.",
+    "timestamp": "2016-01-19T22:01:55.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Ohma (mmacfreier) attacked Walkon (ryanbmilbourne) conquering it, killing 4, losing 4.",
+    "timestamp": "2016-01-19T22:02:03.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Ohma (mmacfreier) occupied Walkon with 5 troops.",
+    "timestamp": "2016-01-19T22:02:05.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Walkon (mmacfreier) attacked Woxan (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T22:02:09.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Walkon (mmacfreier) occupied Woxan with 1 troop.",
+    "timestamp": "2016-01-19T22:02:12.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Walkon (mmacfreier) attacked Wa (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T22:02:15.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Walkon (mmacfreier) occupied Wa with 3 troops.",
+    "timestamp": "2016-01-19T22:02:16.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Wa (mmacfreier) attacked Wun (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-19T22:02:21.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Wa (mmacfreier) was fortified from Onbri (mmacfreier) with 5 troops.",
+    "timestamp": "2016-01-19T22:02:29.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-19T22:02:30.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-19T22:02:30.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-19T22:02:35.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren received 4 troops for 13 territories.",
+    "timestamp": "2016-01-19T22:02:35.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren received 2 troops for holding T Region.",
+    "timestamp": "2016-01-19T22:02:35.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Traln (kwren) was reinforced by kwren with 1 troop.",
+    "timestamp": "2016-01-19T22:02:46.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Vreen (kwren) was reinforced by kwren with 5 troops.",
+    "timestamp": "2016-01-19T22:02:48.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Traln (kwren) attacked Echo (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T22:02:52.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Traln (kwren) occupied Echo with 1 troop.",
+    "timestamp": "2016-01-19T22:03:00.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Vreen (kwren) attacked Du (tanleach1001) conquering it, killing 4, losing 2.",
+    "timestamp": "2016-01-19T22:03:09.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Vreen (kwren) occupied Du with 4 troops.",
+    "timestamp": "2016-01-19T22:03:13.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Vabon (kwren) was fortified from Vahn (kwren) with 6 troops.",
+    "timestamp": "2016-01-19T22:03:53.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-19T22:03:53.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-19T22:03:53.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-19T22:05:59.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 8 territories.",
+    "timestamp": "2016-01-19T22:06:00.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Doustmon (tanleach1001) was reinforced by tanleach1001 with 6 troops.",
+    "timestamp": "2016-01-19T22:06:34.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Dune (tanleach1001) was reinforced by tanleach1001 with 2 troops.",
+    "timestamp": "2016-01-19T22:07:00.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Flinn (tanleach1001) was reinforced by tanleach1001 with 3 troops.",
+    "timestamp": "2016-01-19T22:07:08.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Flinn (tanleach1001) attacked Fulcon (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T22:07:12.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Flinn (tanleach1001) occupied Fulcon with 1 troop.",
+    "timestamp": "2016-01-19T22:07:15.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Flinn (tanleach1001) attacked Finch (gcochard) killing 0, losing 2.",
+    "timestamp": "2016-01-19T22:07:19.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Setha (tanleach1001) attacked Off (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T22:07:27.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Doustmon (tanleach1001) attacked Du (kwren) killing 2, losing 8.",
+    "timestamp": "2016-01-19T22:07:37.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-19T22:08:06.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-19T22:08:06.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-19T22:09:01.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "gcochard received 3 troops for 1 territory.",
+    "timestamp": "2016-01-19T22:09:01.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Finch (gcochard) was reinforced by gcochard with 11 troops.",
+    "timestamp": "2016-01-19T22:09:13.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Finch (gcochard) attacked Onbri (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T22:09:20.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Finch (gcochard) occupied Onbri with 1 troop.",
+    "timestamp": "2016-01-19T22:09:23.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Finch (gcochard) attacked Flinn (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T22:09:28.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Finch (gcochard) occupied Flinn with 10 troops.",
+    "timestamp": "2016-01-19T22:09:30.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Flinn (gcochard) attacked Fado (tanleach1001) conquering it, killing 5, losing 0.",
+    "timestamp": "2016-01-19T22:09:36.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Flinn (gcochard) occupied Fado with 5 troops.",
+    "timestamp": "2016-01-19T22:09:43.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Flinn (gcochard) attacked Fulcon (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T22:09:48.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Flinn (gcochard) occupied Fulcon with 1 troop.",
+    "timestamp": "2016-01-19T22:09:53.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Fado (gcochard) attacked Fud (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T22:09:56.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Fado (gcochard) occupied Fud with 1 troop.",
+    "timestamp": "2016-01-19T22:10:00.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Finch (gcochard) was fortified from Flinn (gcochard) with 3 troops.",
+    "timestamp": "2016-01-19T22:10:04.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-19T22:10:05.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-19T22:10:05.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Round 8 started.",
+    "timestamp": "2016-01-19T22:10:05.000Z",
+    "player": "unknown",
+    "round": 8
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-19T22:52:53.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "jobratt received 5 troops for 17 territories.",
+    "timestamp": "2016-01-19T22:52:53.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "jobratt received 2 troops for holding C Region.",
+    "timestamp": "2016-01-19T22:52:53.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Elitt (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-01-19T22:53:08.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Sucana (jobratt) was reinforced by jobratt with 4 troops.",
+    "timestamp": "2016-01-19T22:53:15.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Sucana (jobratt) attacked Setha (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T22:53:18.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Sucana (jobratt) occupied Setha with 8 troops.",
+    "timestamp": "2016-01-19T22:53:21.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Spork (jobratt) attacked So (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T22:53:26.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Spork (jobratt) occupied So with 7 troops.",
+    "timestamp": "2016-01-19T22:53:29.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Clutch (jobratt) attacked Fulcon (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T22:53:53.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Clutch (jobratt) occupied Fulcon with 1 troop.",
+    "timestamp": "2016-01-19T22:53:57.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Elitt (jobratt) was fortified from Setha (jobratt) with 2 troops.",
+    "timestamp": "2016-01-19T22:54:40.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-19T22:54:41.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-19T22:54:41.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-19T23:11:17.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 5 territories.",
+    "timestamp": "2016-01-19T23:11:17.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "ryanbmilbourne received 2 troops on Erdus",
+    "timestamp": "2016-01-19T23:11:20.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Welk (ryanbmilbourne) was reinforced by ryanbmilbourne with 2 troops.",
+    "timestamp": "2016-01-19T23:11:51.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) was reinforced by ryanbmilbourne with 9 troops.",
+    "timestamp": "2016-01-19T23:12:01.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Welk (ryanbmilbourne) attacked Engrash (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T23:12:06.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Welk (ryanbmilbourne) occupied Engrash with 1 troop.",
+    "timestamp": "2016-01-19T23:12:15.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) was fortified from Welk (ryanbmilbourne) with 3 troops.",
+    "timestamp": "2016-01-19T23:12:22.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-19T23:12:22.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-19T23:12:22.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-19T23:18:14.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier received 4 troops for 12 territories.",
+    "timestamp": "2016-01-19T23:18:14.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Ohma (mmacfreier) was reinforced by mmacfreier with 4 troops.",
+    "timestamp": "2016-01-19T23:18:24.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Ohma (mmacfreier) attacked Off (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T23:18:27.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Ohma (mmacfreier) occupied Off with 4 troops.",
+    "timestamp": "2016-01-19T23:18:31.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Ohma (mmacfreier) was fortified from Wa (mmacfreier) with 5 troops.",
+    "timestamp": "2016-01-19T23:18:36.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-19T23:18:36.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-19T23:18:36.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-19T23:18:53.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received 4 troops for 14 territories.",
+    "timestamp": "2016-01-19T23:18:53.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received 2 troops for holding T Region.",
+    "timestamp": "2016-01-19T23:18:53.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Du (kwren) was reinforced by kwren with 6 troops.",
+    "timestamp": "2016-01-19T23:18:55.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Du (kwren) attacked Dune (tanleach1001) killing 4, losing 4.",
+    "timestamp": "2016-01-19T23:19:05.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Du (kwren) attacked Dri (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T23:19:09.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Du (kwren) occupied Dri with 1 troop.",
+    "timestamp": "2016-01-19T23:19:16.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Vabon (kwren) attacked Dune (tanleach1001) conquering it, killing 2, losing 2.",
+    "timestamp": "2016-01-19T23:19:24.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Vabon (kwren) occupied Dune with 4 troops.",
+    "timestamp": "2016-01-19T23:19:26.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Dune (kwren) attacked Doustmon (tanleach1001) killing 0, losing 3.",
+    "timestamp": "2016-01-19T23:19:32.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Du (kwren) attacked Don (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T23:19:36.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Du (kwren) occupied Don with 2 troops.",
+    "timestamp": "2016-01-19T23:19:38.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Don (kwren) attacked Doustmon (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T23:19:41.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "tanleach1001 was defeated by kwren.",
+    "timestamp": "2016-01-19T23:19:41.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "kwren received 2 troops on Dune",
+    "timestamp": "2016-01-19T23:19:47.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Traln (kwren) was reinforced by kwren with 4 troops.",
+    "timestamp": "2016-01-19T23:19:56.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Vhown (kwren) was reinforced by kwren with 4 troops.",
+    "timestamp": "2016-01-19T23:20:21.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Vhown (kwren) was fortified from Vahn (kwren) with 7 troops.",
+    "timestamp": "2016-01-19T23:20:28.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-19T23:20:28.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-19T23:20:28.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-19T23:27:49.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "gcochard received 3 troops for 5 territories.",
+    "timestamp": "2016-01-19T23:27:49.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "Flinn (gcochard) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-01-19T23:27:53.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "Flinn (gcochard) attacked Fulcon (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-19T23:27:58.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "Flinn (gcochard) occupied Fulcon with 2 troops.",
+    "timestamp": "2016-01-19T23:27:59.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "Fulcon (gcochard) was fortified from Finch (gcochard) with 3 troops.",
+    "timestamp": "2016-01-19T23:28:16.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-19T23:28:16.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-19T23:28:16.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "Round 9 started.",
+    "timestamp": "2016-01-19T23:28:16.000Z",
+    "player": "unknown",
+    "round": 9
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-19T23:33:54.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "jobratt received 6 troops for 18 territories.",
+    "timestamp": "2016-01-19T23:33:54.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "jobratt received 5 troops for holding S Region.",
+    "timestamp": "2016-01-19T23:33:54.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "jobratt received 2 troops for holding C Region.",
+    "timestamp": "2016-01-19T23:33:54.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Setha (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-01-19T23:34:19.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Clutch (jobratt) was reinforced by jobratt with 10 troops.",
+    "timestamp": "2016-01-19T23:34:39.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Clutch (jobratt) attacked Fulcon (gcochard) conquering it, killing 5, losing 2.",
+    "timestamp": "2016-01-19T23:34:44.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Clutch (jobratt) occupied Fulcon with 13 troops.",
+    "timestamp": "2016-01-19T23:34:47.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Fulcon (jobratt) attacked Flinn (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T23:34:58.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Fulcon (jobratt) occupied Flinn with 12 troops.",
+    "timestamp": "2016-01-19T23:35:02.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Flinn (jobratt) attacked Fado (gcochard) conquering it, killing 4, losing 4.",
+    "timestamp": "2016-01-19T23:35:13.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Flinn (jobratt) occupied Fado with 7 troops.",
+    "timestamp": "2016-01-19T23:35:23.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Fado (jobratt) attacked Onbri (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T23:35:32.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Fado (jobratt) occupied Onbri with 6 troops.",
+    "timestamp": "2016-01-19T23:35:38.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Onbri (jobratt) attacked Finch (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T23:35:40.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Onbri (jobratt) occupied Finch with 1 troop.",
+    "timestamp": "2016-01-19T23:35:50.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Setha (jobratt) attacked Fud (gcochard) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-19T23:35:55.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "gcochard was defeated by jobratt.",
+    "timestamp": "2016-01-19T23:35:55.000Z",
+    "player": "gcochard",
+    "round": 9
+  },
+  {
+    "message": "Setha (jobratt) occupied Fud with 1 troop.",
+    "timestamp": "2016-01-19T23:35:59.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Elitt (jobratt) attacked Eglo (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-19T23:36:14.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Elitt (jobratt) occupied Eglo with 1 troop.",
+    "timestamp": "2016-01-19T23:36:35.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Elitt (jobratt) was fortified from Onbri (jobratt) with 4 troops.",
+    "timestamp": "2016-01-19T23:38:21.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-19T23:38:21.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-19T23:38:21.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-19T23:55:06.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 5 territories.",
+    "timestamp": "2016-01-19T23:55:06.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-19T23:55:20.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) attacked Eglo (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-19T23:55:28.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) occupied Eglo with 1 troop.",
+    "timestamp": "2016-01-19T23:55:41.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-19T23:55:46.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-19T23:55:46.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-19T23:59:27.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier received 4 troops for 13 territories.",
+    "timestamp": "2016-01-19T23:59:27.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Oshgrind (mmacfreier) was reinforced by mmacfreier with 4 troops.",
+    "timestamp": "2016-01-19T23:59:32.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Oshgrind (mmacfreier) attacked Onbri (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-19T23:59:37.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Oshgrind (mmacfreier) occupied Onbri with 3 troops.",
+    "timestamp": "2016-01-19T23:59:39.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-19T23:59:43.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-19T23:59:43.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-20T00:08:43.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 6 troops for 18 territories.",
+    "timestamp": "2016-01-20T00:08:43.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 2 troops for holding T Region.",
+    "timestamp": "2016-01-20T00:08:43.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 2 troops for holding D Region.",
+    "timestamp": "2016-01-20T00:08:43.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 2 troops on Doustmon",
+    "timestamp": "2016-01-20T00:08:46.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Vhown (kwren) was reinforced by kwren with 18 troops.",
+    "timestamp": "2016-01-20T00:08:48.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Vhown (kwren) attacked Vupano (jobratt) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-20T00:08:51.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Vhown (kwren) occupied Vupano with 29 troops.",
+    "timestamp": "2016-01-20T00:08:59.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Vupano (kwren) attacked Vebn (Neutral) conquering it, killing 3, losing 3.",
+    "timestamp": "2016-01-20T00:09:07.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Vupano (kwren) occupied Vebn with 1 troop.",
+    "timestamp": "2016-01-20T00:09:12.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Vupano (kwren) attacked Vim (Neutral) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-01-20T00:09:16.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Vupano (kwren) occupied Vim with 1 troop.",
+    "timestamp": "2016-01-20T00:09:20.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Vupano (kwren) attacked Vua (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T00:09:23.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Vupano (kwren) occupied Vua with 21 troops.",
+    "timestamp": "2016-01-20T00:09:26.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Vua (kwren) attacked Welk (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T00:09:32.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Vua (kwren) occupied Welk with 1 troop.",
+    "timestamp": "2016-01-20T00:09:38.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Traln (kwren) was fortified from Doustmon (kwren) with 2 troops.",
+    "timestamp": "2016-01-20T00:09:52.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-20T00:09:52.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-20T00:09:52.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Round 10 started.",
+    "timestamp": "2016-01-20T00:09:52.000Z",
+    "player": "unknown",
+    "round": 10
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-20T01:22:04.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "jobratt received 7 troops for 22 territories.",
+    "timestamp": "2016-01-20T01:22:04.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "jobratt received 5 troops for holding S Region.",
+    "timestamp": "2016-01-20T01:22:04.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "jobratt received 2 troops for holding C Region.",
+    "timestamp": "2016-01-20T01:22:04.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "jobratt received 3 troops for holding F Region.",
+    "timestamp": "2016-01-20T01:22:04.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Setha (jobratt) was reinforced by jobratt with 10 troops.",
+    "timestamp": "2016-01-20T01:22:21.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "So (jobratt) was reinforced by jobratt with 10 troops.",
+    "timestamp": "2016-01-20T01:22:37.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Elitt (jobratt) was reinforced by jobratt with 5 troops.",
+    "timestamp": "2016-01-20T01:22:51.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Elitt (jobratt) attacked Eglo (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T01:23:03.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Elitt (jobratt) occupied Eglo with 1 troop.",
+    "timestamp": "2016-01-20T01:23:55.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "So (jobratt) attacked Walkon (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T01:24:04.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "So (jobratt) occupied Walkon with 1 troop.",
+    "timestamp": "2016-01-20T01:24:07.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-20T01:24:15.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-20T01:24:15.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-20T01:25:41.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 3 territories.",
+    "timestamp": "2016-01-20T01:25:41.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-20T01:25:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) attacked Enbrum (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T01:25:53.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) occupied Enbrum with 1 troop.",
+    "timestamp": "2016-01-20T01:26:00.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-20T01:26:11.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-20T01:26:11.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-20T17:21:50.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received 4 troops for 13 territories.",
+    "timestamp": "2016-01-20T17:21:50.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding O Region.",
+    "timestamp": "2016-01-20T17:21:50.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Ohma (mmacfreier) was reinforced by mmacfreier with 16 troops.",
+    "timestamp": "2016-01-20T17:22:23.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Ohma (mmacfreier) attacked So (jobratt) conquering it, killing 16, losing 9.",
+    "timestamp": "2016-01-20T17:22:38.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Ohma (mmacfreier) occupied So with 1 troop.",
+    "timestamp": "2016-01-20T17:22:56.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Off (mmacfreier) was fortified from Ohma (mmacfreier) with 4 troops.",
+    "timestamp": "2016-01-20T17:23:04.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-20T17:23:04.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-20T17:23:04.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-20T17:24:59.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "kwren received 7 troops for 22 territories.",
+    "timestamp": "2016-01-20T17:24:59.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "kwren received 2 troops for holding T Region.",
+    "timestamp": "2016-01-20T17:24:59.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "kwren received 5 troops for holding V Region.",
+    "timestamp": "2016-01-20T17:24:59.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "kwren received 2 troops for holding D Region.",
+    "timestamp": "2016-01-20T17:24:59.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Vua (kwren) was reinforced by kwren with 6 troops.",
+    "timestamp": "2016-01-20T17:25:05.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Welk (kwren) was reinforced by kwren with 10 troops.",
+    "timestamp": "2016-01-20T17:25:07.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Welk (kwren) attacked Whist (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T17:25:11.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Welk (kwren) occupied Whist with 1 troop.",
+    "timestamp": "2016-01-20T17:25:18.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Welk (kwren) attacked Engrash (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T17:25:22.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Welk (kwren) occupied Engrash with 9 troops.",
+    "timestamp": "2016-01-20T17:25:24.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Engrash (kwren) attacked Woxan (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T17:25:27.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Engrash (kwren) occupied Woxan with 8 troops.",
+    "timestamp": "2016-01-20T17:25:29.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Woxan (kwren) attacked Walkon (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T17:25:31.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Woxan (kwren) occupied Walkon with 7 troops.",
+    "timestamp": "2016-01-20T17:25:40.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Walkon (kwren) attacked Wa (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T17:25:43.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Walkon (kwren) occupied Wa with 6 troops.",
+    "timestamp": "2016-01-20T17:25:44.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Wa (kwren) attacked Wun (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T17:25:47.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Wa (kwren) occupied Wun with 5 troops.",
+    "timestamp": "2016-01-20T17:25:49.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Traln (kwren) was fortified from Wun (kwren) with 4 troops.",
+    "timestamp": "2016-01-20T17:26:04.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-20T17:26:04.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-20T17:26:04.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Round 11 started.",
+    "timestamp": "2016-01-20T17:26:04.000Z",
+    "player": "unknown",
+    "round": 11
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-20T17:28:48.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "jobratt received 7 troops for 22 territories.",
+    "timestamp": "2016-01-20T17:28:48.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "jobratt received 2 troops for holding C Region.",
+    "timestamp": "2016-01-20T17:28:48.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "jobratt received 3 troops for holding F Region.",
+    "timestamp": "2016-01-20T17:28:48.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Elitt (jobratt) was reinforced by jobratt with 8 troops.",
+    "timestamp": "2016-01-20T17:29:03.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Eong (jobratt) was reinforced by jobratt with 4 troops.",
+    "timestamp": "2016-01-20T17:29:25.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Eong (jobratt) attacked Woxan (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T17:29:32.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Eong (jobratt) occupied Woxan with 1 troop.",
+    "timestamp": "2016-01-20T17:29:47.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Setha (jobratt) attacked So (mmacfreier) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-01-20T17:29:56.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Setha (jobratt) occupied So with 9 troops.",
+    "timestamp": "2016-01-20T17:30:12.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Setha (jobratt) was fortified from Eong (jobratt) with 2 troops.",
+    "timestamp": "2016-01-20T17:30:44.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-20T17:30:44.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-20T17:30:44.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-20T17:31:06.000Z",
+    "player": "ryanbmilbourne",
+    "round": 11
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 2 territories.",
+    "timestamp": "2016-01-20T17:31:06.000Z",
+    "player": "ryanbmilbourne",
+    "round": 11
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) was reinforced by ryanbmilbourne with 11 troops.",
+    "timestamp": "2016-01-20T17:31:17.000Z",
+    "player": "ryanbmilbourne",
+    "round": 11
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) attacked Eglo (jobratt) killing 0, losing 8.",
+    "timestamp": "2016-01-20T17:31:33.000Z",
+    "player": "ryanbmilbourne",
+    "round": 11
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-20T17:31:37.000Z",
+    "player": "ryanbmilbourne",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-20T17:31:51.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 3 troops for 10 territories.",
+    "timestamp": "2016-01-20T17:31:51.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding O Region.",
+    "timestamp": "2016-01-20T17:31:51.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Emb (mmacfreier) was reinforced by mmacfreier with 7 troops.",
+    "timestamp": "2016-01-20T17:32:01.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Emb (mmacfreier) attacked Enbrum (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T17:32:04.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Emb (mmacfreier) occupied Enbrum with 1 troop.",
+    "timestamp": "2016-01-20T17:32:23.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-20T17:32:30.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-20T17:32:30.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-20T17:33:22.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "kwren received 9 troops for 27 territories.",
+    "timestamp": "2016-01-20T17:33:22.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "kwren received 2 troops for holding T Region.",
+    "timestamp": "2016-01-20T17:33:22.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "kwren received 5 troops for holding V Region.",
+    "timestamp": "2016-01-20T17:33:22.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "kwren received 2 troops for holding D Region.",
+    "timestamp": "2016-01-20T17:33:22.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Walkon (kwren) was reinforced by kwren with 18 troops.",
+    "timestamp": "2016-01-20T17:33:28.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Walkon (kwren) attacked Ohma (mmacfreier) conquering it, killing 8, losing 9.",
+    "timestamp": "2016-01-20T17:33:39.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Walkon (kwren) occupied Ohma with 9 troops.",
+    "timestamp": "2016-01-20T17:33:43.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Ohma (kwren) attacked So (jobratt) killing 4, losing 6.",
+    "timestamp": "2016-01-20T17:33:50.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Traln (kwren) was fortified from Ohma (kwren) with 2 troops.",
+    "timestamp": "2016-01-20T17:34:02.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-20T17:34:02.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-20T17:34:02.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Round 12 started.",
+    "timestamp": "2016-01-20T17:34:02.000Z",
+    "player": "unknown",
+    "round": 12
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-20T18:00:11.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "jobratt received 8 troops for 24 territories.",
+    "timestamp": "2016-01-20T18:00:11.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "jobratt received 5 troops for holding S Region.",
+    "timestamp": "2016-01-20T18:00:11.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "jobratt received 2 troops for holding C Region.",
+    "timestamp": "2016-01-20T18:00:11.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "jobratt received 3 troops for holding F Region.",
+    "timestamp": "2016-01-20T18:00:11.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "jobratt received 2 troops on Setha",
+    "timestamp": "2016-01-20T18:00:14.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "So (jobratt) was reinforced by jobratt with 9 troops.",
+    "timestamp": "2016-01-20T18:00:25.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Setha (jobratt) was reinforced by jobratt with 8 troops.",
+    "timestamp": "2016-01-20T18:00:36.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Elitt (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-01-20T18:00:45.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Ewenn (jobratt) was reinforced by jobratt with 6 troops.",
+    "timestamp": "2016-01-20T18:01:08.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Ewenn (jobratt) attacked Engrash (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-20T18:01:16.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Ewenn (jobratt) occupied Engrash with 4 troops.",
+    "timestamp": "2016-01-20T18:01:17.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Engrash (jobratt) attacked Welk (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T18:01:19.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Engrash (jobratt) occupied Welk with 1 troop.",
+    "timestamp": "2016-01-20T18:03:37.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "So (jobratt) was fortified from Engrash (jobratt) with 2 troops.",
+    "timestamp": "2016-01-20T18:03:52.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-20T18:03:52.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-20T18:03:52.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-20T18:04:22.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 1 territory.",
+    "timestamp": "2016-01-20T18:04:22.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-20T18:04:25.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) attacked Enbrum (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T18:04:29.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) occupied Enbrum with 1 troop.",
+    "timestamp": "2016-01-20T18:04:39.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-20T18:04:44.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-20T18:04:44.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-20T18:18:30.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "mmacfreier received 3 troops for 9 territories.",
+    "timestamp": "2016-01-20T18:18:30.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Off (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-20T18:18:34.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Off (mmacfreier) attacked Ohma (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T18:18:38.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Off (mmacfreier) occupied Ohma with 9 troops.",
+    "timestamp": "2016-01-20T18:18:41.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Ohma (mmacfreier) attacked Walkon (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T18:18:51.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Ohma (mmacfreier) occupied Walkon with 1 troop.",
+    "timestamp": "2016-01-20T18:19:42.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-20T18:19:50.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-20T18:19:50.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-20T18:20:01.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "kwren received 8 troops for 24 territories.",
+    "timestamp": "2016-01-20T18:20:01.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "kwren received 2 troops for holding T Region.",
+    "timestamp": "2016-01-20T18:20:01.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "kwren received 5 troops for holding V Region.",
+    "timestamp": "2016-01-20T18:20:01.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "kwren received 2 troops for holding D Region.",
+    "timestamp": "2016-01-20T18:20:01.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Vua (kwren) was reinforced by kwren with 17 troops.",
+    "timestamp": "2016-01-20T18:20:04.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Vua (kwren) attacked Welk (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T18:20:09.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Vua (kwren) occupied Welk with 40 troops.",
+    "timestamp": "2016-01-20T18:20:10.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Welk (kwren) attacked Engrash (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T18:20:13.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Welk (kwren) occupied Engrash with 39 troops.",
+    "timestamp": "2016-01-20T18:20:15.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Engrash (kwren) attacked Woxan (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T18:20:18.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Engrash (kwren) occupied Woxan with 38 troops.",
+    "timestamp": "2016-01-20T18:20:20.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Woxan (kwren) attacked Walkon (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T18:20:22.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Woxan (kwren) occupied Walkon with 37 troops.",
+    "timestamp": "2016-01-20T18:20:24.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Walkon (kwren) attacked So (jobratt) conquering it, killing 16, losing 8.",
+    "timestamp": "2016-01-20T18:20:32.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Walkon (kwren) occupied So with 28 troops.",
+    "timestamp": "2016-01-20T18:20:34.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "So (kwren) attacked Spork (jobratt) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-20T18:20:40.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "So (kwren) occupied Spork with 25 troops.",
+    "timestamp": "2016-01-20T18:20:42.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Spork (kwren) attacked Sulodoop (jobratt) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-20T18:20:49.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Spork (kwren) occupied Sulodoop with 22 troops.",
+    "timestamp": "2016-01-20T18:20:51.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Sulodoop (kwren) attacked Co (jobratt) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-20T18:20:56.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Sulodoop (kwren) occupied Co with 1 troop.",
+    "timestamp": "2016-01-20T18:20:59.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Vua (kwren) was fortified from Sulodoop (kwren) with 18 troops.",
+    "timestamp": "2016-01-20T18:21:06.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-20T18:21:06.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-20T18:21:06.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Round 13 started.",
+    "timestamp": "2016-01-20T18:21:06.000Z",
+    "player": "unknown",
+    "round": 13
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-20T18:24:09.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt received 6 troops for 19 territories.",
+    "timestamp": "2016-01-20T18:24:10.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt received 3 troops for holding F Region.",
+    "timestamp": "2016-01-20T18:24:10.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Cal (jobratt) was reinforced by jobratt with 5 troops.",
+    "timestamp": "2016-01-20T18:28:02.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Eong (jobratt) was reinforced by jobratt with 4 troops.",
+    "timestamp": "2016-01-20T18:28:06.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Eong (jobratt) attacked Woxan (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-20T18:28:23.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Eong (jobratt) occupied Woxan with 1 troop.",
+    "timestamp": "2016-01-20T18:28:28.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Cal (jobratt) attacked Co (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T18:28:33.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Cal (jobratt) occupied Co with 5 troops.",
+    "timestamp": "2016-01-20T18:28:34.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Co (jobratt) attacked Sulodoop (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T18:28:37.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Co (jobratt) occupied Sulodoop with 4 troops.",
+    "timestamp": "2016-01-20T18:28:39.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Sulodoop (jobratt) attacked Spork (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T18:28:42.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Sulodoop (jobratt) occupied Spork with 3 troops.",
+    "timestamp": "2016-01-20T18:28:46.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Spork (jobratt) attacked So (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T18:29:01.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "So (jobratt) was fortified from Setha (jobratt) with 15 troops.",
+    "timestamp": "2016-01-20T18:38:22.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-20T18:38:22.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-20T18:38:22.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-20T18:38:49.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 2 territories.",
+    "timestamp": "2016-01-20T18:38:49.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-20T18:38:52.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) attacked Eglo (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T18:38:57.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) occupied Eglo with 1 troop.",
+    "timestamp": "2016-01-20T18:39:10.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-20T18:39:13.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-20T18:39:13.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-20T18:39:26.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "mmacfreier received 3 troops for 10 territories.",
+    "timestamp": "2016-01-20T18:39:26.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding O Region.",
+    "timestamp": "2016-01-20T18:39:26.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Emb (mmacfreier) was reinforced by mmacfreier with 7 troops.",
+    "timestamp": "2016-01-20T18:39:31.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Emb (mmacfreier) attacked Enbrum (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T18:39:34.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Emb (mmacfreier) occupied Enbrum with 1 troop.",
+    "timestamp": "2016-01-20T18:39:37.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-20T18:39:42.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-20T18:39:42.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-20T18:39:58.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "kwren received 9 troops for 27 territories.",
+    "timestamp": "2016-01-20T18:39:58.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "kwren received 2 troops for holding T Region.",
+    "timestamp": "2016-01-20T18:39:58.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "kwren received 5 troops for holding V Region.",
+    "timestamp": "2016-01-20T18:39:58.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "kwren received 2 troops for holding D Region.",
+    "timestamp": "2016-01-20T18:39:58.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Engrash (kwren) was reinforced by kwren with 26 troops.",
+    "timestamp": "2016-01-20T18:40:17.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Engrash (kwren) attacked Eglo (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T18:40:22.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Engrash (kwren) occupied Eglo with 1 troop.",
+    "timestamp": "2016-01-20T18:40:29.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Engrash (kwren) attacked Woxan (jobratt) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-20T18:40:38.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Engrash (kwren) occupied Woxan with 1 troop.",
+    "timestamp": "2016-01-20T18:40:43.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Engrash (kwren) attacked Eong (jobratt) conquering it, killing 2, losing 0.",
+    "timestamp": "2016-01-20T18:40:47.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Engrash (kwren) occupied Eong with 1 troop.",
+    "timestamp": "2016-01-20T18:40:51.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Engrash (kwren) attacked Ewenn (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T18:40:54.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Engrash (kwren) occupied Ewenn with 19 troops.",
+    "timestamp": "2016-01-20T18:40:57.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Ewenn (kwren) attacked Enbrum (mmacfreier) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-20T18:41:02.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Ewenn (kwren) occupied Enbrum with 1 troop.",
+    "timestamp": "2016-01-20T18:41:06.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Vua (kwren) was fortified from Ewenn (kwren) with 15 troops.",
+    "timestamp": "2016-01-20T18:41:13.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-20T18:41:13.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-20T18:41:13.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Round 14 started.",
+    "timestamp": "2016-01-20T18:41:13.000Z",
+    "player": "unknown",
+    "round": 14
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-20T18:44:16.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "jobratt received 6 troops for 20 territories.",
+    "timestamp": "2016-01-20T18:44:16.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "jobratt received 3 troops for holding F Region.",
+    "timestamp": "2016-01-20T18:44:16.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "jobratt received 2 troops for holding C Region.",
+    "timestamp": "2016-01-20T18:44:16.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "jobratt received 5 troops for holding S Region.",
+    "timestamp": "2016-01-20T18:44:16.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "So (jobratt) was reinforced by jobratt with 14 troops.",
+    "timestamp": "2016-01-20T18:44:31.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "Elitt (jobratt) was reinforced by jobratt with 10 troops.",
+    "timestamp": "2016-01-20T18:44:34.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "Elitt (jobratt) attacked Eglo (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T18:44:41.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "Elitt (jobratt) occupied Eglo with 36 troops.",
+    "timestamp": "2016-01-20T18:44:53.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "Eglo (jobratt) attacked Enbrum (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T18:44:55.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "Eglo (jobratt) occupied Enbrum with 35 troops.",
+    "timestamp": "2016-01-20T18:44:57.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "Enbrum (jobratt) attacked Echo (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T18:45:01.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "Enbrum (jobratt) occupied Echo with 1 troop.",
+    "timestamp": "2016-01-20T18:45:37.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "Enbrum (jobratt) attacked Ewenn (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T18:45:39.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "Enbrum (jobratt) occupied Ewenn with 33 troops.",
+    "timestamp": "2016-01-20T18:45:41.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "Ewenn (jobratt) attacked Engrash (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T18:45:45.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "Ewenn (jobratt) occupied Engrash with 31 troops.",
+    "timestamp": "2016-01-20T18:45:47.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "Engrash (jobratt) attacked Welk (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-20T18:45:51.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "Engrash (jobratt) occupied Welk with 1 troop.",
+    "timestamp": "2016-01-20T18:49:21.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "Engrash (jobratt) attacked Eong (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T18:49:26.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "Engrash (jobratt) occupied Eong with 27 troops.",
+    "timestamp": "2016-01-20T18:49:28.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "So (jobratt) attacked Walkon (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T18:49:34.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "So (jobratt) occupied Walkon with 29 troops.",
+    "timestamp": "2016-01-20T18:49:38.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "Elitt (jobratt) was fortified from Eong (jobratt) with 26 troops.",
+    "timestamp": "2016-01-20T18:49:54.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-20T18:49:54.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-20T18:49:54.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-20T18:50:30.000Z",
+    "player": "ryanbmilbourne",
+    "round": 14
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 1 territory.",
+    "timestamp": "2016-01-20T18:50:30.000Z",
+    "player": "ryanbmilbourne",
+    "round": 14
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-20T18:50:37.000Z",
+    "player": "ryanbmilbourne",
+    "round": 14
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) attacked Enbrum (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T18:50:41.000Z",
+    "player": "ryanbmilbourne",
+    "round": 14
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) occupied Enbrum with 1 troop.",
+    "timestamp": "2016-01-20T18:50:48.000Z",
+    "player": "ryanbmilbourne",
+    "round": 14
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-20T18:50:55.000Z",
+    "player": "ryanbmilbourne",
+    "round": 14
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-20T18:50:55.000Z",
+    "player": "ryanbmilbourne",
+    "round": 14
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-20T18:58:38.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "mmacfreier received 3 troops for 10 territories.",
+    "timestamp": "2016-01-20T18:58:38.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding O Region.",
+    "timestamp": "2016-01-20T18:58:38.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Emb (mmacfreier) was reinforced by mmacfreier with 7 troops.",
+    "timestamp": "2016-01-20T18:58:47.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Emb (mmacfreier) attacked Enbrum (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T18:58:54.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Emb (mmacfreier) occupied Enbrum with 1 troop.",
+    "timestamp": "2016-01-20T18:58:58.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-20T18:59:02.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-20T18:59:02.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-20T19:16:52.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "kwren received 8 troops for 24 territories.",
+    "timestamp": "2016-01-20T19:16:52.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "kwren received 2 troops for holding T Region.",
+    "timestamp": "2016-01-20T19:16:52.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "kwren received 5 troops for holding V Region.",
+    "timestamp": "2016-01-20T19:16:52.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "kwren received 2 troops for holding D Region.",
+    "timestamp": "2016-01-20T19:16:52.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "Traln (kwren) was reinforced by kwren with 17 troops.",
+    "timestamp": "2016-01-20T19:16:54.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "Traln (kwren) attacked Echo (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T19:16:58.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "Traln (kwren) occupied Echo with 38 troops.",
+    "timestamp": "2016-01-20T19:18:17.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "Echo (kwren) attacked Emb (mmacfreier) conquering it, killing 22, losing 9.",
+    "timestamp": "2016-01-20T19:18:38.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "Echo (kwren) occupied Emb with 1 troop.",
+    "timestamp": "2016-01-20T19:18:42.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "Echo (kwren) attacked Enbrum (mmacfreier) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-20T19:18:47.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "Echo (kwren) occupied Enbrum with 1 troop.",
+    "timestamp": "2016-01-20T19:18:56.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "Vua (kwren) attacked Welk (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T19:19:00.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "Vua (kwren) occupied Welk with 1 troop.",
+    "timestamp": "2016-01-20T19:19:15.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "Vua (kwren) was fortified from Dune (kwren) with 2 troops.",
+    "timestamp": "2016-01-20T19:19:24.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-20T19:19:24.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-20T19:19:24.000Z",
+    "player": "kwren",
+    "round": 14
+  },
+  {
+    "message": "Round 15 started.",
+    "timestamp": "2016-01-20T19:19:24.000Z",
+    "player": "unknown",
+    "round": 15
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-20T19:29:00.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "jobratt received 8 troops for 25 territories.",
+    "timestamp": "2016-01-20T19:29:00.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "jobratt received 5 troops for holding S Region.",
+    "timestamp": "2016-01-20T19:29:00.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "jobratt received 2 troops for holding C Region.",
+    "timestamp": "2016-01-20T19:29:00.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "jobratt received 3 troops for holding F Region.",
+    "timestamp": "2016-01-20T19:29:00.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "Ewenn (jobratt) was reinforced by jobratt with 18 troops.",
+    "timestamp": "2016-01-20T19:29:35.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "Ewenn (jobratt) attacked Enbrum (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T19:29:38.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "Ewenn (jobratt) occupied Enbrum with 18 troops.",
+    "timestamp": "2016-01-20T19:29:40.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "Enbrum (jobratt) attacked Echo (kwren) conquering it, killing 25, losing 12.",
+    "timestamp": "2016-01-20T19:29:55.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "Enbrum (jobratt) occupied Echo with 5 troops.",
+    "timestamp": "2016-01-20T19:29:57.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "Echo (jobratt) attacked Traln (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T19:29:59.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "Echo (jobratt) occupied Traln with 4 troops.",
+    "timestamp": "2016-01-20T19:30:01.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "Traln (jobratt) attacked Tripoc (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T19:30:04.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "Traln (jobratt) occupied Tripoc with 3 troops.",
+    "timestamp": "2016-01-20T19:30:05.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "Tripoc (jobratt) attacked Taulk (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T19:30:09.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-20T19:31:21.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-20T19:31:21.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-20T19:33:39.000Z",
+    "player": "ryanbmilbourne",
+    "round": 15
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 1 territory.",
+    "timestamp": "2016-01-20T19:33:39.000Z",
+    "player": "ryanbmilbourne",
+    "round": 15
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-20T19:33:44.000Z",
+    "player": "ryanbmilbourne",
+    "round": 15
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) attacked Enbrum (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T19:33:51.000Z",
+    "player": "ryanbmilbourne",
+    "round": 15
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) occupied Enbrum with 1 troop.",
+    "timestamp": "2016-01-20T19:34:15.000Z",
+    "player": "ryanbmilbourne",
+    "round": 15
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-20T19:34:20.000Z",
+    "player": "ryanbmilbourne",
+    "round": 15
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-20T19:34:20.000Z",
+    "player": "ryanbmilbourne",
+    "round": 15
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-20T19:39:04.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "mmacfreier received 3 troops for 9 territories.",
+    "timestamp": "2016-01-20T19:39:04.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding O Region.",
+    "timestamp": "2016-01-20T19:39:04.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Ord (mmacfreier) was reinforced by mmacfreier with 15 troops.",
+    "timestamp": "2016-01-20T19:39:15.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-20T19:39:24.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-20T19:46:39.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "kwren received 7 troops for 23 territories.",
+    "timestamp": "2016-01-20T19:46:39.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "kwren received 5 troops for holding V Region.",
+    "timestamp": "2016-01-20T19:46:39.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "kwren received 2 troops for holding D Region.",
+    "timestamp": "2016-01-20T19:46:39.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "kwren received 2 troops on Whist",
+    "timestamp": "2016-01-20T19:46:42.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "Trax (kwren) was reinforced by kwren with 22 troops.",
+    "timestamp": "2016-01-20T19:46:45.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "Trax (kwren) attacked Taulk (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T19:46:48.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "Trax (kwren) occupied Taulk with 22 troops.",
+    "timestamp": "2016-01-20T19:46:50.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "Taulk (kwren) attacked Tripoc (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T19:46:53.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "Taulk (kwren) occupied Tripoc with 21 troops.",
+    "timestamp": "2016-01-20T19:46:55.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "Tripoc (kwren) attacked Traln (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T19:46:57.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "Tripoc (kwren) occupied Traln with 20 troops.",
+    "timestamp": "2016-01-20T19:46:59.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "Traln (kwren) attacked Echo (jobratt) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-01-20T19:47:06.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "Traln (kwren) occupied Echo with 1 troop.",
+    "timestamp": "2016-01-20T19:47:08.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "Traln (kwren) was fortified from Vua (kwren) with 9 troops.",
+    "timestamp": "2016-01-20T19:47:27.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-20T19:47:27.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-20T19:47:27.000Z",
+    "player": "kwren",
+    "round": 15
+  },
+  {
+    "message": "Round 16 started.",
+    "timestamp": "2016-01-20T19:47:27.000Z",
+    "player": "unknown",
+    "round": 16
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-20T19:48:24.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "jobratt received 8 troops for 25 territories.",
+    "timestamp": "2016-01-20T19:48:25.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "jobratt received 5 troops for holding S Region.",
+    "timestamp": "2016-01-20T19:48:25.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "jobratt received 2 troops for holding C Region.",
+    "timestamp": "2016-01-20T19:48:25.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "jobratt received 3 troops for holding F Region.",
+    "timestamp": "2016-01-20T19:48:25.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Ewenn (jobratt) was reinforced by jobratt with 18 troops.",
+    "timestamp": "2016-01-20T19:48:52.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Ewenn (jobratt) attacked Enbrum (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T19:48:54.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Ewenn (jobratt) occupied Enbrum with 18 troops.",
+    "timestamp": "2016-01-20T19:48:56.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Enbrum (jobratt) attacked Echo (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T19:48:58.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Enbrum (jobratt) occupied Echo with 17 troops.",
+    "timestamp": "2016-01-20T19:48:59.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Echo (jobratt) attacked Traln (kwren) killing 12, losing 16.",
+    "timestamp": "2016-01-20T19:49:07.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Walkon (jobratt) attacked Woxan (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T19:49:24.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Walkon (jobratt) occupied Woxan with 1 troop.",
+    "timestamp": "2016-01-20T19:49:31.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Walkon (jobratt) attacked Wa (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T19:49:33.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Walkon (jobratt) occupied Wa with 1 troop.",
+    "timestamp": "2016-01-20T19:49:37.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Elitt (jobratt) was fortified from Walkon (jobratt) with 10 troops.",
+    "timestamp": "2016-01-20T19:50:02.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-20T19:50:02.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-20T19:50:02.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-20T19:50:23.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 1 territory.",
+    "timestamp": "2016-01-20T19:50:23.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "ryanbmilbourne received 2 troops on Erdus",
+    "timestamp": "2016-01-20T19:50:27.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) was reinforced by ryanbmilbourne with 11 troops.",
+    "timestamp": "2016-01-20T19:50:34.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) attacked Enbrum (jobratt) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-20T19:50:42.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) occupied Enbrum with 1 troop.",
+    "timestamp": "2016-01-20T19:50:51.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-20T19:50:58.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-20T19:50:58.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-20T19:51:04.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier received 3 troops for 9 territories.",
+    "timestamp": "2016-01-20T19:51:04.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding O Region.",
+    "timestamp": "2016-01-20T19:51:04.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "Ord (mmacfreier) was reinforced by mmacfreier with 7 troops.",
+    "timestamp": "2016-01-20T19:51:11.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-20T19:51:16.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-20T19:51:30.000Z",
+    "player": "kwren",
+    "round": 16
+  },
+  {
+    "message": "kwren received 8 troops for 24 territories.",
+    "timestamp": "2016-01-20T19:51:30.000Z",
+    "player": "kwren",
+    "round": 16
+  },
+  {
+    "message": "kwren received 5 troops for holding V Region.",
+    "timestamp": "2016-01-20T19:51:30.000Z",
+    "player": "kwren",
+    "round": 16
+  },
+  {
+    "message": "kwren received 2 troops for holding D Region.",
+    "timestamp": "2016-01-20T19:51:30.000Z",
+    "player": "kwren",
+    "round": 16
+  },
+  {
+    "message": "kwren received 2 troops for holding T Region.",
+    "timestamp": "2016-01-20T19:51:30.000Z",
+    "player": "kwren",
+    "round": 16
+  },
+  {
+    "message": "Traln (kwren) was reinforced by kwren with 17 troops.",
+    "timestamp": "2016-01-20T19:51:36.000Z",
+    "player": "kwren",
+    "round": 16
+  },
+  {
+    "message": "Traln (kwren) attacked Echo (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T19:51:39.000Z",
+    "player": "kwren",
+    "round": 16
+  },
+  {
+    "message": "Traln (kwren) occupied Echo with 29 troops.",
+    "timestamp": "2016-01-20T19:51:41.000Z",
+    "player": "kwren",
+    "round": 16
+  },
+  {
+    "message": "Echo (kwren) attacked Enbrum (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T19:51:43.000Z",
+    "player": "kwren",
+    "round": 16
+  },
+  {
+    "message": "Echo (kwren) occupied Enbrum with 1 troop.",
+    "timestamp": "2016-01-20T19:51:52.000Z",
+    "player": "kwren",
+    "round": 16
+  },
+  {
+    "message": "Echo (kwren) was fortified from Whist (kwren) with 2 troops.",
+    "timestamp": "2016-01-20T19:52:01.000Z",
+    "player": "kwren",
+    "round": 16
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-20T19:52:02.000Z",
+    "player": "kwren",
+    "round": 16
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-20T19:52:02.000Z",
+    "player": "kwren",
+    "round": 16
+  },
+  {
+    "message": "Round 17 started.",
+    "timestamp": "2016-01-20T19:52:02.000Z",
+    "player": "unknown",
+    "round": 17
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-20T19:57:41.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "jobratt received 9 troops for 27 territories.",
+    "timestamp": "2016-01-20T19:57:41.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "jobratt received 5 troops for holding S Region.",
+    "timestamp": "2016-01-20T19:57:41.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "jobratt received 2 troops for holding C Region.",
+    "timestamp": "2016-01-20T19:57:41.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "jobratt received 3 troops for holding F Region.",
+    "timestamp": "2016-01-20T19:57:41.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Ewenn (jobratt) was reinforced by jobratt with 19 troops.",
+    "timestamp": "2016-01-20T19:58:04.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Ewenn (jobratt) attacked Enbrum (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T19:58:07.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Ewenn (jobratt) occupied Enbrum with 1 troop.",
+    "timestamp": "2016-01-20T19:58:16.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Elitt (jobratt) was fortified from Ewenn (jobratt) with 17 troops.",
+    "timestamp": "2016-01-20T19:58:41.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-20T19:58:41.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-20T19:58:41.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-20T19:58:53.000Z",
+    "player": "ryanbmilbourne",
+    "round": 17
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 1 territory.",
+    "timestamp": "2016-01-20T19:58:53.000Z",
+    "player": "ryanbmilbourne",
+    "round": 17
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-20T19:58:59.000Z",
+    "player": "ryanbmilbourne",
+    "round": 17
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) attacked Enbrum (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T19:59:02.000Z",
+    "player": "ryanbmilbourne",
+    "round": 17
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) occupied Enbrum with 1 troop.",
+    "timestamp": "2016-01-20T19:59:13.000Z",
+    "player": "ryanbmilbourne",
+    "round": 17
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-20T19:59:18.000Z",
+    "player": "ryanbmilbourne",
+    "round": 17
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-20T19:59:18.000Z",
+    "player": "ryanbmilbourne",
+    "round": 17
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-20T19:59:57.000Z",
+    "player": "mmacfreier",
+    "round": 17
+  },
+  {
+    "message": "mmacfreier received 3 troops for 9 territories.",
+    "timestamp": "2016-01-20T19:59:57.000Z",
+    "player": "mmacfreier",
+    "round": 17
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding O Region.",
+    "timestamp": "2016-01-20T19:59:57.000Z",
+    "player": "mmacfreier",
+    "round": 17
+  },
+  {
+    "message": "Ord (mmacfreier) was reinforced by mmacfreier with 7 troops.",
+    "timestamp": "2016-01-20T20:00:00.000Z",
+    "player": "mmacfreier",
+    "round": 17
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-20T20:00:05.000Z",
+    "player": "mmacfreier",
+    "round": 17
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-20T20:01:32.000Z",
+    "player": "kwren",
+    "round": 17
+  },
+  {
+    "message": "kwren received 8 troops for 25 territories.",
+    "timestamp": "2016-01-20T20:01:32.000Z",
+    "player": "kwren",
+    "round": 17
+  },
+  {
+    "message": "kwren received 5 troops for holding V Region.",
+    "timestamp": "2016-01-20T20:01:32.000Z",
+    "player": "kwren",
+    "round": 17
+  },
+  {
+    "message": "kwren received 2 troops for holding D Region.",
+    "timestamp": "2016-01-20T20:01:32.000Z",
+    "player": "kwren",
+    "round": 17
+  },
+  {
+    "message": "kwren received 2 troops for holding T Region.",
+    "timestamp": "2016-01-20T20:01:32.000Z",
+    "player": "kwren",
+    "round": 17
+  },
+  {
+    "message": "Welk (kwren) was reinforced by kwren with 17 troops.",
+    "timestamp": "2016-01-20T20:01:35.000Z",
+    "player": "kwren",
+    "round": 17
+  },
+  {
+    "message": "Welk (kwren) attacked Engrash (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T20:01:38.000Z",
+    "player": "kwren",
+    "round": 17
+  },
+  {
+    "message": "Welk (kwren) occupied Engrash with 16 troops.",
+    "timestamp": "2016-01-20T20:01:40.000Z",
+    "player": "kwren",
+    "round": 17
+  },
+  {
+    "message": "Engrash (kwren) attacked Eglo (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T20:01:44.000Z",
+    "player": "kwren",
+    "round": 17
+  },
+  {
+    "message": "Engrash (kwren) occupied Eglo with 1 troop.",
+    "timestamp": "2016-01-20T20:01:49.000Z",
+    "player": "kwren",
+    "round": 17
+  },
+  {
+    "message": "Engrash (kwren) attacked Woxan (jobratt) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-01-20T20:01:55.000Z",
+    "player": "kwren",
+    "round": 17
+  },
+  {
+    "message": "Engrash (kwren) occupied Woxan with 1 troop.",
+    "timestamp": "2016-01-20T20:02:06.000Z",
+    "player": "kwren",
+    "round": 17
+  },
+  {
+    "message": "Vua (kwren) was fortified from Engrash (kwren) with 9 troops.",
+    "timestamp": "2016-01-20T20:02:12.000Z",
+    "player": "kwren",
+    "round": 17
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-20T20:02:12.000Z",
+    "player": "kwren",
+    "round": 17
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-20T20:02:12.000Z",
+    "player": "kwren",
+    "round": 17
+  },
+  {
+    "message": "Round 18 started.",
+    "timestamp": "2016-01-20T20:02:12.000Z",
+    "player": "unknown",
+    "round": 18
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-20T20:06:59.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "jobratt received 8 troops for 24 territories.",
+    "timestamp": "2016-01-20T20:06:59.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "jobratt received 5 troops for holding S Region.",
+    "timestamp": "2016-01-20T20:06:59.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "jobratt received 2 troops for holding C Region.",
+    "timestamp": "2016-01-20T20:06:59.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "jobratt received 3 troops for holding F Region.",
+    "timestamp": "2016-01-20T20:06:59.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "jobratt received 2 troops on Clutch",
+    "timestamp": "2016-01-20T20:07:03.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Elitt (jobratt) was reinforced by jobratt with 26 troops.",
+    "timestamp": "2016-01-20T20:07:05.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Elitt (jobratt) attacked Eglo (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:07:21.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Elitt (jobratt) occupied Eglo with 79 troops.",
+    "timestamp": "2016-01-20T20:07:23.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Eglo (jobratt) attacked Engrash (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:07:26.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Eglo (jobratt) occupied Engrash with 78 troops.",
+    "timestamp": "2016-01-20T20:07:27.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Engrash (jobratt) attacked Welk (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:07:33.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Engrash (jobratt) occupied Welk with 77 troops.",
+    "timestamp": "2016-01-20T20:07:35.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Welk (jobratt) attacked Vua (kwren) conquering it, killing 35, losing 23.",
+    "timestamp": "2016-01-20T20:07:47.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Welk (jobratt) occupied Vua with 53 troops.",
+    "timestamp": "2016-01-20T20:08:02.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Vua (jobratt) attacked Vupano (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-20T20:08:15.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Vua (jobratt) occupied Vupano with 50 troops.",
+    "timestamp": "2016-01-20T20:08:18.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Vupano (jobratt) attacked Vim (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:08:26.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Vupano (jobratt) occupied Vim with 49 troops.",
+    "timestamp": "2016-01-20T20:08:27.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Vim (jobratt) attacked Vebn (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:08:30.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Vim (jobratt) occupied Vebn with 48 troops.",
+    "timestamp": "2016-01-20T20:08:31.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Vebn (jobratt) attacked Vreen (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-20T20:08:35.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Vebn (jobratt) occupied Vreen with 45 troops.",
+    "timestamp": "2016-01-20T20:08:36.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Vreen (jobratt) attacked Du (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-20T20:08:41.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Vreen (jobratt) occupied Du with 42 troops.",
+    "timestamp": "2016-01-20T20:08:43.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Du (jobratt) attacked Dri (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:08:45.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Du (jobratt) occupied Dri with 1 troop.",
+    "timestamp": "2016-01-20T20:08:49.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Du (jobratt) attacked Don (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:08:53.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Du (jobratt) occupied Don with 40 troops.",
+    "timestamp": "2016-01-20T20:08:55.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Don (jobratt) attacked Doustmon (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-20T20:09:00.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Don (jobratt) occupied Doustmon with 37 troops.",
+    "timestamp": "2016-01-20T20:09:01.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Doustmon (jobratt) attacked Dune (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T20:09:04.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Doustmon (jobratt) occupied Dune with 35 troops.",
+    "timestamp": "2016-01-20T20:09:05.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Dune (jobratt) attacked Vabon (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:09:08.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Dune (jobratt) occupied Vabon with 34 troops.",
+    "timestamp": "2016-01-20T20:09:09.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Vabon (jobratt) attacked Vhown (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T20:09:13.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Vabon (jobratt) occupied Vhown with 32 troops.",
+    "timestamp": "2016-01-20T20:09:14.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Vhown (jobratt) attacked Vy (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:09:18.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Vhown (jobratt) occupied Vy with 31 troops.",
+    "timestamp": "2016-01-20T20:09:19.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Vy (jobratt) attacked Vahn (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:09:23.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Vy (jobratt) occupied Vahn with 30 troops.",
+    "timestamp": "2016-01-20T20:09:24.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Vahn (jobratt) attacked Tuloe (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:09:27.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Vahn (jobratt) occupied Tuloe with 1 troop.",
+    "timestamp": "2016-01-20T20:10:01.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Walkon (jobratt) attacked Woxan (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:10:09.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Walkon (jobratt) occupied Woxan with 16 troops.",
+    "timestamp": "2016-01-20T20:10:10.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Woxan (jobratt) attacked Wun (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:10:13.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Woxan (jobratt) occupied Wun with 15 troops.",
+    "timestamp": "2016-01-20T20:10:14.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Wun (jobratt) attacked Whist (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:10:17.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Wun (jobratt) occupied Whist with 1 troop.",
+    "timestamp": "2016-01-20T20:10:19.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "Elitt (jobratt) was fortified from Vahn (jobratt) with 28 troops.",
+    "timestamp": "2016-01-20T20:10:40.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-20T20:10:40.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-20T20:10:40.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-20T20:14:14.000Z",
+    "player": "ryanbmilbourne",
+    "round": 18
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 2 territories.",
+    "timestamp": "2016-01-20T20:14:14.000Z",
+    "player": "ryanbmilbourne",
+    "round": 18
+  },
+  {
+    "message": "Enbrum (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-20T20:14:21.000Z",
+    "player": "ryanbmilbourne",
+    "round": 18
+  },
+  {
+    "message": "Enbrum (ryanbmilbourne) attacked Ewenn (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:14:30.000Z",
+    "player": "ryanbmilbourne",
+    "round": 18
+  },
+  {
+    "message": "Enbrum (ryanbmilbourne) occupied Ewenn with 1 troop.",
+    "timestamp": "2016-01-20T20:14:36.000Z",
+    "player": "ryanbmilbourne",
+    "round": 18
+  },
+  {
+    "message": "Erdus (ryanbmilbourne) was fortified from Enbrum (ryanbmilbourne) with 2 troops.",
+    "timestamp": "2016-01-20T20:14:43.000Z",
+    "player": "ryanbmilbourne",
+    "round": 18
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-20T20:14:43.000Z",
+    "player": "ryanbmilbourne",
+    "round": 18
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-20T20:14:43.000Z",
+    "player": "ryanbmilbourne",
+    "round": 18
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-20T20:22:10.000Z",
+    "player": "mmacfreier",
+    "round": 18
+  },
+  {
+    "message": "mmacfreier received 3 troops for 9 territories.",
+    "timestamp": "2016-01-20T20:22:10.000Z",
+    "player": "mmacfreier",
+    "round": 18
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding O Region.",
+    "timestamp": "2016-01-20T20:22:10.000Z",
+    "player": "mmacfreier",
+    "round": 18
+  },
+  {
+    "message": "Ord (mmacfreier) was reinforced by mmacfreier with 7 troops.",
+    "timestamp": "2016-01-20T20:22:20.000Z",
+    "player": "mmacfreier",
+    "round": 18
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-20T20:22:29.000Z",
+    "player": "mmacfreier",
+    "round": 18
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-20T20:23:06.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "kwren received 3 troops for 7 territories.",
+    "timestamp": "2016-01-20T20:23:06.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "Echo (kwren) was reinforced by kwren with 11 troops.",
+    "timestamp": "2016-01-20T20:23:11.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "Echo (kwren) attacked Enbrum (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:23:14.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "Echo (kwren) occupied Enbrum with 40 troops.",
+    "timestamp": "2016-01-20T20:23:16.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "Enbrum (kwren) attacked Erdus (ryanbmilbourne) conquering it, killing 42, losing 28.",
+    "timestamp": "2016-01-20T20:24:22.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "Enbrum (kwren) occupied Erdus with 1 troop.",
+    "timestamp": "2016-01-20T20:24:26.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "Enbrum (kwren) attacked Ewenn (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:24:29.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "ryanbmilbourne was defeated by kwren.",
+    "timestamp": "2016-01-20T20:24:29.000Z",
+    "player": "ryanbmilbourne",
+    "round": 18
+  },
+  {
+    "message": "Enbrum (kwren) occupied Ewenn with 10 troops.",
+    "timestamp": "2016-01-20T20:24:33.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "kwren received 2 troops on Taulk",
+    "timestamp": "2016-01-20T20:24:37.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "Taulk (kwren) was reinforced by kwren with 8 troops.",
+    "timestamp": "2016-01-20T20:24:42.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "Taulk (kwren) attacked Tuloe (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:24:45.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "Taulk (kwren) occupied Tuloe with 10 troops.",
+    "timestamp": "2016-01-20T20:24:46.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "Tuloe (kwren) attacked Vahn (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T20:24:51.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "Tuloe (kwren) occupied Vahn with 8 troops.",
+    "timestamp": "2016-01-20T20:24:52.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "Vahn (kwren) attacked Vabon (jobratt) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-20T20:24:58.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "Vahn (kwren) occupied Vabon with 5 troops.",
+    "timestamp": "2016-01-20T20:24:59.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "Vabon (kwren) attacked Dune (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T20:25:03.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "Vabon (kwren) occupied Dune with 3 troops.",
+    "timestamp": "2016-01-20T20:25:06.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "Ewenn (kwren) attacked Eglo (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T20:25:10.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "Ewenn (kwren) occupied Eglo with 8 troops.",
+    "timestamp": "2016-01-20T20:25:12.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "Eglo (kwren) attacked Eong (jobratt) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-01-20T20:25:18.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "Eglo (kwren) occupied Eong with 4 troops.",
+    "timestamp": "2016-01-20T20:25:19.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "Eong (kwren) attacked Woxan (jobratt) killing 0, losing 3.",
+    "timestamp": "2016-01-20T20:25:24.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-20T20:27:37.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-20T20:27:37.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "Round 19 started.",
+    "timestamp": "2016-01-20T20:27:37.000Z",
+    "player": "unknown",
+    "round": 19
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-20T20:32:16.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "jobratt received 12 troops for 38 territories.",
+    "timestamp": "2016-01-20T20:32:16.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "jobratt received 5 troops for holding S Region.",
+    "timestamp": "2016-01-20T20:32:16.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "jobratt received 2 troops for holding C Region.",
+    "timestamp": "2016-01-20T20:32:16.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "jobratt received 3 troops for holding F Region.",
+    "timestamp": "2016-01-20T20:32:16.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "jobratt received 3 troops for holding W Region.",
+    "timestamp": "2016-01-20T20:32:16.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Elitt (jobratt) was reinforced by jobratt with 25 troops.",
+    "timestamp": "2016-01-20T20:32:25.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Elitt (jobratt) attacked Eong (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:32:29.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Elitt (jobratt) occupied Eong with 53 troops.",
+    "timestamp": "2016-01-20T20:32:30.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Eong (jobratt) attacked Eglo (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-20T20:32:35.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Eong (jobratt) occupied Eglo with 50 troops.",
+    "timestamp": "2016-01-20T20:32:36.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Eglo (jobratt) attacked Erdus (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:32:40.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Eglo (jobratt) occupied Erdus with 1 troop.",
+    "timestamp": "2016-01-20T20:32:44.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Eglo (jobratt) attacked Ewenn (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T20:32:47.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Eglo (jobratt) occupied Ewenn with 47 troops.",
+    "timestamp": "2016-01-20T20:32:48.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Ewenn (jobratt) attacked Enbrum (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:32:51.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Ewenn (jobratt) occupied Enbrum with 46 troops.",
+    "timestamp": "2016-01-20T20:32:53.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Enbrum (jobratt) attacked Emb (kwren) conquering it, killing 1, losing 5.",
+    "timestamp": "2016-01-20T20:33:03.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Enbrum (jobratt) occupied Emb with 40 troops.",
+    "timestamp": "2016-01-20T20:33:04.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Emb (jobratt) attacked Echo (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:33:07.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Emb (jobratt) occupied Echo with 39 troops.",
+    "timestamp": "2016-01-20T20:33:08.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Echo (jobratt) attacked Traln (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T20:33:12.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Echo (jobratt) occupied Traln with 37 troops.",
+    "timestamp": "2016-01-20T20:33:13.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Traln (jobratt) attacked Tripoc (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:33:16.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Traln (jobratt) occupied Tripoc with 36 troops.",
+    "timestamp": "2016-01-20T20:33:18.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Tripoc (jobratt) attacked Taulk (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:33:22.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Tripoc (jobratt) occupied Taulk with 35 troops.",
+    "timestamp": "2016-01-20T20:33:24.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Taulk (jobratt) attacked Trax (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:33:27.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Taulk (jobratt) occupied Trax with 34 troops.",
+    "timestamp": "2016-01-20T20:33:28.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Trax (jobratt) attacked Teld (kwren) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-01-20T20:33:34.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Trax (jobratt) occupied Teld with 30 troops.",
+    "timestamp": "2016-01-20T20:33:35.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Teld (jobratt) attacked Tuloe (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T20:33:40.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Teld (jobratt) occupied Tuloe with 28 troops.",
+    "timestamp": "2016-01-20T20:33:42.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Tuloe (jobratt) attacked Vahn (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T20:33:46.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Tuloe (jobratt) occupied Vahn with 26 troops.",
+    "timestamp": "2016-01-20T20:33:47.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Vahn (jobratt) attacked Vabon (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-20T20:33:55.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Vahn (jobratt) occupied Vabon with 23 troops.",
+    "timestamp": "2016-01-20T20:33:56.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Vabon (jobratt) attacked Dune (kwren) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-20T20:34:01.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "kwren was defeated by jobratt.",
+    "timestamp": "2016-01-20T20:34:01.000Z",
+    "player": "kwren",
+    "round": 19
+  },
+  {
+    "message": "Vabon (jobratt) occupied Dune with 22 troops.",
+    "timestamp": "2016-01-20T20:34:03.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "jobratt received 2 troops on Fado",
+    "timestamp": "2016-01-20T20:34:08.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "jobratt received 2 troops on Sulodoop",
+    "timestamp": "2016-01-20T20:34:08.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "jobratt received 2 troops on Vahn",
+    "timestamp": "2016-01-20T20:34:08.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Setha (jobratt) was reinforced by jobratt with 8 troops.",
+    "timestamp": "2016-01-20T20:34:31.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Setha (jobratt) attacked Off (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:34:34.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Setha (jobratt) occupied Off with 8 troops.",
+    "timestamp": "2016-01-20T20:34:41.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "Off (jobratt) was fortified from Dune (jobratt) with 21 troops.",
+    "timestamp": "2016-01-20T20:34:51.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-20T20:34:51.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-20T20:34:52.000Z",
+    "player": "jobratt",
+    "round": 19
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-20T20:35:25.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "mmacfreier received 3 troops for 8 territories.",
+    "timestamp": "2016-01-20T20:35:25.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Ord (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-20T20:35:31.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Ohma (mmacfreier) attacked Off (jobratt) killing 8, losing 7.",
+    "timestamp": "2016-01-20T20:35:51.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Ord (mmacfreier) attacked Off (jobratt) conquering it, killing 21, losing 11.",
+    "timestamp": "2016-01-20T20:36:10.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Ord (mmacfreier) occupied Off with 28 troops.",
+    "timestamp": "2016-01-20T20:36:12.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Off (mmacfreier) attacked Setha (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T20:36:18.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Off (mmacfreier) occupied Setha with 26 troops.",
+    "timestamp": "2016-01-20T20:36:20.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Setha (mmacfreier) attacked Fud (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:36:22.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Setha (mmacfreier) occupied Fud with 1 troop.",
+    "timestamp": "2016-01-20T20:36:27.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Setha (mmacfreier) attacked Spork (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:36:39.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Setha (mmacfreier) occupied Spork with 24 troops.",
+    "timestamp": "2016-01-20T20:36:40.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Spork (mmacfreier) attacked Sulodoop (jobratt) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-20T20:36:46.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Spork (mmacfreier) occupied Sulodoop with 5 troops.",
+    "timestamp": "2016-01-20T20:36:52.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Sulodoop (mmacfreier) attacked Co (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:36:54.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Sulodoop (mmacfreier) occupied Co with 4 troops.",
+    "timestamp": "2016-01-20T20:36:58.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Spork (mmacfreier) attacked Spot (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:37:00.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Spork (mmacfreier) occupied Spot with 17 troops.",
+    "timestamp": "2016-01-20T20:37:02.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Spot (mmacfreier) attacked Elitt (jobratt) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-01-20T20:37:10.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Spot (mmacfreier) occupied Elitt with 13 troops.",
+    "timestamp": "2016-01-20T20:37:12.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Elitt (mmacfreier) attacked Eong (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:37:15.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Elitt (mmacfreier) occupied Eong with 12 troops.",
+    "timestamp": "2016-01-20T20:37:19.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Eong (mmacfreier) attacked Woxan (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:37:22.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Eong (mmacfreier) occupied Woxan with 1 troop.",
+    "timestamp": "2016-01-20T20:37:26.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Eong (mmacfreier) attacked Engrash (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:37:33.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Eong (mmacfreier) occupied Engrash with 10 troops.",
+    "timestamp": "2016-01-20T20:37:34.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Engrash (mmacfreier) attacked Welk (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T20:37:39.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Engrash (mmacfreier) occupied Welk with 8 troops.",
+    "timestamp": "2016-01-20T20:37:41.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Welk (mmacfreier) attacked Vua (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:37:44.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Welk (mmacfreier) occupied Vua with 1 troop.",
+    "timestamp": "2016-01-20T20:37:54.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Ohma (mmacfreier) was fortified from Welk (mmacfreier) with 6 troops.",
+    "timestamp": "2016-01-20T20:38:02.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-20T20:38:02.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-20T20:38:02.000Z",
+    "player": "mmacfreier",
+    "round": 19
+  },
+  {
+    "message": "Round 20 started.",
+    "timestamp": "2016-01-20T20:38:02.000Z",
+    "player": "unknown",
+    "round": 20
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-20T20:38:13.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "jobratt received 14 troops for 42 territories.",
+    "timestamp": "2016-01-20T20:38:13.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "jobratt received 2 troops for holding T Region.",
+    "timestamp": "2016-01-20T20:38:13.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "jobratt received 2 troops for holding D Region.",
+    "timestamp": "2016-01-20T20:38:13.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Fado (jobratt) was reinforced by jobratt with 10 troops.",
+    "timestamp": "2016-01-20T20:39:33.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Wun (jobratt) was reinforced by jobratt with 8 troops.",
+    "timestamp": "2016-01-20T20:39:36.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Fado (jobratt) attacked Onbri (mmacfreier) conquering it, killing 3, losing 3.",
+    "timestamp": "2016-01-20T20:39:43.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Fado (jobratt) occupied Onbri with 9 troops.",
+    "timestamp": "2016-01-20T20:39:45.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Wun (jobratt) attacked Woxan (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:39:55.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Wun (jobratt) occupied Woxan with 21 troops.",
+    "timestamp": "2016-01-20T20:39:59.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Woxan (jobratt) attacked Engrash (mmacfreier) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-20T20:40:12.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Woxan (jobratt) occupied Engrash with 18 troops.",
+    "timestamp": "2016-01-20T20:40:13.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Engrash (jobratt) attacked Welk (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T20:40:19.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Engrash (jobratt) occupied Welk with 6 troops.",
+    "timestamp": "2016-01-20T20:40:26.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Welk (jobratt) attacked Vua (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T20:40:31.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Welk (jobratt) occupied Vua with 1 troop.",
+    "timestamp": "2016-01-20T20:40:34.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Engrash (jobratt) attacked Eong (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T20:40:40.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Engrash (jobratt) occupied Eong with 9 troops.",
+    "timestamp": "2016-01-20T20:40:43.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Eong (jobratt) attacked Elitt (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:40:46.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Eong (jobratt) occupied Elitt with 8 troops.",
+    "timestamp": "2016-01-20T20:40:50.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Elitt (jobratt) attacked Spot (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T20:41:15.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Elitt (jobratt) occupied Spot with 6 troops.",
+    "timestamp": "2016-01-20T20:41:18.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Spot (jobratt) attacked Spork (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:41:20.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Spot (jobratt) occupied Spork with 5 troops.",
+    "timestamp": "2016-01-20T20:41:22.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Spork (jobratt) attacked Setha (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:41:24.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Spork (jobratt) occupied Setha with 4 troops.",
+    "timestamp": "2016-01-20T20:41:25.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Setha (jobratt) attacked Fud (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:41:27.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Setha (jobratt) occupied Fud with 3 troops.",
+    "timestamp": "2016-01-20T20:41:29.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Onbri (jobratt) attacked Oshgrind (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:41:32.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Onbri (jobratt) occupied Oshgrind with 8 troops.",
+    "timestamp": "2016-01-20T20:41:33.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Oshgrind (jobratt) attacked Odpewn (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-20T20:41:37.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Oshgrind (jobratt) occupied Odpewn with 6 troops.",
+    "timestamp": "2016-01-20T20:41:39.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Odpewn (jobratt) attacked Oatgol (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:41:42.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Odpewn (jobratt) occupied Oatgol with 5 troops.",
+    "timestamp": "2016-01-20T20:41:44.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Oatgol (jobratt) attacked Octa (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:41:46.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Oatgol (jobratt) occupied Octa with 4 troops.",
+    "timestamp": "2016-01-20T20:41:47.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Octa (jobratt) attacked Ottel (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:41:50.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Octa (jobratt) occupied Ottel with 3 troops.",
+    "timestamp": "2016-01-20T20:41:51.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "Ottel (jobratt) was fortified from Welk (jobratt) with 3 troops.",
+    "timestamp": "2016-01-20T20:41:57.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-20T20:41:57.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-20T20:41:57.000Z",
+    "player": "jobratt",
+    "round": 20
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-20T20:42:07.000Z",
+    "player": "mmacfreier",
+    "round": 20
+  },
+  {
+    "message": "mmacfreier received 3 troops for 5 territories.",
+    "timestamp": "2016-01-20T20:42:07.000Z",
+    "player": "mmacfreier",
+    "round": 20
+  },
+  {
+    "message": "Ohma (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-20T20:42:14.000Z",
+    "player": "mmacfreier",
+    "round": 20
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-20T20:42:16.000Z",
+    "player": "mmacfreier",
+    "round": 20
+  },
+  {
+    "message": "Round 21 started.",
+    "timestamp": "2016-01-20T20:42:16.000Z",
+    "player": "unknown",
+    "round": 21
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-20T20:42:23.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "jobratt received 19 troops for 58 territories.",
+    "timestamp": "2016-01-20T20:42:23.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "jobratt received 2 troops for holding T Region.",
+    "timestamp": "2016-01-20T20:42:23.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "jobratt received 2 troops for holding D Region.",
+    "timestamp": "2016-01-20T20:42:23.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "jobratt received 3 troops for holding W Region.",
+    "timestamp": "2016-01-20T20:42:23.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "jobratt received 5 troops for holding V Region.",
+    "timestamp": "2016-01-20T20:42:23.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "jobratt received 5 troops for holding E Region.",
+    "timestamp": "2016-01-20T20:42:23.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "jobratt received 3 troops for holding F Region.",
+    "timestamp": "2016-01-20T20:42:23.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "jobratt received 2 troops on Sache",
+    "timestamp": "2016-01-20T20:42:27.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "jobratt received 2 troops on Sucana",
+    "timestamp": "2016-01-20T20:42:27.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "jobratt received 2 troops on Vy",
+    "timestamp": "2016-01-20T20:42:27.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "Ottel (jobratt) was reinforced by jobratt with 47 troops.",
+    "timestamp": "2016-01-20T20:42:30.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "Ottel (jobratt) attacked Ord (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:42:58.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "Ottel (jobratt) occupied Ord with 52 troops.",
+    "timestamp": "2016-01-20T20:43:00.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "Ord (jobratt) attacked Off (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:43:03.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "Ord (jobratt) occupied Off with 51 troops.",
+    "timestamp": "2016-01-20T20:43:04.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "Off (jobratt) attacked Ohma (mmacfreier) conquering it, killing 10, losing 5.",
+    "timestamp": "2016-01-20T20:43:08.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "Off (jobratt) occupied Ohma with 45 troops.",
+    "timestamp": "2016-01-20T20:43:17.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "Sache (jobratt) attacked Sulodoop (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-20T20:43:20.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "Sache (jobratt) occupied Sulodoop with 2 troops.",
+    "timestamp": "2016-01-20T20:43:21.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "Sulodoop (jobratt) attacked Co (mmacfreier) killing 0, losing 1.",
+    "timestamp": "2016-01-20T20:43:23.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "Sulodoop (jobratt) was fortified from Ohma (jobratt) with 44 troops.",
+    "timestamp": "2016-01-20T20:43:28.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-20T20:43:28.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-20T20:43:28.000Z",
+    "player": "jobratt",
+    "round": 21
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-20T20:43:32.000Z",
+    "player": "mmacfreier",
+    "round": 21
+  },
+  {
+    "message": "mmacfreier received 3 troops for 1 territory.",
+    "timestamp": "2016-01-20T20:43:32.000Z",
+    "player": "mmacfreier",
+    "round": 21
+  },
+  {
+    "message": "Co (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-20T20:43:35.000Z",
+    "player": "mmacfreier",
+    "round": 21
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-20T20:43:38.000Z",
+    "player": "mmacfreier",
+    "round": 21
+  },
+  {
+    "message": "Round 22 started.",
+    "timestamp": "2016-01-20T20:43:38.000Z",
+    "player": "unknown",
+    "round": 22
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-20T20:43:44.000Z",
+    "player": "jobratt",
+    "round": 22
+  },
+  {
+    "message": "jobratt received 20 troops for 62 territories.",
+    "timestamp": "2016-01-20T20:43:44.000Z",
+    "player": "jobratt",
+    "round": 22
+  },
+  {
+    "message": "jobratt received 2 troops for holding T Region.",
+    "timestamp": "2016-01-20T20:43:44.000Z",
+    "player": "jobratt",
+    "round": 22
+  },
+  {
+    "message": "jobratt received 2 troops for holding D Region.",
+    "timestamp": "2016-01-20T20:43:44.000Z",
+    "player": "jobratt",
+    "round": 22
+  },
+  {
+    "message": "jobratt received 3 troops for holding W Region.",
+    "timestamp": "2016-01-20T20:43:44.000Z",
+    "player": "jobratt",
+    "round": 22
+  },
+  {
+    "message": "jobratt received 5 troops for holding V Region.",
+    "timestamp": "2016-01-20T20:43:44.000Z",
+    "player": "jobratt",
+    "round": 22
+  },
+  {
+    "message": "jobratt received 5 troops for holding E Region.",
+    "timestamp": "2016-01-20T20:43:44.000Z",
+    "player": "jobratt",
+    "round": 22
+  },
+  {
+    "message": "jobratt received 3 troops for holding F Region.",
+    "timestamp": "2016-01-20T20:43:44.000Z",
+    "player": "jobratt",
+    "round": 22
+  },
+  {
+    "message": "jobratt received 4 troops for holding O Region.",
+    "timestamp": "2016-01-20T20:43:44.000Z",
+    "player": "jobratt",
+    "round": 22
+  },
+  {
+    "message": "jobratt received 5 troops for holding S Region.",
+    "timestamp": "2016-01-20T20:43:44.000Z",
+    "player": "jobratt",
+    "round": 22
+  },
+  {
+    "message": "Sulodoop (jobratt) was reinforced by jobratt with 49 troops.",
+    "timestamp": "2016-01-20T20:43:45.000Z",
+    "player": "jobratt",
+    "round": 22
+  },
+  {
+    "message": "Sulodoop (jobratt) attacked Co (mmacfreier) conquering it, killing 7, losing 1.",
+    "timestamp": "2016-01-20T20:43:49.000Z",
+    "player": "jobratt",
+    "round": 22
+  },
+  {
+    "message": "mmacfreier was defeated by jobratt.",
+    "timestamp": "2016-01-20T20:43:49.000Z",
+    "player": "mmacfreier",
+    "round": 22
+  },
+  {
+    "message": "Game finished.",
+    "timestamp": "2016-01-20T20:43:49.000Z",
+    "player": "unknown",
+    "round": 22
+  },
+  {
+    "message": "jobratt won the game.",
+    "timestamp": "2016-01-20T20:43:49.000Z",
+    "player": "jobratt",
+    "round": 22
+  },
+  {
+    "message": "jobratt received 90 rating.",
+    "timestamp": "2016-01-20T20:43:49.000Z",
+    "player": "jobratt",
+    "round": 22
+  },
+  {
+    "message": "jobratt received 20 tokens.",
+    "timestamp": "2016-01-20T20:43:49.000Z",
+    "player": "jobratt",
+    "round": 22
+  },
+  {
+    "message": "ryanbmilbourne lost 17 rating.",
+    "timestamp": "2016-01-20T20:43:49.000Z",
+    "player": "ryanbmilbourne",
+    "round": 22
+  },
+  {
+    "message": "ryanbmilbourne received 20 tokens.",
+    "timestamp": "2016-01-20T20:43:49.000Z",
+    "player": "ryanbmilbourne",
+    "round": 22
+  },
+  {
+    "message": "mmacfreier lost 24 rating.",
+    "timestamp": "2016-01-20T20:43:49.000Z",
+    "player": "mmacfreier",
+    "round": 22
+  },
+  {
+    "message": "mmacfreier received 20 tokens.",
+    "timestamp": "2016-01-20T20:43:49.000Z",
+    "player": "mmacfreier",
+    "round": 22
+  },
+  {
+    "message": "kwren lost 17 rating.",
+    "timestamp": "2016-01-20T20:43:49.000Z",
+    "player": "kwren",
+    "round": 22
+  },
+  {
+    "message": "kwren received 20 tokens.",
+    "timestamp": "2016-01-20T20:43:49.000Z",
+    "player": "kwren",
+    "round": 22
+  },
+  {
+    "message": "tanleach1001 lost 18 rating.",
+    "timestamp": "2016-01-20T20:43:49.000Z",
+    "player": "tanleach1001",
+    "round": 22
+  },
+  {
+    "message": "tanleach1001 received 20 tokens.",
+    "timestamp": "2016-01-20T20:43:49.000Z",
+    "player": "tanleach1001",
+    "round": 22
+  },
+  {
+    "message": "gcochard lost 14 rating.",
+    "timestamp": "2016-01-20T20:43:49.000Z",
+    "player": "gcochard",
+    "round": 22
+  },
+  {
+    "message": "gcochard received 20 tokens.",
+    "timestamp": "2016-01-20T20:43:49.000Z",
+    "player": "gcochard",
+    "round": 22
+  },
+  {
+    "message": "ryanbmilbourne received 4 troops for turning in cards Trax, Don, and Spork.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "ryanbmilbourne",
+    "round": 22
+  },
+  {
+    "message": "mmacfreier received 6 troops for turning in cards Sulodoop, Co, and Fado.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "mmacfreier",
+    "round": 22
+  },
+  {
+    "message": "kwren received 8 troops for turning in cards Vhown, Dri, and Cid.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 22
+  },
+  {
+    "message": "tanleach1001 received 8 troops for turning in cards Wa, Sart, and Ohma.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "tanleach1001",
+    "round": 22
+  },
+  {
+    "message": "gcochard received 8 troops for turning in cards Vreen, Octa, and Oatgol.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "gcochard",
+    "round": 22
+  },
+  {
+    "message": "jobratt received 8 troops for turning in cards Welk, Woxan, and Oshgrind.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "jobratt",
+    "round": 22
+  },
+  {
+    "message": "jobratt received 8 troops for turning in cards Echo, Emb, and Fulcon.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "jobratt",
+    "round": 22
+  },
+  {
+    "message": "mmacfreier received 8 troops for turning in cards Vy, Cei, and Flinn.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "mmacfreier",
+    "round": 22
+  },
+  {
+    "message": "tanleach1001 received 8 troops for turning in cards Vabon, Eong, and Off.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "tanleach1001",
+    "round": 22
+  },
+  {
+    "message": "gcochard received 8 troops for turning in cards Tuloe, Cal, and Fud.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "gcochard",
+    "round": 22
+  },
+  {
+    "message": "ryanbmilbourne received 8 troops for turning in cards Erdus, Engrash, and Walkon.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "ryanbmilbourne",
+    "round": 22
+  },
+  {
+    "message": "kwren received 8 troops for turning in cards Dune, Clutch, and So.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 22
+  },
+  {
+    "message": "kwren received 8 troops for turning in cards Doustmon, Elitt, and Sache.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 22
+  },
+  {
+    "message": "jobratt received 8 troops for turning in cards Vim, Enbrum, and Ottel.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "jobratt",
+    "round": 22
+  },
+  {
+    "message": "mmacfreier received 8 troops for turning in cards Traln, Du, and Culd.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "mmacfreier",
+    "round": 22
+  },
+  {
+    "message": "ryanbmilbourne received 8 troops for turning in cards Eglo, Sucana, and Finch.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "ryanbmilbourne",
+    "round": 22
+  },
+  {
+    "message": "jobratt received 8 troops for turning in cards Vahn, Vua, and Setha.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "jobratt",
+    "round": 22
+  },
+  {
+    "message": "kwren received 8 troops for turning in cards Spot, Odpewn, and Onbri.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 22
+  },
+  {
+    "message": "jobratt received 8 troops for turning in cards Vupano, Tripoc, and Vebn.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "jobratt",
+    "round": 22
+  },
+  {
+    "message": "mmacfreier received 8 troops for turning in cards Ewenn, Wun, and Fud.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "mmacfreier",
+    "round": 22
+  },
+  {
+    "message": "kwren received 8 troops for turning in cards Engrash, Whist, and Flinn.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 22
+  },
+  {
+    "message": "ryanbmilbourne received 8 troops for turning in cards Du, Ohma, and Erdus.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "ryanbmilbourne",
+    "round": 22
+  },
+  {
+    "message": "jobratt received 8 troops for turning in cards Oshgrind, Dune, and Clutch.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "jobratt",
+    "round": 22
+  },
+  {
+    "message": "kwren received 8 troops for turning in cards Dri, Woxan, and Co.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 22
+  },
+  {
+    "message": "kwren received 8 troops for turning in cards Taulk, Ord, and Cid.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 22
+  },
+  {
+    "message": "jobratt received 8 troops for turning in cards Fado, Sulodoop, and Vahn.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "jobratt",
+    "round": 22
+  },
+  {
+    "message": "jobratt received 8 troops for turning in cards Sache, Sucana, and Vy.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "jobratt",
+    "round": 22
+  }
+]

--- a/data/605828.json
+++ b/data/605828.json
@@ -1,0 +1,4730 @@
+[
+  {
+    "message": "Game created.",
+    "timestamp": "2016-01-21T17:18:46.000Z",
+    "player": "unknown",
+    "round": 0
+  },
+  {
+    "message": "jobratt joined the game.",
+    "timestamp": "2016-01-21T17:18:46.000Z",
+    "player": "jobratt",
+    "round": 0
+  },
+  {
+    "message": "ryanbmilbourne joined the game.",
+    "timestamp": "2016-01-21T17:24:09.000Z",
+    "player": "ryanbmilbourne",
+    "round": 0
+  },
+  {
+    "message": "tanleach1001 joined the game.",
+    "timestamp": "2016-01-21T17:24:22.000Z",
+    "player": "tanleach1001",
+    "round": 0
+  },
+  {
+    "message": "kwren joined the game.",
+    "timestamp": "2016-01-21T17:24:42.000Z",
+    "player": "kwren",
+    "round": 0
+  },
+  {
+    "message": "mmacfreier joined the game.",
+    "timestamp": "2016-01-21T17:42:25.000Z",
+    "player": "mmacfreier",
+    "round": 0
+  },
+  {
+    "message": "gcochard joined the game.",
+    "timestamp": "2016-01-21T17:47:24.000Z",
+    "player": "gcochard",
+    "round": 0
+  },
+  {
+    "message": "Game started.",
+    "timestamp": "2016-01-21T17:47:25.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-21T17:56:33.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 9 territories.",
+    "timestamp": "2016-01-21T17:56:33.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Novgorod (tanleach1001) was reinforced by tanleach1001 with 3 troops.",
+    "timestamp": "2016-01-21T17:58:16.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Novgorod (tanleach1001) attacked Finland (ryanbmilbourne) killing 0, losing 4.",
+    "timestamp": "2016-01-21T17:58:20.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Norway (tanleach1001) attacked Denmark (gcochard) killing 0, losing 2.",
+    "timestamp": "2016-01-21T17:58:41.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-21T17:59:19.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-21T18:01:54.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "jobratt received 3 troops for 9 territories.",
+    "timestamp": "2016-01-21T18:01:54.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Switzerland (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-01-21T18:02:00.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Switzerland (jobratt) attacked S. Rhine (gcochard) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-21T18:02:04.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Switzerland (jobratt) occupied S. Rhine with 3 troops.",
+    "timestamp": "2016-01-21T18:02:13.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "N. Rhine (jobratt) was fortified from Galacia (jobratt) with 2 troops.",
+    "timestamp": "2016-01-21T18:02:46.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-21T18:02:46.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-21T18:02:46.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-21T18:10:46.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 9 territories.",
+    "timestamp": "2016-01-21T18:10:46.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Portugal (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-21T18:11:43.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Portugal (ryanbmilbourne) attacked Madrid (kwren) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-21T18:11:59.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Portugal (ryanbmilbourne) occupied Madrid with 1 troop.",
+    "timestamp": "2016-01-21T18:12:07.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Wales (ryanbmilbourne) was fortified from Ireland (ryanbmilbourne) with 1 troop.",
+    "timestamp": "2016-01-21T18:12:46.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-21T18:12:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-21T18:12:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-21T19:42:10.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren received 3 troops for 8 territories.",
+    "timestamp": "2016-01-21T19:42:10.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Burgandy (kwren) was reinforced by kwren with 3 troops.",
+    "timestamp": "2016-01-21T19:44:44.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Burgandy (kwren) attacked Provence (mmacfreier) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-21T19:44:51.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Burgandy (kwren) occupied Provence with 4 troops.",
+    "timestamp": "2016-01-21T19:44:56.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Provence (kwren) was fortified from Germania (kwren) with 2 troops.",
+    "timestamp": "2016-01-21T19:45:12.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-21T19:45:12.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-21T19:45:12.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-21T19:47:19.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard received 3 troops for 8 territories.",
+    "timestamp": "2016-01-21T19:47:19.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Naples (gcochard) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-01-21T19:47:30.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Naples (gcochard) attacked Sicily (jobratt) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-21T19:47:35.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Naples (gcochard) occupied Sicily with 1 troop.",
+    "timestamp": "2016-01-21T19:47:42.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Naples (gcochard) was fortified from Greece (gcochard) with 2 troops.",
+    "timestamp": "2016-01-21T19:48:50.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-21T19:48:50.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-21T19:48:50.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-21T19:51:09.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier received 3 troops for 8 territories.",
+    "timestamp": "2016-01-21T19:51:09.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Turkey (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-21T19:52:52.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Turkey (mmacfreier) attacked Bulgaria (kwren) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-21T19:52:57.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Turkey (mmacfreier) occupied Bulgaria with 5 troops.",
+    "timestamp": "2016-01-21T19:53:08.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Wallachia (mmacfreier) was fortified from Bulgaria (mmacfreier) with 4 troops.",
+    "timestamp": "2016-01-21T19:53:42.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-21T19:53:42.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-21T19:53:42.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Round 2 started.",
+    "timestamp": "2016-01-21T19:53:42.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-21T19:54:29.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 9 territories.",
+    "timestamp": "2016-01-21T19:54:29.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Candia (tanleach1001) was reinforced by tanleach1001 with 3 troops.",
+    "timestamp": "2016-01-21T19:54:35.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Candia (tanleach1001) attacked Turkey (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-21T19:54:40.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Candia (tanleach1001) occupied Turkey with 5 troops.",
+    "timestamp": "2016-01-21T19:55:10.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Turkey (tanleach1001) attacked Bulgaria (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-21T19:55:14.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Turkey (tanleach1001) occupied Bulgaria with 4 troops.",
+    "timestamp": "2016-01-21T19:55:16.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Bosnia (tanleach1001) attacked Greece (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-21T19:55:59.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Bosnia (tanleach1001) occupied Greece with 1 troop.",
+    "timestamp": "2016-01-21T19:56:09.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-21T19:57:30.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-21T19:57:30.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-21T19:59:47.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "jobratt received 3 troops for 9 territories.",
+    "timestamp": "2016-01-21T19:59:47.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "S. Rhine (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-01-21T19:59:49.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "N. Rhine (jobratt) attacked Germania (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-21T19:59:55.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "N. Rhine (jobratt) occupied Germania with 1 troop.",
+    "timestamp": "2016-01-21T20:00:03.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "S. Rhine (jobratt) attacked Illyria (kwren) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-01-21T20:00:07.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "S. Rhine (jobratt) occupied Illyria with 3 troops.",
+    "timestamp": "2016-01-21T20:00:16.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "S. Rhine (jobratt) was fortified from Silesia (jobratt) with 2 troops.",
+    "timestamp": "2016-01-21T20:01:01.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-21T20:01:02.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-21T20:01:02.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-21T20:03:06.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 10 territories.",
+    "timestamp": "2016-01-21T20:03:06.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Wales (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-21T20:03:32.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Wales (ryanbmilbourne) attacked Scotland (jobratt) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-01-21T20:03:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Wales (ryanbmilbourne) occupied Scotland with 2 troops.",
+    "timestamp": "2016-01-21T20:03:57.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Wales (ryanbmilbourne) was fortified from Ireland (ryanbmilbourne) with 1 troop.",
+    "timestamp": "2016-01-21T20:04:27.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-21T20:04:27.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-21T20:04:27.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-21T23:01:42.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "kwren received 3 troops for 6 territories.",
+    "timestamp": "2016-01-21T23:01:42.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Provence (kwren) was reinforced by kwren with 3 troops.",
+    "timestamp": "2016-01-21T23:01:47.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Provence (kwren) attacked Normandy (tanleach1001) conquering it, killing 3, losing 6.",
+    "timestamp": "2016-01-21T23:01:58.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Provence (kwren) occupied Normandy with 2 troops.",
+    "timestamp": "2016-01-21T23:02:01.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-21T23:04:05.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-21T23:04:05.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-21T23:06:50.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "gcochard received 3 troops for 8 territories.",
+    "timestamp": "2016-01-21T23:06:50.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Naples (gcochard) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-01-21T23:07:03.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Naples (gcochard) attacked Italy (mmacfreier) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-21T23:07:17.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Naples (gcochard) occupied Italy with 7 troops.",
+    "timestamp": "2016-01-21T23:07:32.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Italy (gcochard) attacked Rome (kwren) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-21T23:07:39.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Italy (gcochard) occupied Rome with 2 troops.",
+    "timestamp": "2016-01-21T23:07:59.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Naples (gcochard) was fortified from Italy (gcochard) with 2 troops.",
+    "timestamp": "2016-01-21T23:08:19.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-21T23:08:19.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-21T23:08:19.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-22T01:15:28.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier received 3 troops for 6 territories.",
+    "timestamp": "2016-01-22T01:15:28.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Wallachia (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-22T01:16:19.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Wallachia (mmacfreier) attacked Moldavia (tanleach1001) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-01-22T01:16:25.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Wallachia (mmacfreier) occupied Moldavia with 7 troops.",
+    "timestamp": "2016-01-22T01:16:27.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Moldavia (mmacfreier) attacked Little Russia (ryanbmilbourne) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-01-22T01:16:33.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Moldavia (mmacfreier) occupied Little Russia with 4 troops.",
+    "timestamp": "2016-01-22T01:16:34.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Corsica (mmacfreier) was fortified from Balearic Islands (mmacfreier) with 2 troops.",
+    "timestamp": "2016-01-22T01:17:14.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-22T01:17:15.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-22T01:17:15.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Round 3 started.",
+    "timestamp": "2016-01-22T01:17:15.000Z",
+    "player": "unknown",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-22T15:07:00.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 10 territories.",
+    "timestamp": "2016-01-22T15:07:00.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Bulgaria (tanleach1001) was reinforced by tanleach1001 with 3 troops.",
+    "timestamp": "2016-01-22T15:07:15.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Bulgaria (tanleach1001) attacked Wallachia (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T15:07:21.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Bulgaria (tanleach1001) occupied Wallachia with 6 troops.",
+    "timestamp": "2016-01-22T15:07:22.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Wallachia (tanleach1001) attacked Moldavia (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T15:07:28.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Wallachia (tanleach1001) occupied Moldavia with 1 troop.",
+    "timestamp": "2016-01-22T15:07:39.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Bosnia (tanleach1001) was fortified from Wallachia (tanleach1001) with 1 troop.",
+    "timestamp": "2016-01-22T15:12:02.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-22T15:12:02.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-22T15:12:02.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-22T16:57:02.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt received 3 troops for 10 territories.",
+    "timestamp": "2016-01-22T16:57:02.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt received 4 troops for holding Central Europe.",
+    "timestamp": "2016-01-22T16:57:02.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Netherlands (jobratt) was reinforced by jobratt with 2 troops.",
+    "timestamp": "2016-01-22T16:59:05.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "N. Rhine (jobratt) was reinforced by jobratt with 2 troops.",
+    "timestamp": "2016-01-22T16:59:19.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Illyria (jobratt) was reinforced by jobratt with 1 troop.",
+    "timestamp": "2016-01-22T17:00:09.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Switzerland (jobratt) was reinforced by jobratt with 2 troops.",
+    "timestamp": "2016-01-22T17:00:36.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Switzerland (jobratt) attacked Burgandy (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T17:00:44.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Switzerland (jobratt) occupied Burgandy with 1 troop.",
+    "timestamp": "2016-01-22T17:00:48.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-22T17:01:00.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-22T17:01:00.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-22T17:08:56.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 10 territories.",
+    "timestamp": "2016-01-22T17:08:56.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Wales (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-22T17:09:12.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Wales (ryanbmilbourne) attacked England (kwren) killing 0, losing 4.",
+    "timestamp": "2016-01-22T17:09:19.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Scotland (ryanbmilbourne) attacked England (kwren) killing 0, losing 1.",
+    "timestamp": "2016-01-22T17:09:26.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Sweden (ryanbmilbourne) attacked Norway (tanleach1001) killing 0, losing 2.",
+    "timestamp": "2016-01-22T17:09:30.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Bohemia (ryanbmilbourne) attacked Galacia (jobratt) killing 0, losing 2.",
+    "timestamp": "2016-01-22T17:10:03.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-22T17:10:28.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-22T17:10:43.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren received 3 troops for 5 territories.",
+    "timestamp": "2016-01-22T17:10:43.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "England (kwren) was reinforced by kwren with 3 troops.",
+    "timestamp": "2016-01-22T17:11:12.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "England (kwren) attacked Paris (mmacfreier) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-01-22T17:11:18.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "England (kwren) occupied Paris with 3 troops.",
+    "timestamp": "2016-01-22T17:11:22.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Normandy (kwren) was fortified from Paris (kwren) with 2 troops.",
+    "timestamp": "2016-01-22T17:12:04.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-22T17:12:04.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-22T17:12:04.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-22T17:19:46.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard received 3 troops for 10 territories.",
+    "timestamp": "2016-01-22T17:19:46.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard received 3 troops for holding Italy.",
+    "timestamp": "2016-01-22T17:19:46.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Sardinia (gcochard) was reinforced by gcochard with 6 troops.",
+    "timestamp": "2016-01-22T17:20:43.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Sardinia (gcochard) attacked Balearic Islands (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T17:20:47.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Sardinia (gcochard) occupied Balearic Islands with 8 troops.",
+    "timestamp": "2016-01-22T17:20:50.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Balearic Islands (gcochard) attacked Corsica (mmacfreier) conquering it, killing 5, losing 3.",
+    "timestamp": "2016-01-22T17:20:58.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Balearic Islands (gcochard) occupied Corsica with 4 troops.",
+    "timestamp": "2016-01-22T17:21:01.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Esthonia (gcochard) was fortified from White Russia (gcochard) with 2 troops.",
+    "timestamp": "2016-01-22T17:22:06.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-22T17:22:06.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-22T17:22:06.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-22T17:40:38.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier received 3 troops for 3 territories.",
+    "timestamp": "2016-01-22T17:40:38.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Little Russia (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-22T17:40:56.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Little Russia (mmacfreier) attacked Bielgorod (tanleach1001) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-22T17:41:01.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Little Russia (mmacfreier) occupied Bielgorod with 1 troop.",
+    "timestamp": "2016-01-22T17:41:25.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Moscovy (mmacfreier) was fortified from Little Russia (mmacfreier) with 5 troops.",
+    "timestamp": "2016-01-22T17:41:32.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-22T17:41:32.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-22T17:41:32.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Round 4 started.",
+    "timestamp": "2016-01-22T17:41:32.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-22T17:41:42.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 11 territories.",
+    "timestamp": "2016-01-22T17:41:42.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Ottoman Empire.",
+    "timestamp": "2016-01-22T17:41:42.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Moldavia (tanleach1001) was reinforced by tanleach1001 with 4 troops.",
+    "timestamp": "2016-01-22T17:43:13.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Bosnia (tanleach1001) was reinforced by tanleach1001 with 1 troop.",
+    "timestamp": "2016-01-22T17:43:27.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Wallachia (tanleach1001) was reinforced by tanleach1001 with 1 troop.",
+    "timestamp": "2016-01-22T17:43:30.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Moldavia (tanleach1001) attacked Little Russia (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T17:43:42.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Moldavia (tanleach1001) occupied Little Russia with 4 troops.",
+    "timestamp": "2016-01-22T17:43:50.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Little Russia (tanleach1001) attacked Galacia (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T17:43:54.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Little Russia (tanleach1001) occupied Galacia with 3 troops.",
+    "timestamp": "2016-01-22T17:43:56.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-22T17:44:55.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-22T17:44:55.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-22T18:14:09.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "jobratt received 3 troops for 10 territories.",
+    "timestamp": "2016-01-22T18:14:09.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "jobratt received 4 troops for holding Central Europe.",
+    "timestamp": "2016-01-22T18:14:09.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Netherlands (jobratt) was reinforced by jobratt with 11 troops.",
+    "timestamp": "2016-01-22T18:14:23.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Netherlands (jobratt) attacked England (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T18:14:35.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Netherlands (jobratt) occupied England with 15 troops.",
+    "timestamp": "2016-01-22T18:14:36.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "England (jobratt) attacked Scotland (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T18:14:41.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "England (jobratt) occupied Scotland with 14 troops.",
+    "timestamp": "2016-01-22T18:14:50.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Scotland (jobratt) attacked Ireland (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T18:14:55.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Scotland (jobratt) occupied Ireland with 9 troops.",
+    "timestamp": "2016-01-22T18:15:15.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Ireland (jobratt) attacked Wales (ryanbmilbourne) conquering it, killing 3, losing 3.",
+    "timestamp": "2016-01-22T18:15:20.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Ireland (jobratt) occupied Wales with 5 troops.",
+    "timestamp": "2016-01-22T18:15:24.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "England (jobratt) was fortified from Wales (jobratt) with 4 troops.",
+    "timestamp": "2016-01-22T18:15:41.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-22T18:15:41.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-22T18:15:41.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-22T18:20:49.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 7 territories.",
+    "timestamp": "2016-01-22T18:20:49.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "Portugal (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-22T18:21:04.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "Portugal (ryanbmilbourne) attacked Andalusia (jobratt) conquering it, killing 3, losing 5.",
+    "timestamp": "2016-01-22T18:21:14.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "Madrid (ryanbmilbourne) was fortified from Catalonia (ryanbmilbourne) with 2 troops.",
+    "timestamp": "2016-01-22T18:21:44.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-22T18:21:44.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-22T18:21:44.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-22T18:21:50.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "kwren received 3 troops for 5 territories.",
+    "timestamp": "2016-01-22T18:21:50.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Normandy (kwren) was reinforced by kwren with 3 troops.",
+    "timestamp": "2016-01-22T18:21:59.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Normandy (kwren) attacked Gascony (tanleach1001) conquering it, killing 3, losing 3.",
+    "timestamp": "2016-01-22T18:22:05.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Normandy (kwren) occupied Gascony with 1 troop.",
+    "timestamp": "2016-01-22T18:22:08.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Normandy (kwren) attacked Burgandy (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T18:22:11.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Normandy (kwren) occupied Burgandy with 2 troops.",
+    "timestamp": "2016-01-22T18:22:13.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Provence (kwren) was fortified from Burgandy (kwren) with 1 troop.",
+    "timestamp": "2016-01-22T18:22:22.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-22T18:22:22.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-22T18:22:22.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-22T18:23:22.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard received 4 troops for 12 territories.",
+    "timestamp": "2016-01-22T18:23:22.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard received 3 troops for holding Italy.",
+    "timestamp": "2016-01-22T18:23:22.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard received 2 troops on Denmark",
+    "timestamp": "2016-01-22T18:25:38.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Denmark (gcochard) was reinforced by gcochard with 6 troops.",
+    "timestamp": "2016-01-22T18:26:04.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Warsaw (gcochard) was reinforced by gcochard with 4 troops.",
+    "timestamp": "2016-01-22T18:26:59.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Rome (gcochard) was reinforced by gcochard with 1 troop.",
+    "timestamp": "2016-01-22T18:27:11.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "White Russia (gcochard) was reinforced by gcochard with 2 troops.",
+    "timestamp": "2016-01-22T18:27:16.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Denmark (gcochard) attacked N. Rhine (jobratt) conquering it, killing 5, losing 6.",
+    "timestamp": "2016-01-22T18:27:30.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Denmark (gcochard) occupied N. Rhine with 4 troops.",
+    "timestamp": "2016-01-22T18:27:33.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "N. Rhine (gcochard) attacked Berlin (mmacfreier) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-22T18:27:45.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "N. Rhine (gcochard) occupied Berlin with 2 troops.",
+    "timestamp": "2016-01-22T18:27:47.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Warsaw (gcochard) attacked Lithuania (ryanbmilbourne) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-22T18:28:06.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Warsaw (gcochard) occupied Lithuania with 4 troops.",
+    "timestamp": "2016-01-22T18:28:15.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Berlin (gcochard) attacked Silesia (jobratt) killing 0, losing 1.",
+    "timestamp": "2016-01-22T18:28:19.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Esthonia (gcochard) attacked Novgorod (tanleach1001) killing 1, losing 4.",
+    "timestamp": "2016-01-22T18:28:29.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Berlin (gcochard) was fortified from White Russia (gcochard) with 2 troops.",
+    "timestamp": "2016-01-22T18:28:42.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-22T18:28:42.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-22T18:28:42.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-22T18:31:00.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier received 3 troops for 2 territories.",
+    "timestamp": "2016-01-22T18:31:00.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Moscovy (mmacfreier) was reinforced by mmacfreier with 11 troops.",
+    "timestamp": "2016-01-22T18:31:27.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Moscovy (mmacfreier) attacked Novgorod (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T18:31:30.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Moscovy (mmacfreier) occupied Novgorod with 18 troops.",
+    "timestamp": "2016-01-22T18:31:31.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Novgorod (mmacfreier) attacked White Russia (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T18:31:39.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Novgorod (mmacfreier) occupied White Russia with 14 troops.",
+    "timestamp": "2016-01-22T18:31:46.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "White Russia (mmacfreier) attacked Esthonia (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T18:31:50.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "White Russia (mmacfreier) occupied Esthonia with 9 troops.",
+    "timestamp": "2016-01-22T18:32:01.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Esthonia (mmacfreier) attacked Courland (kwren) conquering it, killing 3, losing 3.",
+    "timestamp": "2016-01-22T18:32:06.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Esthonia (mmacfreier) occupied Courland with 5 troops.",
+    "timestamp": "2016-01-22T18:32:08.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-22T18:32:23.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-22T18:32:23.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Round 5 started.",
+    "timestamp": "2016-01-22T18:32:23.000Z",
+    "player": "unknown",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-22T18:33:37.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 11 territories.",
+    "timestamp": "2016-01-22T18:33:37.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Ottoman Empire.",
+    "timestamp": "2016-01-22T18:33:37.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received 2 troops on Leon",
+    "timestamp": "2016-01-22T18:33:44.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Greece (tanleach1001) was reinforced by tanleach1001 with 7 troops.",
+    "timestamp": "2016-01-22T18:39:03.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Galacia (tanleach1001) was reinforced by tanleach1001 with 7 troops.",
+    "timestamp": "2016-01-22T18:39:27.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Greece (tanleach1001) attacked Naples (gcochard) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-22T18:39:34.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Greece (tanleach1001) occupied Naples with 7 troops.",
+    "timestamp": "2016-01-22T18:40:20.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Galacia (tanleach1001) attacked Austria (Neutral) conquering it, killing 3, losing 4.",
+    "timestamp": "2016-01-22T18:40:31.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Galacia (tanleach1001) occupied Austria with 1 troop.",
+    "timestamp": "2016-01-22T18:41:02.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Wallachia (tanleach1001) was fortified from Galacia (tanleach1001) with 3 troops.",
+    "timestamp": "2016-01-22T18:54:42.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-22T18:54:42.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-22T18:54:42.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-22T19:05:28.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "jobratt received 3 troops for 11 territories.",
+    "timestamp": "2016-01-22T19:05:28.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "jobratt received 2 troops for holding British Isles.",
+    "timestamp": "2016-01-22T19:05:28.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "S. Rhine (jobratt) was reinforced by jobratt with 5 troops.",
+    "timestamp": "2016-01-22T19:05:55.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "S. Rhine (jobratt) attacked N. Rhine (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T19:05:58.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "S. Rhine (jobratt) occupied N. Rhine with 5 troops.",
+    "timestamp": "2016-01-22T19:06:33.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Scotland (jobratt) attacked Denmark (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T19:12:23.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Scotland (jobratt) occupied Denmark with 4 troops.",
+    "timestamp": "2016-01-22T19:12:26.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "S. Rhine (jobratt) was fortified from England (jobratt) with 4 troops.",
+    "timestamp": "2016-01-22T19:13:24.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-22T19:13:24.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-22T19:13:24.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-22T19:19:46.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 7 territories.",
+    "timestamp": "2016-01-22T19:19:46.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Madrid (ryanbmilbourne) was reinforced by ryanbmilbourne with 11 troops.",
+    "timestamp": "2016-01-22T19:20:18.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Madrid (ryanbmilbourne) attacked Balearic Islands (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T19:20:23.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Madrid (ryanbmilbourne) occupied Balearic Islands with 1 troop.",
+    "timestamp": "2016-01-22T19:20:28.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Madrid (ryanbmilbourne) attacked Leon\t (tanleach1001) conquering it, killing 5, losing 10.",
+    "timestamp": "2016-01-22T19:20:43.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Madrid (ryanbmilbourne) occupied Leon\t with 2 troops.",
+    "timestamp": "2016-01-22T19:20:44.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-22T19:20:55.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-22T19:20:55.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-22T19:49:33.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received 3 troops for 6 territories.",
+    "timestamp": "2016-01-22T19:49:33.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Provence (kwren) was reinforced by kwren with 11 troops.",
+    "timestamp": "2016-01-22T19:49:41.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Provence (kwren) attacked Corsica (gcochard) conquering it, killing 4, losing 0.",
+    "timestamp": "2016-01-22T19:49:47.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Provence (kwren) occupied Corsica with 12 troops.",
+    "timestamp": "2016-01-22T19:49:50.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-22T19:50:28.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-22T19:50:28.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-22T19:59:46.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "gcochard received 3 troops for 8 territories.",
+    "timestamp": "2016-01-22T19:59:46.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Italy (gcochard) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-01-22T20:00:02.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Berlin (gcochard) attacked Silesia (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T20:00:19.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Berlin (gcochard) occupied Silesia with 1 troop.",
+    "timestamp": "2016-01-22T20:00:34.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Silesia (gcochard) was fortified from Prussia (gcochard) with 2 troops.",
+    "timestamp": "2016-01-22T20:01:01.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-22T20:01:04.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-22T20:01:04.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-22T20:22:45.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier received 3 troops for 6 territories.",
+    "timestamp": "2016-01-22T20:22:45.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Bielgorod (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-22T20:23:09.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Bielgorod (mmacfreier) attacked Podlesia (jobratt) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-22T20:23:15.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Bielgorod (mmacfreier) occupied Podlesia with 2 troops.",
+    "timestamp": "2016-01-22T20:23:24.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-22T20:23:28.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-22T20:23:28.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Round 6 started.",
+    "timestamp": "2016-01-22T20:23:28.000Z",
+    "player": "unknown",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-22T20:24:06.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 received 4 troops for 12 territories.",
+    "timestamp": "2016-01-22T20:24:06.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Ottoman Empire.",
+    "timestamp": "2016-01-22T20:24:06.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Austria (tanleach1001) was reinforced by tanleach1001 with 5 troops.",
+    "timestamp": "2016-01-22T20:25:03.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Naples (tanleach1001) was reinforced by tanleach1001 with 2 troops.",
+    "timestamp": "2016-01-22T20:25:07.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Austria (tanleach1001) attacked Hungary (kwren) killing 0, losing 4.",
+    "timestamp": "2016-01-22T20:25:12.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Naples (tanleach1001) attacked Sicily (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T20:25:22.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Naples (tanleach1001) occupied Sicily with 8 troops.",
+    "timestamp": "2016-01-22T20:25:27.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Sicily (tanleach1001) attacked Sardinia (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T20:25:32.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Sicily (tanleach1001) occupied Sardinia with 6 troops.",
+    "timestamp": "2016-01-22T20:25:35.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Sardinia (tanleach1001) attacked Balearic Islands (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T20:25:39.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Sardinia (tanleach1001) occupied Balearic Islands with 1 troop.",
+    "timestamp": "2016-01-22T20:25:43.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Naples (tanleach1001) was fortified from Sardinia (tanleach1001) with 4 troops.",
+    "timestamp": "2016-01-22T20:26:02.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-22T20:26:02.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-22T20:26:02.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-22T20:30:23.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "jobratt received 3 troops for 11 territories.",
+    "timestamp": "2016-01-22T20:30:23.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "jobratt received 2 troops for holding British Isles.",
+    "timestamp": "2016-01-22T20:30:23.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "jobratt received 4 troops for holding Central Europe.",
+    "timestamp": "2016-01-22T20:30:23.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Denmark (jobratt) was reinforced by jobratt with 9 troops.",
+    "timestamp": "2016-01-22T20:30:53.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Denmark (jobratt) attacked Sweden (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T20:31:00.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Denmark (jobratt) occupied Sweden with 11 troops.",
+    "timestamp": "2016-01-22T20:31:01.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Sweden (jobratt) attacked Finland (ryanbmilbourne) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-22T20:31:06.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Sweden (jobratt) occupied Finland with 1 troop.",
+    "timestamp": "2016-01-22T20:31:10.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "N. Rhine (jobratt) attacked Bohemia (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T20:31:17.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "N. Rhine (jobratt) occupied Bohemia with 1 troop.",
+    "timestamp": "2016-01-22T20:31:21.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Sweden (jobratt) attacked Norway (tanleach1001) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-22T20:31:26.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Sweden (jobratt) occupied Norway with 1 troop.",
+    "timestamp": "2016-01-22T20:31:29.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Sweden (jobratt) attacked Berlin (gcochard) conquering it, killing 2, losing 0.",
+    "timestamp": "2016-01-22T20:31:36.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Sweden (jobratt) occupied Berlin with 6 troops.",
+    "timestamp": "2016-01-22T20:31:45.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Finland (jobratt) was fortified from Switzerland (jobratt) with 3 troops.",
+    "timestamp": "2016-01-22T20:32:33.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-22T20:32:33.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-22T20:32:33.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-22T20:32:52.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 5 territories.",
+    "timestamp": "2016-01-22T20:32:53.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Madrid (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-22T20:33:06.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Madrid (ryanbmilbourne) attacked Balearic Islands (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T20:33:11.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Madrid (ryanbmilbourne) occupied Balearic Islands with 2 troops.",
+    "timestamp": "2016-01-22T20:33:13.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Balearic Islands (ryanbmilbourne) was fortified from Leon\t (ryanbmilbourne) with 1 troop.",
+    "timestamp": "2016-01-22T20:33:18.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-22T20:33:18.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-22T20:33:18.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-22T20:33:34.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 3 troops for 7 territories.",
+    "timestamp": "2016-01-22T20:33:34.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 3 troops for holding France.",
+    "timestamp": "2016-01-22T20:33:34.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Corsica (kwren) was reinforced by kwren with 6 troops.",
+    "timestamp": "2016-01-22T20:33:37.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Corsica (kwren) attacked Sardinia (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T20:33:52.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Corsica (kwren) occupied Sardinia with 17 troops.",
+    "timestamp": "2016-01-22T20:33:53.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Sardinia (kwren) attacked Balearic Islands (ryanbmilbourne) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-01-22T20:34:09.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Sardinia (kwren) occupied Balearic Islands with 14 troops.",
+    "timestamp": "2016-01-22T20:34:11.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Balearic Islands (kwren) attacked Madrid (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T20:34:15.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Balearic Islands (kwren) occupied Madrid with 13 troops.",
+    "timestamp": "2016-01-22T20:34:17.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Madrid (kwren) attacked Leon\t (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T20:34:51.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Madrid (kwren) occupied Leon\t with 12 troops.",
+    "timestamp": "2016-01-22T20:34:56.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Leon\t (kwren) attacked Catalonia (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T20:34:59.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Leon\t (kwren) occupied Catalonia with 1 troop.",
+    "timestamp": "2016-01-22T20:35:04.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Leon\t (kwren) attacked Portugal (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T20:35:07.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Leon\t (kwren) occupied Portugal with 10 troops.",
+    "timestamp": "2016-01-22T20:35:08.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Portugal (kwren) attacked Andalusia (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T20:35:13.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne was defeated by kwren.",
+    "timestamp": "2016-01-22T20:35:13.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Portugal (kwren) occupied Andalusia with 1 troop.",
+    "timestamp": "2016-01-22T20:35:21.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Sardinia (kwren) was fortified from Portugal (kwren) with 7 troops.",
+    "timestamp": "2016-01-22T20:35:38.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-22T20:35:38.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-22T20:35:38.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-22T20:37:41.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "gcochard received 3 troops for 6 territories.",
+    "timestamp": "2016-01-22T20:37:41.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Silesia (gcochard) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-01-22T20:37:57.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Silesia (gcochard) attacked Berlin (jobratt) killing 5, losing 5.",
+    "timestamp": "2016-01-22T20:38:06.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Lithuania (gcochard) attacked Bielgorod (mmacfreier) killing 0, losing 3.",
+    "timestamp": "2016-01-22T20:38:18.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Warsaw (gcochard) attacked Galacia (tanleach1001) killing 0, losing 2.",
+    "timestamp": "2016-01-22T20:38:44.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Rome (gcochard) was fortified from Italy (gcochard) with 5 troops.",
+    "timestamp": "2016-01-22T20:40:09.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-22T20:40:09.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-22T20:40:22.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier received 3 troops for 7 territories.",
+    "timestamp": "2016-01-22T20:40:22.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Podlesia (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-22T20:40:27.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Podlesia (mmacfreier) attacked Little Russia (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T20:40:30.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Podlesia (mmacfreier) occupied Little Russia with 2 troops.",
+    "timestamp": "2016-01-22T20:41:04.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Little Russia (mmacfreier) was fortified from Courland (mmacfreier) with 1 troop.",
+    "timestamp": "2016-01-22T20:41:25.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-22T20:41:25.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-22T20:41:25.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Round 7 started.",
+    "timestamp": "2016-01-22T20:41:25.000Z",
+    "player": "unknown",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-22T20:41:29.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 11 territories.",
+    "timestamp": "2016-01-22T20:41:29.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Ottoman Empire.",
+    "timestamp": "2016-01-22T20:41:29.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Austria (tanleach1001) was reinforced by tanleach1001 with 6 troops.",
+    "timestamp": "2016-01-22T20:41:58.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Austria (tanleach1001) attacked Hungary (kwren) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-22T20:42:03.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Austria (tanleach1001) occupied Hungary with 1 troop.",
+    "timestamp": "2016-01-22T20:42:23.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Austria (tanleach1001) attacked Bohemia (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T20:42:28.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Austria (tanleach1001) occupied Bohemia with 3 troops.",
+    "timestamp": "2016-01-22T20:42:38.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Bosnia (tanleach1001) was fortified from Naples (tanleach1001) with 4 troops.",
+    "timestamp": "2016-01-22T20:43:08.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-22T20:43:09.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-22T20:43:09.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-22T20:49:08.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "jobratt received 5 troops for 15 territories.",
+    "timestamp": "2016-01-22T20:49:08.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "jobratt received 2 troops for holding British Isles.",
+    "timestamp": "2016-01-22T20:49:08.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "jobratt received 4 troops for holding Central Europe.",
+    "timestamp": "2016-01-22T20:49:08.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "jobratt received 2 troops for holding Denmark & Sweden.",
+    "timestamp": "2016-01-22T20:49:08.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Finland (jobratt) was reinforced by jobratt with 13 troops.",
+    "timestamp": "2016-01-22T20:50:04.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Finland (jobratt) attacked Novgorod (mmacfreier) conquering it, killing 4, losing 2.",
+    "timestamp": "2016-01-22T20:50:09.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Finland (jobratt) occupied Novgorod with 14 troops.",
+    "timestamp": "2016-01-22T20:50:11.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "N. Rhine (jobratt) was fortified from Novgorod (jobratt) with 5 troops.",
+    "timestamp": "2016-01-22T20:55:41.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-22T20:55:41.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-22T20:55:41.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-22T20:56:23.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren received 4 troops for 13 territories.",
+    "timestamp": "2016-01-22T20:56:23.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren received 3 troops for holding France.",
+    "timestamp": "2016-01-22T20:56:23.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren received 3 troops for holding Iberian Peninsula.",
+    "timestamp": "2016-01-22T20:56:23.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren received 2 troops on Corsica",
+    "timestamp": "2016-01-22T20:56:56.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Sardinia (kwren) was reinforced by kwren with 18 troops.",
+    "timestamp": "2016-01-22T20:57:00.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Sardinia (kwren) attacked Naples (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T20:57:28.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Sardinia (kwren) occupied Naples with 1 troop.",
+    "timestamp": "2016-01-22T20:57:33.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Balearic Islands (kwren) was fortified from Sardinia (kwren) with 24 troops.",
+    "timestamp": "2016-01-22T20:57:39.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-22T20:57:39.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-22T20:57:39.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-22T20:58:13.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "gcochard received 3 troops for 6 territories.",
+    "timestamp": "2016-01-22T20:58:13.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Silesia (gcochard) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-01-22T20:58:30.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Silesia (gcochard) attacked Berlin (jobratt) killing 0, losing 3.",
+    "timestamp": "2016-01-22T20:58:35.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Rome (gcochard) attacked Naples (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T20:58:43.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Rome (gcochard) occupied Naples with 6 troops.",
+    "timestamp": "2016-01-22T20:58:47.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Naples (gcochard) attacked Sicily (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T20:58:53.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Naples (gcochard) occupied Sicily with 4 troops.",
+    "timestamp": "2016-01-22T20:58:55.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Sicily (gcochard) attacked Sardinia (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T20:58:59.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Sicily (gcochard) occupied Sardinia with 3 troops.",
+    "timestamp": "2016-01-22T20:59:01.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Rome (gcochard) was fortified from Sardinia (gcochard) with 2 troops.",
+    "timestamp": "2016-01-22T20:59:27.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-22T20:59:27.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-22T20:59:27.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-22T21:00:39.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier received 3 troops for 7 territories.",
+    "timestamp": "2016-01-22T21:00:40.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Esthonia (mmacfreier) was reinforced by mmacfreier with 11 troops.",
+    "timestamp": "2016-01-22T21:01:46.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Esthonia (mmacfreier) attacked Novgorod (jobratt) killing 3, losing 11.",
+    "timestamp": "2016-01-22T21:01:56.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "White Russia (mmacfreier) attacked Lithuania (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T21:02:13.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "White Russia (mmacfreier) occupied Lithuania with 1 troop.",
+    "timestamp": "2016-01-22T21:02:17.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Esthonia (mmacfreier) was fortified from Courland (mmacfreier) with 3 troops.",
+    "timestamp": "2016-01-22T21:02:28.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-22T21:02:28.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-22T21:02:28.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Round 8 started.",
+    "timestamp": "2016-01-22T21:02:28.000Z",
+    "player": "unknown",
+    "round": 8
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-22T21:03:07.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 11 territories.",
+    "timestamp": "2016-01-22T21:03:07.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Ottoman Empire.",
+    "timestamp": "2016-01-22T21:03:07.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "tanleach1001 received 2 troops for holding Austrian Empire.",
+    "timestamp": "2016-01-22T21:03:07.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Moldavia (tanleach1001) was reinforced by tanleach1001 with 2 troops.",
+    "timestamp": "2016-01-22T21:03:50.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Greece (tanleach1001) was reinforced by tanleach1001 with 6 troops.",
+    "timestamp": "2016-01-22T21:03:54.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Greece (tanleach1001) attacked Naples (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T21:03:56.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Greece (tanleach1001) occupied Naples with 6 troops.",
+    "timestamp": "2016-01-22T21:04:13.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Naples (tanleach1001) attacked Sicily (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T21:04:39.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Naples (tanleach1001) occupied Sicily with 1 troop.",
+    "timestamp": "2016-01-22T21:04:42.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-22T21:04:59.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-22T21:04:59.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-22T21:11:15.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "jobratt received 5 troops for 16 territories.",
+    "timestamp": "2016-01-22T21:11:15.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "jobratt received 2 troops for holding British Isles.",
+    "timestamp": "2016-01-22T21:11:15.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "jobratt received 4 troops for holding Central Europe.",
+    "timestamp": "2016-01-22T21:11:15.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "jobratt received 2 troops for holding Denmark & Sweden.",
+    "timestamp": "2016-01-22T21:11:15.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Berlin (jobratt) was reinforced by jobratt with 13 troops.",
+    "timestamp": "2016-01-22T21:12:39.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Berlin (jobratt) attacked Silesia (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T21:12:44.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Berlin (jobratt) occupied Silesia with 12 troops.",
+    "timestamp": "2016-01-22T21:12:46.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Silesia (jobratt) attacked Warsaw (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T21:12:48.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Silesia (jobratt) occupied Warsaw with 11 troops.",
+    "timestamp": "2016-01-22T21:13:16.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Warsaw (jobratt) attacked Prussia (gcochard) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-01-22T21:13:21.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Warsaw (jobratt) occupied Prussia with 1 troop.",
+    "timestamp": "2016-01-22T21:13:24.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Warsaw (jobratt) attacked Lithuania (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T21:13:27.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Warsaw (jobratt) occupied Lithuania with 4 troops.",
+    "timestamp": "2016-01-22T21:15:19.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-22T21:15:31.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-22T21:15:31.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-22T21:15:36.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received 4 troops for 12 territories.",
+    "timestamp": "2016-01-22T21:15:36.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received 3 troops for holding France.",
+    "timestamp": "2016-01-22T21:15:36.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received 3 troops for holding Iberian Peninsula.",
+    "timestamp": "2016-01-22T21:15:36.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Corsica (kwren) was reinforced by kwren with 1 troop.",
+    "timestamp": "2016-01-22T21:15:46.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Provence (kwren) was reinforced by kwren with 9 troops.",
+    "timestamp": "2016-01-22T21:15:49.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Provence (kwren) attacked Rome (gcochard) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-22T21:15:53.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Provence (kwren) occupied Rome with 9 troops.",
+    "timestamp": "2016-01-22T21:15:56.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Rome (kwren) attacked Naples (tanleach1001) conquering it, killing 5, losing 3.",
+    "timestamp": "2016-01-22T21:16:11.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Rome (kwren) occupied Naples with 5 troops.",
+    "timestamp": "2016-01-22T21:16:13.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Naples (kwren) attacked Italy (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T21:16:16.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Naples (kwren) occupied Italy with 1 troop.",
+    "timestamp": "2016-01-22T21:16:23.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Corsica (kwren) attacked Sardinia (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T21:16:26.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "gcochard was defeated by kwren.",
+    "timestamp": "2016-01-22T21:16:26.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "Corsica (kwren) occupied Sardinia with 3 troops.",
+    "timestamp": "2016-01-22T21:16:34.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Naples (kwren) was reinforced by kwren with 8 troops.",
+    "timestamp": "2016-01-22T21:16:44.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Naples (kwren) attacked Sicily (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T21:16:48.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Naples (kwren) occupied Sicily with 1 troop.",
+    "timestamp": "2016-01-22T21:16:54.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Naples (kwren) was fortified from Balearic Islands (kwren) with 24 troops.",
+    "timestamp": "2016-01-22T21:17:10.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-22T21:17:10.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-22T21:17:10.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-22T21:19:25.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier received 3 troops for 7 territories.",
+    "timestamp": "2016-01-22T21:19:25.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Esthonia (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-22T21:19:35.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Esthonia (mmacfreier) attacked Novgorod (jobratt) conquering it, killing 6, losing 4.",
+    "timestamp": "2016-01-22T21:19:46.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Esthonia (mmacfreier) occupied Novgorod with 2 troops.",
+    "timestamp": "2016-01-22T21:19:48.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-22T21:19:59.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-22T21:19:59.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Round 9 started.",
+    "timestamp": "2016-01-22T21:19:59.000Z",
+    "player": "unknown",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-22T21:20:11.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 11 territories.",
+    "timestamp": "2016-01-22T21:20:11.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Ottoman Empire.",
+    "timestamp": "2016-01-22T21:20:11.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 received 2 troops for holding Austrian Empire.",
+    "timestamp": "2016-01-22T21:20:11.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Bosnia (tanleach1001) was reinforced by tanleach1001 with 16 troops.",
+    "timestamp": "2016-01-22T21:20:49.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Galacia (tanleach1001) attacked Silesia (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T21:21:11.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Bosnia (tanleach1001) was fortified from Wallachia (tanleach1001) with 6 troops.",
+    "timestamp": "2016-01-22T21:21:38.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-22T21:21:38.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-22T21:21:38.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-22T21:25:00.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "jobratt received 6 troops for 18 territories.",
+    "timestamp": "2016-01-22T21:25:00.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "jobratt received 2 troops for holding British Isles.",
+    "timestamp": "2016-01-22T21:25:00.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "jobratt received 4 troops for holding Central Europe.",
+    "timestamp": "2016-01-22T21:25:00.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "jobratt received 2 troops for holding Denmark & Sweden.",
+    "timestamp": "2016-01-22T21:25:00.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "jobratt received 2 troops on Norway",
+    "timestamp": "2016-01-22T21:25:03.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Lithuania (jobratt) was reinforced by jobratt with 22 troops.",
+    "timestamp": "2016-01-22T21:25:06.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Lithuania (jobratt) attacked Bielgorod (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T21:25:11.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Lithuania (jobratt) occupied Bielgorod with 25 troops.",
+    "timestamp": "2016-01-22T21:26:18.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Bielgorod (jobratt) attacked Podlesia (mmacfreier) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-22T21:26:31.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Bielgorod (jobratt) occupied Podlesia with 8 troops.",
+    "timestamp": "2016-01-22T21:26:55.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Podlesia (jobratt) attacked Little Russia (mmacfreier) killing 1, losing 7.",
+    "timestamp": "2016-01-22T21:27:05.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Bielgorod (jobratt) attacked Moscovy (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T21:27:39.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Bielgorod (jobratt) occupied Moscovy with 14 troops.",
+    "timestamp": "2016-01-22T21:27:41.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Moscovy (jobratt) attacked Novgorod (mmacfreier) conquering it, killing 2, losing 4.",
+    "timestamp": "2016-01-22T21:27:49.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Moscovy (jobratt) occupied Novgorod with 9 troops.",
+    "timestamp": "2016-01-22T21:27:51.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Novgorod (jobratt) attacked White Russia (mmacfreier) conquering it, killing 4, losing 3.",
+    "timestamp": "2016-01-22T21:27:58.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Novgorod (jobratt) occupied White Russia with 5 troops.",
+    "timestamp": "2016-01-22T21:28:00.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "White Russia (jobratt) attacked Esthonia (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T21:28:07.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "White Russia (jobratt) occupied Esthonia with 3 troops.",
+    "timestamp": "2016-01-22T21:28:09.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "N. Rhine (jobratt) attacked Silesia (tanleach1001) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-22T21:28:24.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "N. Rhine (jobratt) occupied Silesia with 6 troops.",
+    "timestamp": "2016-01-22T21:28:37.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Warsaw (jobratt) was fortified from Norway (jobratt) with 2 troops.",
+    "timestamp": "2016-01-22T21:29:14.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-22T21:29:14.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-22T21:29:14.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-22T21:30:30.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 5 troops for 17 territories.",
+    "timestamp": "2016-01-22T21:30:30.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 3 troops for holding France.",
+    "timestamp": "2016-01-22T21:30:30.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 3 troops for holding Iberian Peninsula.",
+    "timestamp": "2016-01-22T21:30:30.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 3 troops for holding Italy.",
+    "timestamp": "2016-01-22T21:30:30.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Naples (kwren) was reinforced by kwren with 14 troops.",
+    "timestamp": "2016-01-22T21:30:33.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Naples (kwren) attacked Bosnia (tanleach1001) conquering it, killing 30, losing 30.",
+    "timestamp": "2016-01-22T21:31:49.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Naples (kwren) occupied Bosnia with 18 troops.",
+    "timestamp": "2016-01-22T21:31:54.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Bosnia (kwren) attacked Hungary (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T21:33:01.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Bosnia (kwren) occupied Hungary with 16 troops.",
+    "timestamp": "2016-01-22T21:33:04.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Hungary (kwren) attacked Wallachia (tanleach1001) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-01-22T21:33:27.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Hungary (kwren) occupied Wallachia with 12 troops.",
+    "timestamp": "2016-01-22T21:33:29.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Wallachia (kwren) attacked Moldavia (tanleach1001) conquering it, killing 3, losing 5.",
+    "timestamp": "2016-01-22T21:34:57.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Wallachia (kwren) occupied Moldavia with 6 troops.",
+    "timestamp": "2016-01-22T21:34:59.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Moldavia (kwren) attacked Bulgaria (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T21:35:02.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Moldavia (kwren) occupied Bulgaria with 5 troops.",
+    "timestamp": "2016-01-22T21:35:04.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Bulgaria (kwren) attacked Greece (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T21:35:12.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Bulgaria (kwren) occupied Greece with 4 troops.",
+    "timestamp": "2016-01-22T21:35:13.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Greece (kwren) attacked Candia (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T21:35:25.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Greece (kwren) occupied Candia with 2 troops.",
+    "timestamp": "2016-01-22T21:35:26.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Candia (kwren) was fortified from Sardinia (kwren) with 2 troops.",
+    "timestamp": "2016-01-22T21:35:37.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-22T21:35:37.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-22T21:35:37.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-22T21:43:21.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier received 3 troops for 2 territories.",
+    "timestamp": "2016-01-22T21:43:21.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Little Russia (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-22T21:44:05.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-22T21:44:11.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Round 10 started.",
+    "timestamp": "2016-01-22T21:44:11.000Z",
+    "player": "unknown",
+    "round": 10
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-22T21:44:20.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 4 territories.",
+    "timestamp": "2016-01-22T21:44:20.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Austria (tanleach1001) was reinforced by tanleach1001 with 3 troops.",
+    "timestamp": "2016-01-22T21:46:02.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Austria (tanleach1001) attacked Hungary (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T21:46:05.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Austria (tanleach1001) occupied Hungary with 1 troop.",
+    "timestamp": "2016-01-22T21:46:12.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-22T21:46:37.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-22T21:46:37.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-22T21:55:53.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "jobratt received 8 troops for 25 territories.",
+    "timestamp": "2016-01-22T21:55:53.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "jobratt received 2 troops for holding British Isles.",
+    "timestamp": "2016-01-22T21:55:53.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "jobratt received 4 troops for holding Central Europe.",
+    "timestamp": "2016-01-22T21:55:53.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "jobratt received 2 troops for holding Denmark & Sweden.",
+    "timestamp": "2016-01-22T21:55:53.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "jobratt received 3 troops for holding Prussia & Poland.",
+    "timestamp": "2016-01-22T21:55:53.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Esthonia (jobratt) was reinforced by jobratt with 4 troops.",
+    "timestamp": "2016-01-22T21:56:14.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Podlesia (jobratt) was reinforced by jobratt with 15 troops.",
+    "timestamp": "2016-01-22T21:56:20.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Esthonia (jobratt) attacked Courland (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T21:56:23.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Esthonia (jobratt) occupied Courland with 5 troops.",
+    "timestamp": "2016-01-22T21:56:25.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Podlesia (jobratt) attacked Little Russia (mmacfreier) conquering it, killing 5, losing 0.",
+    "timestamp": "2016-01-22T21:56:30.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier was defeated by jobratt.",
+    "timestamp": "2016-01-22T21:56:30.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Podlesia (jobratt) occupied Little Russia with 15 troops.",
+    "timestamp": "2016-01-22T21:56:35.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "jobratt received 2 troops on Illyria",
+    "timestamp": "2016-01-22T21:56:40.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Little Russia (jobratt) was reinforced by jobratt with 8 troops.",
+    "timestamp": "2016-01-22T21:57:17.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Little Russia (jobratt) attacked Galacia (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T21:57:19.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Little Russia (jobratt) occupied Galacia with 22 troops.",
+    "timestamp": "2016-01-22T21:57:21.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Galacia (jobratt) attacked Austria (tanleach1001) conquering it, killing 5, losing 1.",
+    "timestamp": "2016-01-22T21:57:27.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Galacia (jobratt) occupied Austria with 20 troops.",
+    "timestamp": "2016-01-22T21:57:30.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Silesia (jobratt) attacked Bohemia (tanleach1001) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-22T21:57:35.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Silesia (jobratt) occupied Bohemia with 4 troops.",
+    "timestamp": "2016-01-22T21:57:38.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Austria (jobratt) attacked Hungary (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T21:57:44.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Austria (jobratt) occupied Hungary with 18 troops.",
+    "timestamp": "2016-01-22T21:57:46.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Hungary (jobratt) attacked Wallachia (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T21:57:50.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Hungary (jobratt) occupied Wallachia with 16 troops.",
+    "timestamp": "2016-01-22T21:57:56.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Wallachia (jobratt) attacked Bosnia (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-22T21:58:06.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Wallachia (jobratt) occupied Bosnia with 13 troops.",
+    "timestamp": "2016-01-22T21:58:07.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Bosnia (jobratt) attacked Greece (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T21:58:17.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Bosnia (jobratt) occupied Greece with 11 troops.",
+    "timestamp": "2016-01-22T21:58:23.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Greece (jobratt) attacked Naples (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T21:58:27.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Greece (jobratt) occupied Naples with 1 troop.",
+    "timestamp": "2016-01-22T21:58:29.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Greece (jobratt) attacked Candia (kwren) conquering it, killing 4, losing 0.",
+    "timestamp": "2016-01-22T21:58:34.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Greece (jobratt) occupied Candia with 9 troops.",
+    "timestamp": "2016-01-22T21:58:35.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Candia (jobratt) attacked Turkey (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T21:58:40.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "tanleach1001 was defeated by jobratt.",
+    "timestamp": "2016-01-22T21:58:40.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Candia (jobratt) occupied Turkey with 8 troops.",
+    "timestamp": "2016-01-22T21:58:42.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "jobratt received 2 troops on White Russia",
+    "timestamp": "2016-01-22T21:58:45.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "S. Rhine (jobratt) was reinforced by jobratt with 8 troops.",
+    "timestamp": "2016-01-22T21:59:25.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Turkey (jobratt) attacked Bulgaria (kwren) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-01-22T21:59:39.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Turkey (jobratt) occupied Bulgaria with 4 troops.",
+    "timestamp": "2016-01-22T21:59:40.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "S. Rhine (jobratt) attacked Italy (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T21:59:48.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "S. Rhine (jobratt) occupied Italy with 13 troops.",
+    "timestamp": "2016-01-22T21:59:49.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Italy (jobratt) attacked Rome (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-22T22:00:03.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Italy (jobratt) occupied Rome with 10 troops.",
+    "timestamp": "2016-01-22T22:00:07.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Little Russia (jobratt) was fortified from Rome (jobratt) with 9 troops.",
+    "timestamp": "2016-01-22T22:00:54.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-22T22:00:55.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-22T22:00:55.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-22T22:01:21.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "kwren received 5 troops for 15 territories.",
+    "timestamp": "2016-01-22T22:01:21.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "kwren received 3 troops for holding France.",
+    "timestamp": "2016-01-22T22:01:21.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "kwren received 3 troops for holding Iberian Peninsula.",
+    "timestamp": "2016-01-22T22:01:21.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Moldavia (kwren) was reinforced by kwren with 19 troops.",
+    "timestamp": "2016-01-22T22:01:30.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Moldavia (kwren) attacked Hungary (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:01:34.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Moldavia (kwren) occupied Hungary with 19 troops.",
+    "timestamp": "2016-01-22T22:01:36.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Hungary (kwren) attacked Galacia (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:01:57.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Hungary (kwren) occupied Galacia with 18 troops.",
+    "timestamp": "2016-01-22T22:01:59.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Galacia (kwren) attacked Podlesia (jobratt) conquering it, killing 1, losing 4.",
+    "timestamp": "2016-01-22T22:02:17.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Galacia (kwren) occupied Podlesia with 1 troop.",
+    "timestamp": "2016-01-22T22:02:19.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Galacia (kwren) attacked Silesia (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:02:22.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Galacia (kwren) occupied Silesia with 12 troops.",
+    "timestamp": "2016-01-22T22:02:24.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Silesia (kwren) attacked N. Rhine (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T22:02:28.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Silesia (kwren) occupied N. Rhine with 10 troops.",
+    "timestamp": "2016-01-22T22:02:30.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "N. Rhine (kwren) attacked Sweden (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:02:40.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "N. Rhine (kwren) occupied Sweden with 1 troop.",
+    "timestamp": "2016-01-22T22:02:43.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "N. Rhine (kwren) attacked Germania (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:02:46.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "N. Rhine (kwren) occupied Germania with 8 troops.",
+    "timestamp": "2016-01-22T22:02:47.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Germania (kwren) attacked Netherlands (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:02:51.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Germania (kwren) occupied Netherlands with 7 troops.",
+    "timestamp": "2016-01-22T22:02:52.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Netherlands (kwren) attacked England (jobratt) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-01-22T22:03:02.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Netherlands (kwren) occupied England with 3 troops.",
+    "timestamp": "2016-01-22T22:03:03.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "England (kwren) attacked Scotland (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:03:45.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "England (kwren) occupied Scotland with 2 troops.",
+    "timestamp": "2016-01-22T22:03:47.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Scotland (kwren) attacked Ireland (jobratt) killing 0, losing 1.",
+    "timestamp": "2016-01-22T22:03:51.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-22T22:04:08.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-22T22:04:08.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Round 11 started.",
+    "timestamp": "2016-01-22T22:04:08.000Z",
+    "player": "unknown",
+    "round": 11
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-22T22:07:47.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "jobratt received 10 troops for 30 territories.",
+    "timestamp": "2016-01-22T22:07:47.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Naples (jobratt) was reinforced by jobratt with 10 troops.",
+    "timestamp": "2016-01-22T22:08:06.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Naples (jobratt) attacked Sicily (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:08:09.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Naples (jobratt) occupied Sicily with 10 troops.",
+    "timestamp": "2016-01-22T22:08:11.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Sicily (jobratt) attacked Sardinia (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:08:14.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Sicily (jobratt) occupied Sardinia with 9 troops.",
+    "timestamp": "2016-01-22T22:08:17.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Sardinia (jobratt) attacked Balearic Islands (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T22:08:21.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Sardinia (jobratt) occupied Balearic Islands with 7 troops.",
+    "timestamp": "2016-01-22T22:08:22.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Balearic Islands (jobratt) attacked Madrid (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-22T22:08:37.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Balearic Islands (jobratt) occupied Madrid with 1 troop.",
+    "timestamp": "2016-01-22T22:08:40.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Balearic Islands (jobratt) attacked Corsica (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:08:43.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Balearic Islands (jobratt) occupied Corsica with 3 troops.",
+    "timestamp": "2016-01-22T22:08:45.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Little Russia (jobratt) attacked Galacia (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:08:54.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Little Russia (jobratt) occupied Galacia with 9 troops.",
+    "timestamp": "2016-01-22T22:08:55.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Galacia (jobratt) attacked Podlesia (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T22:09:02.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Galacia (jobratt) occupied Podlesia with 1 troop.",
+    "timestamp": "2016-01-22T22:09:05.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Galacia (jobratt) attacked Moldavia (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:09:07.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Galacia (jobratt) occupied Moldavia with 1 troop.",
+    "timestamp": "2016-01-22T22:09:10.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Galacia (jobratt) attacked Silesia (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-22T22:09:14.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Galacia (jobratt) occupied Silesia with 3 troops.",
+    "timestamp": "2016-01-22T22:09:16.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Corsica (jobratt) attacked Provence (kwren) killing 0, losing 2.",
+    "timestamp": "2016-01-22T22:09:29.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Berlin (jobratt) was fortified from Courland (jobratt) with 4 troops.",
+    "timestamp": "2016-01-22T22:09:59.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-22T22:09:59.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-22T22:09:59.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-22T22:41:37.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "kwren received 5 troops for 16 territories.",
+    "timestamp": "2016-01-22T22:41:37.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Hungary (kwren) was reinforced by kwren with 5 troops.",
+    "timestamp": "2016-01-22T22:41:54.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Hungary (kwren) attacked Galacia (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:41:57.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Hungary (kwren) occupied Galacia with 5 troops.",
+    "timestamp": "2016-01-22T22:41:59.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Galacia (kwren) attacked Podlesia (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:42:02.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Galacia (kwren) occupied Podlesia with 4 troops.",
+    "timestamp": "2016-01-22T22:42:05.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Podlesia (kwren) attacked Lithuania (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:42:08.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Podlesia (kwren) occupied Lithuania with 1 troop.",
+    "timestamp": "2016-01-22T22:42:12.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Podlesia (kwren) attacked Little Russia (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:42:15.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Podlesia (kwren) occupied Little Russia with 2 troops.",
+    "timestamp": "2016-01-22T22:42:17.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Little Russia (kwren) attacked Bielgorod (jobratt) killing 0, losing 1.",
+    "timestamp": "2016-01-22T22:42:23.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-22T22:42:26.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-22T22:42:26.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Round 12 started.",
+    "timestamp": "2016-01-22T22:42:26.000Z",
+    "player": "unknown",
+    "round": 12
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-22T22:42:55.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "jobratt received 11 troops for 35 territories.",
+    "timestamp": "2016-01-22T22:42:55.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "jobratt received 3 troops for holding Italy.",
+    "timestamp": "2016-01-22T22:42:55.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "jobratt received 3 troops for holding Ottoman Empire.",
+    "timestamp": "2016-01-22T22:42:55.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "jobratt received 2 troops on Switzerland",
+    "timestamp": "2016-01-22T22:42:59.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "jobratt received 2 troops on Bohemia",
+    "timestamp": "2016-01-22T22:42:59.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Madrid (jobratt) was reinforced by jobratt with 10 troops.",
+    "timestamp": "2016-01-22T22:44:00.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Wales (jobratt) was reinforced by jobratt with 10 troops.",
+    "timestamp": "2016-01-22T22:44:14.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Austria (jobratt) was reinforced by jobratt with 5 troops.",
+    "timestamp": "2016-01-22T22:44:58.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Madrid (jobratt) attacked Leon\t (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:45:07.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Madrid (jobratt) occupied Leon\t with 10 troops.",
+    "timestamp": "2016-01-22T22:45:12.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Leon\t (jobratt) attacked Portugal (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T22:45:16.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Leon\t (jobratt) occupied Portugal with 5 troops.",
+    "timestamp": "2016-01-22T22:45:25.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Portugal (jobratt) attacked Andalusia (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:45:28.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Portugal (jobratt) occupied Andalusia with 4 troops.",
+    "timestamp": "2016-01-22T22:45:30.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Leon\t (jobratt) attacked Catalonia (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:45:33.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Leon\t (jobratt) occupied Catalonia with 3 troops.",
+    "timestamp": "2016-01-22T22:45:34.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Wales (jobratt) attacked Scotland (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:45:45.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Wales (jobratt) occupied Scotland with 10 troops.",
+    "timestamp": "2016-01-22T22:45:46.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Scotland (jobratt) attacked England (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:45:50.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Scotland (jobratt) occupied England with 9 troops.",
+    "timestamp": "2016-01-22T22:45:52.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "England (jobratt) attacked Paris (kwren) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-01-22T22:46:03.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "England (jobratt) occupied Paris with 5 troops.",
+    "timestamp": "2016-01-22T22:46:04.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Catalonia (jobratt) attacked Gascony (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:46:13.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Catalonia (jobratt) occupied Gascony with 2 troops.",
+    "timestamp": "2016-01-22T22:46:14.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Paris (jobratt) attacked Netherlands (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T22:46:31.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Paris (jobratt) occupied Netherlands with 3 troops.",
+    "timestamp": "2016-01-22T22:46:33.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Netherlands (jobratt) attacked Germania (kwren) killing 0, losing 2.",
+    "timestamp": "2016-01-22T22:46:37.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Berlin (jobratt) attacked Sweden (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:46:47.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Berlin (jobratt) occupied Sweden with 4 troops.",
+    "timestamp": "2016-01-22T22:46:48.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Sweden (jobratt) attacked N. Rhine (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:46:52.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Sweden (jobratt) occupied N. Rhine with 3 troops.",
+    "timestamp": "2016-01-22T22:46:53.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "N. Rhine (jobratt) attacked Germania (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:47:00.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "N. Rhine (jobratt) occupied Germania with 2 troops.",
+    "timestamp": "2016-01-22T22:47:02.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Switzerland (jobratt) attacked Burgandy (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:47:06.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Switzerland (jobratt) occupied Burgandy with 2 troops.",
+    "timestamp": "2016-01-22T22:47:08.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Burgandy (jobratt) attacked Provence (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:47:11.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Austria (jobratt) attacked Hungary (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:47:40.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Austria (jobratt) occupied Hungary with 5 troops.",
+    "timestamp": "2016-01-22T22:47:41.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Hungary (jobratt) attacked Galacia (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:47:44.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Hungary (jobratt) occupied Galacia with 4 troops.",
+    "timestamp": "2016-01-22T22:47:48.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Galacia (jobratt) attacked Podlesia (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:47:51.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Galacia (jobratt) occupied Podlesia with 3 troops.",
+    "timestamp": "2016-01-22T22:47:53.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Podlesia (jobratt) attacked Little Russia (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:47:56.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Podlesia (jobratt) occupied Little Russia with 1 troop.",
+    "timestamp": "2016-01-22T22:48:00.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "White Russia (jobratt) attacked Lithuania (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:48:03.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "White Russia (jobratt) occupied Lithuania with 2 troops.",
+    "timestamp": "2016-01-22T22:48:04.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Paris (jobratt) was fortified from Bohemia (jobratt) with 5 troops.",
+    "timestamp": "2016-01-22T22:48:22.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-22T22:48:22.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-22T22:48:22.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-22T22:48:28.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "kwren received 3 troops for 1 territory.",
+    "timestamp": "2016-01-22T22:48:28.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Normandy (kwren) was reinforced by kwren with 3 troops.",
+    "timestamp": "2016-01-22T22:48:34.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Normandy (kwren) attacked England (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:48:40.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Normandy (kwren) occupied England with 3 troops.",
+    "timestamp": "2016-01-22T22:48:42.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "England (kwren) attacked Scotland (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:48:49.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "England (kwren) occupied Scotland with 2 troops.",
+    "timestamp": "2016-01-22T22:48:52.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Scotland (kwren) attacked Denmark (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:48:56.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-22T22:49:02.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-22T22:49:02.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Round 13 started.",
+    "timestamp": "2016-01-22T22:49:02.000Z",
+    "player": "unknown",
+    "round": 13
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-22T22:49:08.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt received 17 troops for 51 territories.",
+    "timestamp": "2016-01-22T22:49:08.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt received 3 troops for holding Italy.",
+    "timestamp": "2016-01-22T22:49:08.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt received 3 troops for holding Ottoman Empire.",
+    "timestamp": "2016-01-22T22:49:08.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt received 3 troops for holding Iberian Peninsula.",
+    "timestamp": "2016-01-22T22:49:08.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt received 4 troops for holding Central Europe.",
+    "timestamp": "2016-01-22T22:49:08.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt received 2 troops for holding Austrian Empire.",
+    "timestamp": "2016-01-22T22:49:08.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt received 4 troops for holding Russia.",
+    "timestamp": "2016-01-22T22:49:08.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt received 3 troops for holding Prussia & Poland.",
+    "timestamp": "2016-01-22T22:49:08.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Paris (jobratt) was reinforced by jobratt with 39 troops.",
+    "timestamp": "2016-01-22T22:49:16.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Paris (jobratt) attacked Normandy (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:49:19.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Paris (jobratt) occupied Normandy with 44 troops.",
+    "timestamp": "2016-01-22T22:49:20.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Normandy (jobratt) attacked England (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-22T22:49:22.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Normandy (jobratt) occupied England with 43 troops.",
+    "timestamp": "2016-01-22T22:49:24.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "England (jobratt) attacked Scotland (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-22T22:49:36.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "England (jobratt) occupied Scotland with 40 troops.",
+    "timestamp": "2016-01-22T22:49:37.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Scotland (jobratt) attacked Denmark (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-22T22:49:42.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "kwren was defeated by jobratt.",
+    "timestamp": "2016-01-22T22:49:42.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Game finished.",
+    "timestamp": "2016-01-22T22:49:42.000Z",
+    "player": "unknown",
+    "round": 13
+  },
+  {
+    "message": "tanleach1001 lost 18 rating.",
+    "timestamp": "2016-01-22T22:49:42.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "tanleach1001 received 20 tokens.",
+    "timestamp": "2016-01-22T22:49:42.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "jobratt won the game.",
+    "timestamp": "2016-01-22T22:49:42.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt received 90 rating.",
+    "timestamp": "2016-01-22T22:49:42.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt received 20 tokens.",
+    "timestamp": "2016-01-22T22:49:42.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "ryanbmilbourne lost 17 rating.",
+    "timestamp": "2016-01-22T22:49:42.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "ryanbmilbourne received 20 tokens.",
+    "timestamp": "2016-01-22T22:49:42.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "kwren lost 17 rating.",
+    "timestamp": "2016-01-22T22:49:42.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "kwren received 20 tokens.",
+    "timestamp": "2016-01-22T22:49:42.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "gcochard lost 14 rating.",
+    "timestamp": "2016-01-22T22:49:42.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "gcochard received 20 tokens.",
+    "timestamp": "2016-01-22T22:49:42.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "mmacfreier lost 24 rating.",
+    "timestamp": "2016-01-22T22:49:42.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "mmacfreier received 20 tokens.",
+    "timestamp": "2016-01-22T22:49:42.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "jobratt received 4 troops for turning in cards Portugal, Courland, and Esthonia.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "gcochard received 6 troops for turning in cards Andalusia, Silesia, and Denmark.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "mmacfreier received 8 troops for turning in cards Balearic Islands, Podlesia, and Little Russia.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "tanleach1001 received 8 troops for turning in cards Leon\t, Scotland, and Sweden.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "ryanbmilbourne received 8 troops for turning in cards Provence, Bielgorod, and Galacia.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "kwren received 8 troops for turning in cards N. Rhine, Bosnia, and Moscovy.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "kwren received 8 troops for turning in cards Corsica, Berlin, and Prussia.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "mmacfreier received 8 troops for turning in cards Austria, Naples, and Greece.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "kwren received 8 troops for turning in cards Wales, Sicily, and Bulgaria.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "tanleach1001 received 8 troops for turning in cards Lithuania, Warsaw, and Novgorod.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "jobratt received 8 troops for turning in cards Candia, Hungary, and Norway.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt received 8 troops for turning in cards Illyria, Gascony, and Madrid.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt received 8 troops for turning in cards Paris, White Russia, and Moldavia.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "kwren received 8 troops for turning in cards Italy, Turkey, and Wallachia.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "jobratt received 8 troops for turning in cards Germania, Switzerland, and Bohemia.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "jobratt",
+    "round": 13
+  }
+]

--- a/data/607343.json
+++ b/data/607343.json
@@ -1,0 +1,4172 @@
+[
+  {
+    "message": "Game created.",
+    "timestamp": "2016-01-26T17:51:50.000Z",
+    "player": "unknown",
+    "round": 0
+  },
+  {
+    "message": "kwren joined the game.",
+    "timestamp": "2016-01-26T17:51:50.000Z",
+    "player": "kwren",
+    "round": 0
+  },
+  {
+    "message": "ryanbmilbourne joined the game.",
+    "timestamp": "2016-01-26T17:52:48.000Z",
+    "player": "ryanbmilbourne",
+    "round": 0
+  },
+  {
+    "message": "tanleach1001 joined the game.",
+    "timestamp": "2016-01-26T17:52:59.000Z",
+    "player": "tanleach1001",
+    "round": 0
+  },
+  {
+    "message": "jobratt joined the game.",
+    "timestamp": "2016-01-26T17:53:00.000Z",
+    "player": "jobratt",
+    "round": 0
+  },
+  {
+    "message": "gcochard joined the game.",
+    "timestamp": "2016-01-26T17:53:11.000Z",
+    "player": "gcochard",
+    "round": 0
+  },
+  {
+    "message": "mmacfreier joined the game.",
+    "timestamp": "2016-01-26T17:54:33.000Z",
+    "player": "mmacfreier",
+    "round": 0
+  },
+  {
+    "message": "Game started.",
+    "timestamp": "2016-01-26T17:54:33.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-26T17:55:45.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 9 territories.",
+    "timestamp": "2016-01-26T17:55:45.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Pleasanton (tanleach1001) was reinforced by tanleach1001 with 3 troops.",
+    "timestamp": "2016-01-26T17:56:08.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Pleasanton (tanleach1001) attacked Sunol (kwren) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-01-26T17:56:18.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Pleasanton (tanleach1001) occupied Sunol with 3 troops.",
+    "timestamp": "2016-01-26T17:56:25.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Portola (tanleach1001) was fortified from SFO (tanleach1001) with 2 troops.",
+    "timestamp": "2016-01-26T17:56:54.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-26T17:56:55.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-26T17:56:55.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-26T17:58:34.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard received 3 troops for 9 territories.",
+    "timestamp": "2016-01-26T17:58:34.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Hayward (gcochard) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-01-26T17:58:48.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Hayward (gcochard) attacked Union City (tanleach1001) conquering it, killing 3, losing 3.",
+    "timestamp": "2016-01-26T17:58:56.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Hayward (gcochard) occupied Union City with 2 troops.",
+    "timestamp": "2016-01-26T17:59:01.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Redwood City (gcochard) was fortified from Belmont (gcochard) with 2 troops.",
+    "timestamp": "2016-01-26T17:59:23.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-26T17:59:23.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-26T17:59:23.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-26T18:22:00.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "jobratt received 3 troops for 9 territories.",
+    "timestamp": "2016-01-26T18:22:00.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Daly City (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-01-26T18:22:11.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Daly City (jobratt) attacked SFO (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T18:22:14.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Daly City (jobratt) occupied SFO with 5 troops.",
+    "timestamp": "2016-01-26T18:22:15.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Berkeley (jobratt) was fortified from Downtown (jobratt) with 2 troops.",
+    "timestamp": "2016-01-26T18:22:49.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-26T18:22:50.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-26T18:22:50.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-26T18:31:29.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren received 3 troops for 8 territories.",
+    "timestamp": "2016-01-26T18:31:29.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Livermore (kwren) was reinforced by kwren with 1 troop.",
+    "timestamp": "2016-01-26T18:31:33.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "San Mateo (kwren) was reinforced by kwren with 1 troop.",
+    "timestamp": "2016-01-26T18:31:40.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Livermore (kwren) was reinforced by kwren with 1 troop.",
+    "timestamp": "2016-01-26T18:32:00.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Livermore (kwren) attacked Pleasanton (tanleach1001) killing 0, losing 2.",
+    "timestamp": "2016-01-26T18:32:05.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Castro Valley (kwren) attacked Pleasanton (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T18:32:09.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Castro Valley (kwren) occupied Pleasanton with 1 troop.",
+    "timestamp": "2016-01-26T18:32:13.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Castro Valley (kwren) was fortified from Livermore (kwren) with 2 troops.",
+    "timestamp": "2016-01-26T18:32:33.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-26T18:32:33.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-26T18:32:33.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-26T18:32:41.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier received 3 troops for 9 territories.",
+    "timestamp": "2016-01-26T18:32:41.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Marin City (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-26T18:32:47.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Marin City (mmacfreier) attacked Muir Woods (ryanbmilbourne) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-26T18:32:53.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Marin City (mmacfreier) occupied Muir Woods with 4 troops.",
+    "timestamp": "2016-01-26T18:33:01.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Lafayette (mmacfreier) was fortified from Oakland (mmacfreier) with 2 troops.",
+    "timestamp": "2016-01-26T18:33:20.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-26T18:33:20.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-26T18:33:20.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-26T18:35:17.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 8 territories.",
+    "timestamp": "2016-01-26T18:35:18.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "San Bruno (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-26T18:35:39.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Sunset District (ryanbmilbourne) attacked Daly City (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T18:35:45.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Sunset District (ryanbmilbourne) occupied Daly City with 2 troops.",
+    "timestamp": "2016-01-26T18:35:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Daly City (ryanbmilbourne) was fortified from Pacifica (ryanbmilbourne) with 2 troops.",
+    "timestamp": "2016-01-26T18:36:07.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-26T18:36:07.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-26T18:36:07.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Round 2 started.",
+    "timestamp": "2016-01-26T18:36:07.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-26T19:04:57.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 7 territories.",
+    "timestamp": "2016-01-26T19:04:57.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Portola (tanleach1001) was reinforced by tanleach1001 with 3 troops.",
+    "timestamp": "2016-01-26T19:06:06.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Portola (tanleach1001) attacked Sunset District (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T19:06:09.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Portola (tanleach1001) occupied Sunset District with 1 troop.",
+    "timestamp": "2016-01-26T19:06:12.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Portola (tanleach1001) attacked Noe Valley (jobratt) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-26T19:06:16.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Portola (tanleach1001) occupied Noe Valley with 2 troops.",
+    "timestamp": "2016-01-26T19:06:28.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Alcatraz (tanleach1001) attacked Downtown (jobratt) killing 0, losing 2.",
+    "timestamp": "2016-01-26T19:06:36.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-26T19:06:57.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-26T19:06:57.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-26T19:09:55.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "gcochard received 3 troops for 10 territories.",
+    "timestamp": "2016-01-26T19:09:55.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Redwood City (gcochard) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-01-26T19:10:06.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Redwood City (gcochard) attacked Palo Alto (tanleach1001) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-26T19:10:10.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Redwood City (gcochard) occupied Palo Alto with 7 troops.",
+    "timestamp": "2016-01-26T19:10:12.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Palo Alto (gcochard) attacked Newark (kwren) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-26T19:10:17.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Palo Alto (gcochard) occupied Newark with 5 troops.",
+    "timestamp": "2016-01-26T19:10:19.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Newark (gcochard) was fortified from Union City (gcochard) with 1 troop.",
+    "timestamp": "2016-01-26T19:10:53.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-26T19:10:53.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-26T19:10:53.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-26T19:30:34.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "jobratt received 3 troops for 8 territories.",
+    "timestamp": "2016-01-26T19:30:34.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Foster City (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-01-26T19:30:46.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Foster City (jobratt) attacked Burlingame (gcochard) killing 0, losing 5.",
+    "timestamp": "2016-01-26T19:30:51.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Millbrae (jobratt) attacked Burlingame (gcochard) killing 1, losing 1.",
+    "timestamp": "2016-01-26T19:30:55.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Berkeley (jobratt) attacked Oakland (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T19:30:58.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Berkeley (jobratt) occupied Oakland with 1 troop.",
+    "timestamp": "2016-01-26T19:31:04.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Foster City (jobratt) was fortified from SFO (jobratt) with 4 troops.",
+    "timestamp": "2016-01-26T19:31:12.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-26T19:31:12.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-26T19:31:12.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-26T19:35:15.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "kwren received 3 troops for 8 territories.",
+    "timestamp": "2016-01-26T19:35:15.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Castro Valley (kwren) was reinforced by kwren with 3 troops.",
+    "timestamp": "2016-01-26T19:35:23.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Castro Valley (kwren) attacked Hayward (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T19:35:26.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Castro Valley (kwren) occupied Hayward with 6 troops.",
+    "timestamp": "2016-01-26T19:35:28.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Danville (kwren) was fortified from San Ramon (kwren) with 2 troops.",
+    "timestamp": "2016-01-26T19:35:40.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-26T19:35:40.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-26T19:35:40.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-26T19:35:56.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier received 3 troops for 9 territories.",
+    "timestamp": "2016-01-26T19:35:56.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Muir Woods (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-26T19:36:03.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Muir Woods (mmacfreier) attacked San Rafael (kwren) killing 0, losing 6.",
+    "timestamp": "2016-01-26T19:36:09.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Lafayette (mmacfreier) attacked Oakland (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T19:36:20.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Lafayette (mmacfreier) occupied Oakland with 1 troop.",
+    "timestamp": "2016-01-26T19:36:23.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Lafayette (mmacfreier) was fortified from Moraga (mmacfreier) with 2 troops.",
+    "timestamp": "2016-01-26T19:36:27.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-26T19:36:27.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-26T19:36:27.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-26T19:42:42.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 8 territories.",
+    "timestamp": "2016-01-26T19:42:42.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Daly City (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-26T19:42:49.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Daly City (ryanbmilbourne) attacked SFO (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T19:42:55.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Daly City (ryanbmilbourne) occupied SFO with 6 troops.",
+    "timestamp": "2016-01-26T19:42:56.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Concord (ryanbmilbourne) attacked Black Diamond Mines (kwren) killing 0, losing 2.",
+    "timestamp": "2016-01-26T19:43:17.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Fremont (ryanbmilbourne) attacked Union City (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-26T19:43:30.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "San Bruno (ryanbmilbourne) attacked Half Moon Bay (mmacfreier) killing 1, losing 3.",
+    "timestamp": "2016-01-26T19:43:37.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "San Bruno (ryanbmilbourne) was fortified from SFO (ryanbmilbourne) with 2 troops.",
+    "timestamp": "2016-01-26T19:44:00.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-26T19:44:00.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-26T19:44:00.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Round 3 started.",
+    "timestamp": "2016-01-26T19:44:00.000Z",
+    "player": "unknown",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-26T19:44:17.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 8 territories.",
+    "timestamp": "2016-01-26T19:44:17.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Portola (tanleach1001) was reinforced by tanleach1001 with 3 troops.",
+    "timestamp": "2016-01-26T19:44:27.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Portola (tanleach1001) attacked Bayview (Neutral) conquering it, killing 3, losing 3.",
+    "timestamp": "2016-01-26T19:44:33.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Portola (tanleach1001) occupied Bayview with 3 troops.",
+    "timestamp": "2016-01-26T19:44:47.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Noe Valley (tanleach1001) attacked Downtown (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T19:44:58.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-26T19:45:23.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-26T19:45:23.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-26T19:47:30.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard received 3 troops for 10 territories.",
+    "timestamp": "2016-01-26T19:47:30.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Newark (gcochard) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-01-26T19:47:34.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Newark (gcochard) attacked Sunol (tanleach1001) conquering it, killing 3, losing 5.",
+    "timestamp": "2016-01-26T19:47:44.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Newark (gcochard) occupied Sunol with 3 troops.",
+    "timestamp": "2016-01-26T19:47:47.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "South San Leandro (gcochard) attacked Castro Valley (kwren) killing 0, losing 2.",
+    "timestamp": "2016-01-26T19:48:08.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-26T19:48:25.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-26T19:48:25.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-26T20:28:26.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt received 3 troops for 6 territories.",
+    "timestamp": "2016-01-26T20:28:26.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Martinez (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-01-26T20:28:42.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Martinez (jobratt) attacked Concord (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T20:28:45.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Martinez (jobratt) occupied Concord with 5 troops.",
+    "timestamp": "2016-01-26T20:28:57.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Concord (jobratt) attacked Pittsburg (gcochard) killing 0, losing 2.",
+    "timestamp": "2016-01-26T20:29:01.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Foster City (jobratt) attacked Burlingame (gcochard) conquering it, killing 2, losing 2.",
+    "timestamp": "2016-01-26T20:29:12.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Foster City (jobratt) occupied Burlingame with 2 troops.",
+    "timestamp": "2016-01-26T20:29:14.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Berkeley (jobratt) was fortified from Alameda (jobratt) with 2 troops.",
+    "timestamp": "2016-01-26T20:29:34.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-26T20:29:34.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-26T20:29:34.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-26T20:29:51.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren received 3 troops for 9 territories.",
+    "timestamp": "2016-01-26T20:29:51.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Hayward (kwren) was reinforced by kwren with 3 troops.",
+    "timestamp": "2016-01-26T20:30:06.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Hayward (kwren) attacked Garin Creek (ryanbmilbourne) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-26T20:30:16.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Hayward (kwren) occupied Garin Creek with 1 troop.",
+    "timestamp": "2016-01-26T20:30:22.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Hayward (kwren) attacked Foster City (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T20:30:30.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Hayward (kwren) occupied Foster City with 1 troop.",
+    "timestamp": "2016-01-26T20:30:36.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Castro Valley (kwren) was fortified from San Mateo (kwren) with 3 troops.",
+    "timestamp": "2016-01-26T20:30:46.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-26T20:30:46.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-26T20:30:46.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-26T20:36:32.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier received 3 troops for 10 territories.",
+    "timestamp": "2016-01-26T20:36:33.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Mill Valley (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-26T20:36:46.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Mill Valley (mmacfreier) attacked San Rafael (kwren) conquering it, killing 3, losing 3.",
+    "timestamp": "2016-01-26T20:36:57.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Mill Valley (mmacfreier) occupied San Rafael with 2 troops.",
+    "timestamp": "2016-01-26T20:36:59.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-26T20:37:28.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-26T20:37:28.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-26T21:07:38.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 8 territories.",
+    "timestamp": "2016-01-26T21:07:38.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "San Bruno (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-26T21:07:45.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "San Bruno (ryanbmilbourne) attacked Half Moon Bay (mmacfreier) killing 0, losing 4.",
+    "timestamp": "2016-01-26T21:07:49.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Tassajara (ryanbmilbourne) attacked Livermore (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-26T21:08:02.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-26T21:08:09.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-26T21:08:09.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Round 4 started.",
+    "timestamp": "2016-01-26T21:08:09.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-26T21:08:28.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 9 territories.",
+    "timestamp": "2016-01-26T21:08:28.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Bayview (tanleach1001) was reinforced by tanleach1001 with 3 troops.",
+    "timestamp": "2016-01-26T21:08:43.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Bayview (tanleach1001) attacked Hunters Point (mmacfreier) killing 0, losing 2.",
+    "timestamp": "2016-01-26T21:08:47.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "North San Leandro (tanleach1001) attacked Oakland (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T21:08:55.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "North San Leandro (tanleach1001) occupied Oakland with 2 troops.",
+    "timestamp": "2016-01-26T21:09:01.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Bayview (tanleach1001) attacked Hunters Point (mmacfreier) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-26T21:09:17.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Bayview (tanleach1001) occupied Hunters Point with 1 troop.",
+    "timestamp": "2016-01-26T21:09:42.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Downtown (tanleach1001) was fortified from Bayview (tanleach1001) with 2 troops.",
+    "timestamp": "2016-01-26T21:09:52.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-26T21:09:52.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-26T21:09:52.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-26T21:45:21.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard received 3 troops for 10 territories.",
+    "timestamp": "2016-01-26T21:45:21.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Sunol (gcochard) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-01-26T21:45:28.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Sunol (gcochard) attacked Union City (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T21:45:34.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Sunol (gcochard) occupied Union City with 1 troop.",
+    "timestamp": "2016-01-26T21:45:38.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Sunol (gcochard) attacked Milpitas (Neutral) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-26T21:45:47.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Sunol (gcochard) occupied Milpitas with 1 troop.",
+    "timestamp": "2016-01-26T21:45:51.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Sunol (gcochard) attacked Fremont (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T21:45:54.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Sunol (gcochard) occupied Fremont with 1 troop.",
+    "timestamp": "2016-01-26T21:45:58.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Pittsburg (gcochard) attacked Black Diamond Mines (kwren) killing 0, losing 2.",
+    "timestamp": "2016-01-26T21:46:25.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "San Pablo (gcochard) attacked Martinez (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-26T21:46:33.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Clayton (gcochard) attacked Tassajara (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T21:46:38.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Clayton (gcochard) occupied Tassajara with 2 troops.",
+    "timestamp": "2016-01-26T21:46:40.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Blackhawk (gcochard) was fortified from Tassajara (gcochard) with 1 troop.",
+    "timestamp": "2016-01-26T21:46:44.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-26T21:46:44.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-26T21:46:44.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-26T21:53:10.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "jobratt received 3 troops for 6 territories.",
+    "timestamp": "2016-01-26T21:53:10.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Concord (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-01-26T21:53:20.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Concord (jobratt) attacked Pittsburg (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-26T21:53:25.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Concord (jobratt) occupied Pittsburg with 2 troops.",
+    "timestamp": "2016-01-26T21:53:32.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Berkeley (jobratt) attacked San Pablo (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T21:53:36.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Berkeley (jobratt) occupied San Pablo with 3 troops.",
+    "timestamp": "2016-01-26T21:53:50.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "San Pablo (jobratt) attacked Martinez (gcochard) killing 0, losing 2.",
+    "timestamp": "2016-01-26T21:53:55.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Walnut Creek (jobratt) attacked Martinez (gcochard) killing 0, losing 2.",
+    "timestamp": "2016-01-26T21:54:21.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Concord (jobratt) attacked Martinez (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-26T21:54:24.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Walnut Creek (jobratt) was fortified from Berkeley (jobratt) with 2 troops.",
+    "timestamp": "2016-01-26T21:54:37.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-26T21:54:37.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-26T21:54:37.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-26T21:54:58.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "kwren received 3 troops for 9 territories.",
+    "timestamp": "2016-01-26T21:54:58.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "kwren received 2 troops on Hayward",
+    "timestamp": "2016-01-26T21:55:04.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "kwren received 2 troops on Danville",
+    "timestamp": "2016-01-26T21:55:04.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Castro Valley (kwren) was reinforced by kwren with 4 troops.",
+    "timestamp": "2016-01-26T21:55:24.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Pleasanton (kwren) was reinforced by kwren with 7 troops.",
+    "timestamp": "2016-01-26T21:55:30.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Castro Valley (kwren) attacked South San Leandro (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T21:55:33.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Castro Valley (kwren) occupied South San Leandro with 7 troops.",
+    "timestamp": "2016-01-26T21:55:35.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "South San Leandro (kwren) attacked Dublin (Neutral) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-01-26T21:55:41.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "South San Leandro (kwren) occupied Dublin with 4 troops.",
+    "timestamp": "2016-01-26T21:55:43.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Hayward (kwren) attacked Union City (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-26T21:55:48.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Hayward (kwren) occupied Union City with 6 troops.",
+    "timestamp": "2016-01-26T21:55:53.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Union City (kwren) attacked Fremont (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T21:56:00.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Union City (kwren) occupied Fremont with 5 troops.",
+    "timestamp": "2016-01-26T21:56:04.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Fremont (kwren) attacked Newark (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-26T21:56:08.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Fremont (kwren) occupied Newark with 3 troops.",
+    "timestamp": "2016-01-26T21:56:14.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Pleasanton (kwren) attacked Sunol (gcochard) conquering it, killing 2, losing 0.",
+    "timestamp": "2016-01-26T21:56:18.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Pleasanton (kwren) occupied Sunol with 7 troops.",
+    "timestamp": "2016-01-26T21:56:24.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Sunol (kwren) attacked Milpitas (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T21:56:27.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Sunol (kwren) occupied Milpitas with 1 troop.",
+    "timestamp": "2016-01-26T21:56:33.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Dublin (kwren) attacked Livermore (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-26T21:58:13.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Dublin (kwren) occupied Livermore with 2 troops.",
+    "timestamp": "2016-01-26T21:58:16.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Livermore (kwren) was fortified from Sunol (kwren) with 5 troops.",
+    "timestamp": "2016-01-26T21:58:27.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-26T21:58:27.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-26T21:58:27.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-26T22:29:20.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier received 3 troops for 9 territories.",
+    "timestamp": "2016-01-26T22:29:20.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier received 2 troops for holding Marin.",
+    "timestamp": "2016-01-26T22:29:20.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Lafayette (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-26T22:29:35.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Marin City (mmacfreier) was reinforced by mmacfreier with 2 troops.",
+    "timestamp": "2016-01-26T22:29:38.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Lafayette (mmacfreier) attacked Berkeley (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T22:29:41.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Lafayette (mmacfreier) occupied Berkeley with 8 troops.",
+    "timestamp": "2016-01-26T22:29:42.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Berkeley (mmacfreier) attacked Richmond (tanleach1001) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-26T22:29:47.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Berkeley (mmacfreier) occupied Richmond with 7 troops.",
+    "timestamp": "2016-01-26T22:30:02.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Marin City (mmacfreier) was fortified from Wildcat Canyon (mmacfreier) with 2 troops.",
+    "timestamp": "2016-01-26T22:30:13.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-26T22:30:13.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-26T22:30:13.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-26T23:18:34.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 5 territories.",
+    "timestamp": "2016-01-26T23:18:34.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "San Bruno (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-26T23:18:39.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "San Bruno (ryanbmilbourne) attacked Half Moon Bay (mmacfreier) conquering it, killing 2, losing 0.",
+    "timestamp": "2016-01-26T23:18:44.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "San Bruno (ryanbmilbourne) occupied Half Moon Bay with 4 troops.",
+    "timestamp": "2016-01-26T23:18:54.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-26T23:19:04.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-26T23:19:04.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "Round 5 started.",
+    "timestamp": "2016-01-26T23:19:04.000Z",
+    "player": "unknown",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-26T23:19:10.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 10 territories.",
+    "timestamp": "2016-01-26T23:19:10.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received 2 troops on Oakland",
+    "timestamp": "2016-01-26T23:19:14.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Downtown (tanleach1001) was reinforced by tanleach1001 with 8 troops.",
+    "timestamp": "2016-01-26T23:20:09.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Sunset District (tanleach1001) was reinforced by tanleach1001 with 1 troop.",
+    "timestamp": "2016-01-26T23:20:13.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Portola (tanleach1001) was reinforced by tanleach1001 with 1 troop.",
+    "timestamp": "2016-01-26T23:20:17.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Alamo (tanleach1001) was reinforced by tanleach1001 with 1 troop.",
+    "timestamp": "2016-01-26T23:20:28.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Alamo (tanleach1001) attacked Moraga (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T23:20:30.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Alamo (tanleach1001) occupied Moraga with 3 troops.",
+    "timestamp": "2016-01-26T23:20:32.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Oakland (tanleach1001) attacked Alameda (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T23:20:41.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Oakland (tanleach1001) occupied Alameda with 1 troop.",
+    "timestamp": "2016-01-26T23:20:53.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Downtown (tanleach1001) attacked Pacific Heights (Neutral) conquering it, killing 3, losing 3.",
+    "timestamp": "2016-01-26T23:21:02.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Downtown (tanleach1001) occupied Pacific Heights with 5 troops.",
+    "timestamp": "2016-01-26T23:21:22.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Alameda (tanleach1001) was fortified from Downtown (tanleach1001) with 2 troops.",
+    "timestamp": "2016-01-26T23:21:44.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-26T23:21:44.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-26T23:21:44.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-26T23:36:00.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "gcochard received 3 troops for 6 territories.",
+    "timestamp": "2016-01-26T23:36:00.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Belmont (gcochard) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-01-26T23:36:10.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Belmont (gcochard) attacked Foster City (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T23:36:13.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Belmont (gcochard) occupied Foster City with 3 troops.",
+    "timestamp": "2016-01-26T23:36:17.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Palo Alto (gcochard) was fortified from Foster City (gcochard) with 2 troops.",
+    "timestamp": "2016-01-26T23:36:41.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-26T23:36:42.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-26T23:36:42.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-26T23:37:19.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "jobratt received 3 troops for 7 territories.",
+    "timestamp": "2016-01-26T23:37:19.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "jobratt received 3 troops for holding Sacramento.",
+    "timestamp": "2016-01-26T23:37:19.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Burlingame (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-01-26T23:37:46.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Concord (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-01-26T23:37:54.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Burlingame (jobratt) attacked Foster City (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T23:38:13.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Burlingame (jobratt) occupied Foster City with 1 troop.",
+    "timestamp": "2016-01-26T23:38:16.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Burlingame (jobratt) attacked San Mateo (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T23:38:21.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Burlingame (jobratt) occupied San Mateo with 1 troop.",
+    "timestamp": "2016-01-26T23:38:26.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-26T23:38:57.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-26T23:38:57.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-26T23:39:04.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received 5 troops for 15 territories.",
+    "timestamp": "2016-01-26T23:39:04.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received 4 troops for holding Stanislaus.",
+    "timestamp": "2016-01-26T23:39:04.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received 3 troops for holding Merced.",
+    "timestamp": "2016-01-26T23:39:04.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Livermore (kwren) was reinforced by kwren with 6 troops.",
+    "timestamp": "2016-01-26T23:39:16.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Newark (kwren) was reinforced by kwren with 6 troops.",
+    "timestamp": "2016-01-26T23:39:18.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Newark (kwren) attacked Palo Alto (gcochard) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-26T23:39:22.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Newark (kwren) occupied Palo Alto with 8 troops.",
+    "timestamp": "2016-01-26T23:39:24.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Palo Alto (kwren) attacked Redwood City (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T23:39:27.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Palo Alto (kwren) occupied Redwood City with 7 troops.",
+    "timestamp": "2016-01-26T23:39:30.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Redwood City (kwren) attacked Belmont (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-26T23:39:35.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Redwood City (kwren) occupied Belmont with 1 troop.",
+    "timestamp": "2016-01-26T23:39:48.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Livermore (kwren) attacked Blackhawk (gcochard) killing 1, losing 11.",
+    "timestamp": "2016-01-26T23:40:18.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Black Diamond Mines (kwren) attacked Tassajara (gcochard) killing 0, losing 1.",
+    "timestamp": "2016-01-26T23:40:22.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Livermore (kwren) attacked Blackhawk (gcochard) killing 0, losing 1.",
+    "timestamp": "2016-01-26T23:40:33.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Black Diamond Mines (kwren) attacked Tassajara (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T23:40:39.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Livermore (kwren) was fortified from Redwood City (kwren) with 4 troops.",
+    "timestamp": "2016-01-26T23:40:46.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-26T23:40:47.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-26T23:40:47.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-26T23:42:16.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier received 3 troops for 9 territories.",
+    "timestamp": "2016-01-26T23:42:16.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier received 2 troops for holding Marin.",
+    "timestamp": "2016-01-26T23:42:16.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier received 2 troops on Mill Valley",
+    "timestamp": "2016-01-26T23:42:22.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Marin City (mmacfreier) was reinforced by mmacfreier with 2 troops.",
+    "timestamp": "2016-01-26T23:42:51.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Lafayette (mmacfreier) was reinforced by mmacfreier with 11 troops.",
+    "timestamp": "2016-01-26T23:43:06.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Lafayette (mmacfreier) attacked San Pablo (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-26T23:43:12.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Lafayette (mmacfreier) occupied San Pablo with 5 troops.",
+    "timestamp": "2016-01-26T23:43:25.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Lafayette (mmacfreier) attacked Alamo (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T23:43:29.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Lafayette (mmacfreier) occupied Alamo with 1 troop.",
+    "timestamp": "2016-01-26T23:43:35.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Berkeley (mmacfreier) was fortified from Richmond (mmacfreier) with 4 troops.",
+    "timestamp": "2016-01-26T23:43:54.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-26T23:43:54.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-26T23:43:54.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-26T23:44:00.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 6 territories.",
+    "timestamp": "2016-01-26T23:44:00.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for holding San Mateo.",
+    "timestamp": "2016-01-26T23:44:00.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Half Moon Bay (ryanbmilbourne) was reinforced by ryanbmilbourne with 4 troops.",
+    "timestamp": "2016-01-26T23:44:29.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "San Bruno (ryanbmilbourne) was reinforced by ryanbmilbourne with 4 troops.",
+    "timestamp": "2016-01-26T23:44:34.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "SFO (ryanbmilbourne) was reinforced by ryanbmilbourne with 6 troops.",
+    "timestamp": "2016-01-26T23:44:38.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "SFO (ryanbmilbourne) attacked Millbrae (jobratt) conquering it, killing 2, losing 3.",
+    "timestamp": "2016-01-26T23:44:43.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "SFO (ryanbmilbourne) occupied Millbrae with 6 troops.",
+    "timestamp": "2016-01-26T23:45:42.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "San Bruno (ryanbmilbourne) attacked Burlingame (jobratt) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-01-26T23:45:50.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "San Bruno (ryanbmilbourne) occupied Burlingame with 1 troop.",
+    "timestamp": "2016-01-26T23:46:02.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Millbrae (ryanbmilbourne) attacked Foster City (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T23:46:06.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Millbrae (ryanbmilbourne) occupied Foster City with 5 troops.",
+    "timestamp": "2016-01-26T23:46:09.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Foster City (ryanbmilbourne) attacked San Mateo (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-26T23:46:14.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Foster City (ryanbmilbourne) occupied San Mateo with 1 troop.",
+    "timestamp": "2016-01-26T23:46:17.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "San Mateo (ryanbmilbourne) was fortified from San Bruno (ryanbmilbourne) with 3 troops.",
+    "timestamp": "2016-01-26T23:46:29.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-01-26T23:46:29.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-26T23:46:29.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Round 6 started.",
+    "timestamp": "2016-01-26T23:46:29.000Z",
+    "player": "unknown",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-27T00:07:14.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 received 4 troops for 12 territories.",
+    "timestamp": "2016-01-27T00:07:14.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 received 4 troops for holding San Francisco.",
+    "timestamp": "2016-01-27T00:07:14.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Pacific Heights (tanleach1001) was reinforced by tanleach1001 with 2 troops.",
+    "timestamp": "2016-01-27T00:07:34.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Alameda (tanleach1001) was reinforced by tanleach1001 with 2 troops.",
+    "timestamp": "2016-01-27T00:07:47.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Oakland (tanleach1001) was reinforced by tanleach1001 with 2 troops.",
+    "timestamp": "2016-01-27T00:07:51.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "North San Leandro (tanleach1001) was reinforced by tanleach1001 with 2 troops.",
+    "timestamp": "2016-01-27T00:07:59.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "North San Leandro (tanleach1001) attacked San Ramon (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T00:08:04.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "North San Leandro (tanleach1001) occupied San Ramon with 1 troop.",
+    "timestamp": "2016-01-27T00:08:19.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Moraga (tanleach1001) was fortified from North San Leandro (tanleach1001) with 1 troop.",
+    "timestamp": "2016-01-27T00:08:41.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-27T00:08:41.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-27T00:08:41.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-27T00:13:45.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "gcochard received 3 troops for 2 territories.",
+    "timestamp": "2016-01-27T00:13:45.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Clayton (gcochard) was reinforced by gcochard with 11 troops.",
+    "timestamp": "2016-01-27T00:13:55.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Clayton (gcochard) attacked Mt. Diablo (ryanbmilbourne) conquering it, killing 3, losing 5.",
+    "timestamp": "2016-01-27T00:14:04.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Clayton (gcochard) occupied Mt. Diablo with 6 troops.",
+    "timestamp": "2016-01-27T00:14:06.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Mt. Diablo (gcochard) attacked Tassajara (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T00:14:11.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Mt. Diablo (gcochard) occupied Tassajara with 5 troops.",
+    "timestamp": "2016-01-27T00:14:12.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Tassajara (gcochard) attacked Black Diamond Mines (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T00:14:18.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Tassajara (gcochard) occupied Black Diamond Mines with 1 troop.",
+    "timestamp": "2016-01-27T00:14:21.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-27T00:14:32.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-27T00:14:32.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-27T00:16:47.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "jobratt received 3 troops for 4 territories.",
+    "timestamp": "2016-01-27T00:16:47.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "jobratt received 3 troops for holding Sacramento.",
+    "timestamp": "2016-01-27T00:16:47.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Walnut Creek (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-01-27T00:17:22.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Martinez (jobratt) was reinforced by jobratt with 4 troops.",
+    "timestamp": "2016-01-27T00:17:36.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Concord (jobratt) was reinforced by jobratt with 7 troops.",
+    "timestamp": "2016-01-27T00:17:47.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Concord (jobratt) attacked Black Diamond Mines (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T00:17:52.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Concord (jobratt) occupied Black Diamond Mines with 9 troops.",
+    "timestamp": "2016-01-27T00:17:59.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Black Diamond Mines (jobratt) attacked Clayton (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T00:18:05.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Black Diamond Mines (jobratt) occupied Clayton with 4 troops.",
+    "timestamp": "2016-01-27T00:18:33.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Black Diamond Mines (jobratt) was fortified from Pittsburg (jobratt) with 1 troop.",
+    "timestamp": "2016-01-27T00:18:43.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-27T00:18:43.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-27T00:18:43.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-27T00:22:49.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 5 troops for 16 territories.",
+    "timestamp": "2016-01-27T00:22:49.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 4 troops for holding Stanislaus.",
+    "timestamp": "2016-01-27T00:22:49.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 3 troops for holding Merced.",
+    "timestamp": "2016-01-27T00:22:49.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Livermore (kwren) was reinforced by kwren with 5 troops.",
+    "timestamp": "2016-01-27T00:22:55.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Danville (kwren) was reinforced by kwren with 3 troops.",
+    "timestamp": "2016-01-27T00:22:59.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Hayward (kwren) was reinforced by kwren with 4 troops.",
+    "timestamp": "2016-01-27T00:23:02.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Danville (kwren) attacked Alamo (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T00:23:05.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Danville (kwren) occupied Alamo with 9 troops.",
+    "timestamp": "2016-01-27T00:23:07.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Livermore (kwren) attacked Blackhawk (gcochard) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-27T00:23:13.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Livermore (kwren) occupied Blackhawk with 1 troop.",
+    "timestamp": "2016-01-27T00:23:20.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Alamo (kwren) attacked Walnut Creek (jobratt) killing 0, losing 2.",
+    "timestamp": "2016-01-27T00:23:38.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Alamo (kwren) attacked Lafayette (mmacfreier) conquering it, killing 5, losing 3.",
+    "timestamp": "2016-01-27T00:23:47.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Alamo (kwren) occupied Lafayette with 3 troops.",
+    "timestamp": "2016-01-27T00:23:50.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Livermore (kwren) attacked Tassajara (gcochard) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-01-27T00:23:58.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Livermore (kwren) occupied Tassajara with 6 troops.",
+    "timestamp": "2016-01-27T00:24:04.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Tassajara (kwren) attacked Mt. Diablo (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T00:24:07.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "gcochard was defeated by kwren.",
+    "timestamp": "2016-01-27T00:24:07.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Tassajara (kwren) occupied Mt. Diablo with 1 troop.",
+    "timestamp": "2016-01-27T00:24:18.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Hayward (kwren) was reinforced by kwren with 5 troops.",
+    "timestamp": "2016-01-27T00:24:37.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Livermore (kwren) was reinforced by kwren with 3 troops.",
+    "timestamp": "2016-01-27T00:24:40.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Hayward (kwren) attacked Foster City (ryanbmilbourne) conquering it, killing 4, losing 3.",
+    "timestamp": "2016-01-27T00:24:50.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Hayward (kwren) occupied Foster City with 6 troops.",
+    "timestamp": "2016-01-27T00:24:56.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Foster City (kwren) attacked Millbrae (ryanbmilbourne) killing 0, losing 1.",
+    "timestamp": "2016-01-27T00:25:38.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Foster City (kwren) was fortified from Tassajara (kwren) with 4 troops.",
+    "timestamp": "2016-01-27T00:27:51.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-27T00:27:51.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-27T00:27:51.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-27T00:28:09.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier received 3 troops for 9 territories.",
+    "timestamp": "2016-01-27T00:28:09.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier received 2 troops for holding Marin.",
+    "timestamp": "2016-01-27T00:28:09.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Berkeley (mmacfreier) was reinforced by mmacfreier with 5 troops.",
+    "timestamp": "2016-01-27T00:28:17.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Berkeley (mmacfreier) attacked Lafayette (kwren) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-27T00:28:23.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Berkeley (mmacfreier) occupied Lafayette with 4 troops.",
+    "timestamp": "2016-01-27T00:28:43.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Lafayette (mmacfreier) was fortified from Mill Valley (mmacfreier) with 2 troops.",
+    "timestamp": "2016-01-27T00:28:55.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-27T00:28:55.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-27T00:28:55.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-27T00:30:14.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 8 territories.",
+    "timestamp": "2016-01-27T00:30:14.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for holding San Mateo.",
+    "timestamp": "2016-01-27T00:30:14.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "San Mateo (ryanbmilbourne) was reinforced by ryanbmilbourne with 6 troops.",
+    "timestamp": "2016-01-27T00:30:20.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "San Mateo (ryanbmilbourne) attacked Foster City (kwren) killing 1, losing 7.",
+    "timestamp": "2016-01-27T00:30:42.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "San Mateo (ryanbmilbourne) was fortified from Half Moon Bay (ryanbmilbourne) with 7 troops.",
+    "timestamp": "2016-01-27T00:32:01.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-27T00:32:01.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Round 7 started.",
+    "timestamp": "2016-01-27T00:32:01.000Z",
+    "player": "unknown",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-27T00:32:11.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 received 4 troops for 13 territories.",
+    "timestamp": "2016-01-27T00:32:11.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 received 4 troops for holding San Francisco.",
+    "timestamp": "2016-01-27T00:32:11.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "San Ramon (tanleach1001) was reinforced by tanleach1001 with 5 troops.",
+    "timestamp": "2016-01-27T00:33:07.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Sunset District (tanleach1001) was reinforced by tanleach1001 with 1 troop.",
+    "timestamp": "2016-01-27T00:33:20.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Portola (tanleach1001) was reinforced by tanleach1001 with 1 troop.",
+    "timestamp": "2016-01-27T00:33:25.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Pacific Heights (tanleach1001) was reinforced by tanleach1001 with 9 troops.",
+    "timestamp": "2016-01-27T00:33:28.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "San Ramon (tanleach1001) attacked Danville (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T00:33:31.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "San Ramon (tanleach1001) occupied Danville with 5 troops.",
+    "timestamp": "2016-01-27T00:33:33.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Danville (tanleach1001) attacked Alamo (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T00:33:36.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Danville (tanleach1001) occupied Alamo with 4 troops.",
+    "timestamp": "2016-01-27T00:33:38.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Pacific Heights (tanleach1001) attacked Marin City (mmacfreier) conquering it, killing 7, losing 5.",
+    "timestamp": "2016-01-27T00:33:57.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Pacific Heights (tanleach1001) occupied Marin City with 10 troops.",
+    "timestamp": "2016-01-27T00:35:26.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Marin City (tanleach1001) attacked Muir Woods (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T00:35:30.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Marin City (tanleach1001) occupied Muir Woods with 9 troops.",
+    "timestamp": "2016-01-27T00:35:46.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Muir Woods (tanleach1001) attacked San Rafael (mmacfreier) conquering it, killing 2, losing 1.",
+    "timestamp": "2016-01-27T00:35:52.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Muir Woods (tanleach1001) occupied San Rafael with 7 troops.",
+    "timestamp": "2016-01-27T00:35:55.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "San Rafael (tanleach1001) attacked Mill Valley (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T00:36:02.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "San Rafael (tanleach1001) occupied Mill Valley with 1 troop.",
+    "timestamp": "2016-01-27T00:36:10.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Pacific Heights (tanleach1001) was fortified from San Rafael (tanleach1001) with 5 troops.",
+    "timestamp": "2016-01-27T00:39:28.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-27T00:39:28.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-27T00:39:28.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-27T00:44:17.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "jobratt received 3 troops for 6 territories.",
+    "timestamp": "2016-01-27T00:44:17.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "jobratt received 3 troops for holding Sacramento.",
+    "timestamp": "2016-01-27T00:44:17.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Walnut Creek (jobratt) was reinforced by jobratt with 6 troops.",
+    "timestamp": "2016-01-27T00:44:31.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Walnut Creek (jobratt) attacked Lafayette (mmacfreier) conquering it, killing 6, losing 8.",
+    "timestamp": "2016-01-27T00:44:43.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Walnut Creek (jobratt) occupied Lafayette with 3 troops.",
+    "timestamp": "2016-01-27T00:44:50.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Lafayette (jobratt) was fortified from Black Diamond Mines (jobratt) with 4 troops.",
+    "timestamp": "2016-01-27T00:45:04.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-27T00:45:04.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-27T00:45:04.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-27T00:45:30.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren received 6 troops for 19 territories.",
+    "timestamp": "2016-01-27T00:45:30.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren received 4 troops for holding Stanislaus.",
+    "timestamp": "2016-01-27T00:45:30.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren received 3 troops for holding Merced.",
+    "timestamp": "2016-01-27T00:45:30.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Foster City (kwren) was reinforced by kwren with 13 troops.",
+    "timestamp": "2016-01-27T00:45:34.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Foster City (kwren) attacked San Mateo (ryanbmilbourne) conquering it, killing 10, losing 8.",
+    "timestamp": "2016-01-27T00:46:25.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Foster City (kwren) occupied San Mateo with 1 troop.",
+    "timestamp": "2016-01-27T00:46:33.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Foster City (kwren) attacked Burlingame (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T00:46:39.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Foster City (kwren) occupied Burlingame with 4 troops.",
+    "timestamp": "2016-01-27T00:46:47.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Burlingame (kwren) attacked San Bruno (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T00:46:57.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Burlingame (kwren) occupied San Bruno with 3 troops.",
+    "timestamp": "2016-01-27T00:47:00.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "San Bruno (kwren) attacked Millbrae (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T00:47:06.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "San Bruno (kwren) occupied Millbrae with 2 troops.",
+    "timestamp": "2016-01-27T00:47:08.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Millbrae (kwren) attacked SFO (ryanbmilbourne) killing 0, losing 1.",
+    "timestamp": "2016-01-27T00:47:18.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Foster City (kwren) was fortified from Livermore (kwren) with 3 troops.",
+    "timestamp": "2016-01-27T00:47:35.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-27T00:47:35.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-27T00:47:35.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-01-27T01:02:34.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier received 3 troops for 5 territories.",
+    "timestamp": "2016-01-27T01:02:34.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Richmond (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-01-27T01:02:55.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Berkeley (mmacfreier) attacked Alameda (tanleach1001) killing 3, losing 5.",
+    "timestamp": "2016-01-27T01:03:04.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "San Pablo (mmacfreier) attacked Martinez (jobratt) killing 2, losing 4.",
+    "timestamp": "2016-01-27T01:03:11.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Richmond (mmacfreier) attacked San Rafael (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T01:03:15.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Richmond (mmacfreier) occupied San Rafael with 5 troops.",
+    "timestamp": "2016-01-27T01:03:16.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "San Rafael (mmacfreier) attacked Mill Valley (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T01:03:20.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "San Rafael (mmacfreier) occupied Mill Valley with 3 troops.",
+    "timestamp": "2016-01-27T01:03:23.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-01-27T01:03:28.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-01-27T01:03:28.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-01-27T15:44:39.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 4 territories.",
+    "timestamp": "2016-01-27T15:44:39.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Half Moon Bay (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-01-27T15:44:54.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Half Moon Bay (ryanbmilbourne) attacked Huddart Park (mmacfreier) killing 1, losing 3.",
+    "timestamp": "2016-01-27T15:45:11.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-01-27T15:45:17.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Round 8 started.",
+    "timestamp": "2016-01-27T15:45:17.000Z",
+    "player": "unknown",
+    "round": 8
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-27T16:10:27.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "tanleach1001 received 5 troops for 17 territories.",
+    "timestamp": "2016-01-27T16:10:27.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "tanleach1001 received 4 troops for holding San Francisco.",
+    "timestamp": "2016-01-27T16:10:27.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "tanleach1001 received 4 troops for holding Alameda.",
+    "timestamp": "2016-01-27T16:10:27.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Marin City (tanleach1001) was reinforced by tanleach1001 with 6 troops.",
+    "timestamp": "2016-01-27T16:11:45.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Sunset District (tanleach1001) was reinforced by tanleach1001 with 7 troops.",
+    "timestamp": "2016-01-27T16:11:50.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Marin City (tanleach1001) attacked Mill Valley (mmacfreier) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-01-27T16:11:58.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Marin City (tanleach1001) occupied Mill Valley with 4 troops.",
+    "timestamp": "2016-01-27T16:12:00.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Mill Valley (tanleach1001) attacked San Rafael (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T16:12:04.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Mill Valley (tanleach1001) occupied San Rafael with 3 troops.",
+    "timestamp": "2016-01-27T16:12:06.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "San Rafael (tanleach1001) attacked Richmond (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T16:12:12.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "San Rafael (tanleach1001) occupied Richmond with 2 troops.",
+    "timestamp": "2016-01-27T16:12:14.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Richmond (tanleach1001) attacked Wildcat Canyon (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T16:12:17.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Sunset District (tanleach1001) attacked Daly City (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T16:12:27.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Sunset District (tanleach1001) occupied Daly City with 9 troops.",
+    "timestamp": "2016-01-27T16:12:33.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Daly City (tanleach1001) attacked Pacifica (ryanbmilbourne) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-27T16:12:41.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Daly City (tanleach1001) occupied Pacifica with 1 troop.",
+    "timestamp": "2016-01-27T16:12:46.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Daly City (tanleach1001) attacked SFO (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T16:12:52.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Daly City (tanleach1001) occupied SFO with 4 troops.",
+    "timestamp": "2016-01-27T16:13:04.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "SFO (tanleach1001) attacked San Bruno (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T16:13:11.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "SFO (tanleach1001) occupied San Bruno with 3 troops.",
+    "timestamp": "2016-01-27T16:13:14.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "San Bruno (tanleach1001) attacked Half Moon Bay (ryanbmilbourne) killing 0, losing 2.",
+    "timestamp": "2016-01-27T16:13:19.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Oakland (tanleach1001) attacked Berkeley (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T16:13:33.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Oakland (tanleach1001) occupied Berkeley with 3 troops.",
+    "timestamp": "2016-01-27T16:13:38.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Berkeley (tanleach1001) attacked San Pablo (mmacfreier) killing 0, losing 2.",
+    "timestamp": "2016-01-27T16:13:43.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Alamo (tanleach1001) attacked Walnut Creek (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T16:13:48.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Alamo (tanleach1001) occupied Walnut Creek with 3 troops.",
+    "timestamp": "2016-01-27T16:17:42.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Walnut Creek (tanleach1001) attacked Martinez (jobratt) killing 1, losing 2.",
+    "timestamp": "2016-01-27T16:17:47.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Sunset District (tanleach1001) was fortified from Moraga (tanleach1001) with 3 troops.",
+    "timestamp": "2016-01-27T16:19:18.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-01-27T16:19:18.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-27T16:19:18.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-27T16:56:34.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "jobratt received 3 troops for 6 territories.",
+    "timestamp": "2016-01-27T16:56:34.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Clayton (jobratt) was reinforced by jobratt with 11 troops.",
+    "timestamp": "2016-01-27T16:57:32.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Clayton (jobratt) attacked Walnut Creek (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T16:57:35.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Clayton (jobratt) occupied Walnut Creek with 13 troops.",
+    "timestamp": "2016-01-27T16:57:36.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Walnut Creek (jobratt) attacked Alamo (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T16:57:40.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Walnut Creek (jobratt) occupied Alamo with 11 troops.",
+    "timestamp": "2016-01-27T16:57:41.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Alamo (jobratt) attacked Danville (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T16:57:43.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Alamo (jobratt) occupied Danville with 10 troops.",
+    "timestamp": "2016-01-27T16:57:44.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Danville (jobratt) attacked San Ramon (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T16:57:47.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Danville (jobratt) occupied San Ramon with 8 troops.",
+    "timestamp": "2016-01-27T16:57:48.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "San Ramon (jobratt) attacked North San Leandro (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T16:57:50.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "San Ramon (jobratt) occupied North San Leandro with 7 troops.",
+    "timestamp": "2016-01-27T16:57:51.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "North San Leandro (jobratt) attacked Oakland (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T16:57:54.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "North San Leandro (jobratt) occupied Oakland with 6 troops.",
+    "timestamp": "2016-01-27T16:57:55.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Oakland (jobratt) attacked Alameda (tanleach1001) conquering it, killing 2, losing 2.",
+    "timestamp": "2016-01-27T16:57:59.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Oakland (jobratt) occupied Alameda with 3 troops.",
+    "timestamp": "2016-01-27T16:58:03.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Alameda (jobratt) attacked Downtown (tanleach1001) killing 0, losing 2.",
+    "timestamp": "2016-01-27T16:58:08.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Lafayette (jobratt) attacked Berkeley (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T16:58:11.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Lafayette (jobratt) occupied Berkeley with 1 troop.",
+    "timestamp": "2016-01-27T16:58:41.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Lafayette (jobratt) attacked San Pablo (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T16:58:44.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Lafayette (jobratt) occupied San Pablo with 5 troops.",
+    "timestamp": "2016-01-27T16:58:48.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "San Pablo (jobratt) attacked Wildcat Canyon (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T16:58:52.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "San Pablo (jobratt) occupied Wildcat Canyon with 4 troops.",
+    "timestamp": "2016-01-27T16:58:53.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Wildcat Canyon (jobratt) attacked Richmond (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T16:58:55.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Wildcat Canyon (jobratt) occupied Richmond with 3 troops.",
+    "timestamp": "2016-01-27T16:58:56.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Richmond (jobratt) attacked San Rafael (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T16:59:08.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Richmond (jobratt) occupied San Rafael with 1 troop.",
+    "timestamp": "2016-01-27T16:59:21.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-27T16:59:34.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-27T16:59:34.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-27T17:09:27.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received 7 troops for 22 territories.",
+    "timestamp": "2016-01-27T17:09:27.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received 4 troops for holding Stanislaus.",
+    "timestamp": "2016-01-27T17:09:27.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received 3 troops for holding Merced.",
+    "timestamp": "2016-01-27T17:09:27.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received 3 troops for holding Santa Clara.",
+    "timestamp": "2016-01-27T17:09:27.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Burlingame (kwren) was reinforced by kwren with 17 troops.",
+    "timestamp": "2016-01-27T17:09:35.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Burlingame (kwren) attacked San Bruno (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T17:09:40.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Burlingame (kwren) occupied San Bruno with 16 troops.",
+    "timestamp": "2016-01-27T17:09:42.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "San Bruno (kwren) attacked Half Moon Bay (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T17:09:47.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "ryanbmilbourne was defeated by kwren.",
+    "timestamp": "2016-01-27T17:09:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "San Bruno (kwren) occupied Half Moon Bay with 6 troops.",
+    "timestamp": "2016-01-27T17:09:54.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received 2 troops on Pleasanton",
+    "timestamp": "2016-01-27T17:10:02.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received 2 troops on Fremont",
+    "timestamp": "2016-01-27T17:10:02.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received 2 troops on Palo Alto",
+    "timestamp": "2016-01-27T17:10:02.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Half Moon Bay (kwren) was reinforced by kwren with 4 troops.",
+    "timestamp": "2016-01-27T17:10:11.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Livermore (kwren) was reinforced by kwren with 4 troops.",
+    "timestamp": "2016-01-27T17:10:20.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "San Bruno (kwren) attacked SFO (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T17:10:24.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "San Bruno (kwren) occupied SFO with 9 troops.",
+    "timestamp": "2016-01-27T17:10:26.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "SFO (kwren) attacked Daly City (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T17:10:29.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "SFO (kwren) occupied Daly City with 8 troops.",
+    "timestamp": "2016-01-27T17:10:31.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Daly City (kwren) attacked Pacifica (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T17:10:35.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Daly City (kwren) occupied Pacifica with 1 troop.",
+    "timestamp": "2016-01-27T17:10:38.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Half Moon Bay (kwren) attacked Huddart Park (mmacfreier) conquering it, killing 2, losing 5.",
+    "timestamp": "2016-01-27T17:11:02.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier was defeated by kwren.",
+    "timestamp": "2016-01-27T17:11:02.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Half Moon Bay (kwren) occupied Huddart Park with 4 troops.",
+    "timestamp": "2016-01-27T17:11:05.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received 2 troops on Redwood City",
+    "timestamp": "2016-01-27T17:11:19.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received 2 troops on Millbrae",
+    "timestamp": "2016-01-27T17:11:19.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Daly City (kwren) was reinforced by kwren with 16 troops.",
+    "timestamp": "2016-01-27T17:11:29.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Huddart Park (kwren) attacked San Carlos (Neutral) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-27T17:11:34.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Huddart Park (kwren) occupied San Carlos with 2 troops.",
+    "timestamp": "2016-01-27T17:11:36.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Daly City (kwren) attacked Portola (tanleach1001) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-27T17:11:42.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Daly City (kwren) occupied Portola with 20 troops.",
+    "timestamp": "2016-01-27T17:11:44.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Portola (kwren) attacked Sunset District (tanleach1001) conquering it, killing 4, losing 0.",
+    "timestamp": "2016-01-27T17:11:48.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Portola (kwren) occupied Sunset District with 1 troop.",
+    "timestamp": "2016-01-27T17:11:52.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Portola (kwren) attacked Bayview (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T17:11:54.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Portola (kwren) occupied Bayview with 18 troops.",
+    "timestamp": "2016-01-27T17:11:56.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Bayview (kwren) attacked Hunters Point (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T17:11:59.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Bayview (kwren) occupied Hunters Point with 1 troop.",
+    "timestamp": "2016-01-27T17:12:05.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Bayview (kwren) attacked Noe Valley (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T17:12:07.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Bayview (kwren) occupied Noe Valley with 16 troops.",
+    "timestamp": "2016-01-27T17:12:09.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Noe Valley (kwren) attacked Pacific Heights (tanleach1001) conquering it, killing 6, losing 5.",
+    "timestamp": "2016-01-27T17:12:16.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Noe Valley (kwren) occupied Pacific Heights with 10 troops.",
+    "timestamp": "2016-01-27T17:12:19.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Pacific Heights (kwren) attacked Downtown (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T17:12:22.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Pacific Heights (kwren) occupied Downtown with 9 troops.",
+    "timestamp": "2016-01-27T17:12:25.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Downtown (kwren) attacked Alcatraz (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T17:12:28.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Downtown (kwren) occupied Alcatraz with 1 troop.",
+    "timestamp": "2016-01-27T17:12:30.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Downtown (kwren) attacked Alameda (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T17:12:34.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Downtown (kwren) occupied Alameda with 6 troops.",
+    "timestamp": "2016-01-27T17:12:35.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Alameda (kwren) attacked Oakland (jobratt) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-27T17:12:39.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Alameda (kwren) occupied Oakland with 3 troops.",
+    "timestamp": "2016-01-27T17:12:41.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Oakland (kwren) attacked Lafayette (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T17:12:44.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Oakland (kwren) occupied Lafayette with 2 troops.",
+    "timestamp": "2016-01-27T17:12:45.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Lafayette (kwren) attacked Walnut Creek (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T17:12:48.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Lafayette (kwren) was fortified from Foster City (kwren) with 9 troops.",
+    "timestamp": "2016-01-27T17:13:30.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-01-27T17:13:30.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-01-27T17:13:30.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Round 9 started.",
+    "timestamp": "2016-01-27T17:13:30.000Z",
+    "player": "unknown",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-01-27T17:13:48.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 4 territories.",
+    "timestamp": "2016-01-27T17:13:48.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Moraga (tanleach1001) was reinforced by tanleach1001 with 3 troops.",
+    "timestamp": "2016-01-27T17:14:00.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-01-27T17:15:10.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-01-27T17:16:22.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "jobratt received 4 troops for 14 territories.",
+    "timestamp": "2016-01-27T17:16:22.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "San Rafael (jobratt) was reinforced by jobratt with 4 troops.",
+    "timestamp": "2016-01-27T17:16:32.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "San Rafael (jobratt) attacked Mill Valley (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T17:16:34.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "San Rafael (jobratt) occupied Mill Valley with 4 troops.",
+    "timestamp": "2016-01-27T17:16:35.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Mill Valley (jobratt) attacked Marin City (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T17:16:38.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Mill Valley (jobratt) occupied Marin City with 3 troops.",
+    "timestamp": "2016-01-27T17:16:39.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Marin City (jobratt) attacked Pacific Heights (kwren) killing 0, losing 2.",
+    "timestamp": "2016-01-27T17:16:42.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-01-27T17:16:45.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-01-27T17:16:45.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-01-27T17:17:39.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 13 troops for 41 territories.",
+    "timestamp": "2016-01-27T17:17:39.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 4 troops for holding Stanislaus.",
+    "timestamp": "2016-01-27T17:17:39.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 3 troops for holding Merced.",
+    "timestamp": "2016-01-27T17:17:39.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 3 troops for holding Santa Clara.",
+    "timestamp": "2016-01-27T17:17:39.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 3 troops for holding San Mateo.",
+    "timestamp": "2016-01-27T17:17:39.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 3 troops for holding San Benito.",
+    "timestamp": "2016-01-27T17:17:39.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 4 troops for holding San Francisco.",
+    "timestamp": "2016-01-27T17:17:39.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Pacific Heights (kwren) was reinforced by kwren with 33 troops.",
+    "timestamp": "2016-01-27T17:17:48.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Pacific Heights (kwren) attacked Marin City (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T17:17:53.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Pacific Heights (kwren) occupied Marin City with 32 troops.",
+    "timestamp": "2016-01-27T17:17:54.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Marin City (kwren) attacked Mill Valley (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T17:17:59.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Marin City (kwren) occupied Mill Valley with 30 troops.",
+    "timestamp": "2016-01-27T17:18:00.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Mill Valley (kwren) attacked Muir Woods (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T17:18:04.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Mill Valley (kwren) occupied Muir Woods with 28 troops.",
+    "timestamp": "2016-01-27T17:18:05.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Muir Woods (kwren) attacked San Rafael (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T17:18:08.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Muir Woods (kwren) occupied San Rafael with 27 troops.",
+    "timestamp": "2016-01-27T17:18:09.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "San Rafael (kwren) attacked Richmond (jobratt) conquering it, killing 2, losing 1.",
+    "timestamp": "2016-01-27T17:18:13.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "San Rafael (kwren) occupied Richmond with 25 troops.",
+    "timestamp": "2016-01-27T17:18:14.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Richmond (kwren) attacked Berkeley (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T17:18:23.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Richmond (kwren) occupied Berkeley with 24 troops.",
+    "timestamp": "2016-01-27T17:18:24.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Berkeley (kwren) attacked Wildcat Canyon (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T17:18:27.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Berkeley (kwren) occupied Wildcat Canyon with 23 troops.",
+    "timestamp": "2016-01-27T17:18:29.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Wildcat Canyon (kwren) attacked San Pablo (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T17:18:32.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Wildcat Canyon (kwren) occupied San Pablo with 22 troops.",
+    "timestamp": "2016-01-27T17:18:33.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "San Pablo (kwren) attacked Martinez (jobratt) conquering it, killing 2, losing 6.",
+    "timestamp": "2016-01-27T17:18:39.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "San Pablo (kwren) occupied Martinez with 15 troops.",
+    "timestamp": "2016-01-27T17:18:41.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Martinez (kwren) attacked Concord (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T17:18:43.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Martinez (kwren) occupied Concord with 14 troops.",
+    "timestamp": "2016-01-27T17:18:44.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Concord (kwren) attacked Clayton (jobratt) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-27T17:18:49.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Concord (kwren) occupied Clayton with 11 troops.",
+    "timestamp": "2016-01-27T17:18:50.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Clayton (kwren) attacked Black Diamond Mines (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T17:18:52.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Clayton (kwren) occupied Black Diamond Mines with 10 troops.",
+    "timestamp": "2016-01-27T17:18:53.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Black Diamond Mines (kwren) attacked Pittsburg (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T17:18:56.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Black Diamond Mines (kwren) occupied Pittsburg with 9 troops.",
+    "timestamp": "2016-01-27T17:18:57.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Lafayette (kwren) attacked Alamo (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T17:19:06.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Lafayette (kwren) occupied Alamo with 8 troops.",
+    "timestamp": "2016-01-27T17:19:08.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Alamo (kwren) attacked Danville (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T17:19:11.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Alamo (kwren) occupied Danville with 7 troops.",
+    "timestamp": "2016-01-27T17:19:12.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Danville (kwren) attacked San Ramon (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T17:19:17.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Danville (kwren) occupied San Ramon with 1 troop.",
+    "timestamp": "2016-01-27T17:19:19.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Danville (kwren) attacked North San Leandro (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T17:19:22.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "jobratt was defeated by kwren.",
+    "timestamp": "2016-01-27T17:19:22.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Danville (kwren) occupied North San Leandro with 1 troop.",
+    "timestamp": "2016-01-27T17:19:27.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 2 troops on Portola",
+    "timestamp": "2016-01-27T17:19:43.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 2 troops on Pacifica",
+    "timestamp": "2016-01-27T17:19:43.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 2 troops on San Mateo",
+    "timestamp": "2016-01-27T17:19:43.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Danville (kwren) was reinforced by kwren with 8 troops.",
+    "timestamp": "2016-01-27T17:19:49.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Danville (kwren) attacked Moraga (tanleach1001) conquering it, killing 4, losing 2.",
+    "timestamp": "2016-01-27T17:19:54.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 was defeated by kwren.",
+    "timestamp": "2016-01-27T17:19:54.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Game finished.",
+    "timestamp": "2016-01-27T17:19:54.000Z",
+    "player": "unknown",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 lost 18 rating.",
+    "timestamp": "2016-01-27T17:19:54.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 received 20 tokens.",
+    "timestamp": "2016-01-27T17:19:54.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "gcochard lost 14 rating.",
+    "timestamp": "2016-01-27T17:19:54.000Z",
+    "player": "gcochard",
+    "round": 9
+  },
+  {
+    "message": "gcochard received 20 tokens.",
+    "timestamp": "2016-01-27T17:19:54.000Z",
+    "player": "gcochard",
+    "round": 9
+  },
+  {
+    "message": "jobratt lost 30 rating.",
+    "timestamp": "2016-01-27T17:19:54.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "jobratt received 20 tokens.",
+    "timestamp": "2016-01-27T17:19:54.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "kwren won the game.",
+    "timestamp": "2016-01-27T17:19:54.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 101 rating.",
+    "timestamp": "2016-01-27T17:19:54.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 20 tokens.",
+    "timestamp": "2016-01-27T17:19:54.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier lost 23 rating.",
+    "timestamp": "2016-01-27T17:19:54.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier received 20 tokens.",
+    "timestamp": "2016-01-27T17:19:54.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "ryanbmilbourne lost 16 rating.",
+    "timestamp": "2016-01-27T17:19:54.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "ryanbmilbourne received 20 tokens.",
+    "timestamp": "2016-01-27T17:19:54.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "kwren received 8 troops for turning in cards Hayward, Noe Valley, and Danville.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 received 8 troops for turning in cards Berkeley, Walnut Creek, and Oakland.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier received 8 troops for turning in cards Mill Valley, Livermore, and Moraga.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "ryanbmilbourne received 8 troops for turning in cards Pittsburg, North San Leandro, and Alcatraz.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "gcochard received 8 troops for turning in cards Tassajara, Alameda, and San Ramon.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "gcochard",
+    "round": 9
+  },
+  {
+    "message": "jobratt received 8 troops for turning in cards Muir Woods, Black Diamond Mines, and Sunol.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "kwren received 8 troops for turning in cards Daly City, Half Moon Bay, and Burlingame.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 received 8 troops for turning in cards Lafayette, Foster City, and Wildcat Canyon.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "jobratt received 8 troops for turning in cards San Rafael, Belmont, and San Carlos.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "kwren received 8 troops for turning in cards Pleasanton, Fremont, and Palo Alto.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 8 troops for turning in cards Marin City, Redwood City, and Millbrae.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 8 troops for turning in cards Clayton, Concord, and Pacific Heights.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 8 troops for turning in cards Portola, Pacifica, and San Mateo.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "kwren",
+    "round": 9
+  }
+]

--- a/data/607443.json
+++ b/data/607443.json
@@ -1,0 +1,1274 @@
+[
+  {
+    "message": "Game created.",
+    "timestamp": "2016-01-27T00:56:27.000Z",
+    "player": "unknown",
+    "round": 0
+  },
+  {
+    "message": "greg<script>alert(2)</script> joined the game.",
+    "timestamp": "2016-01-27T00:56:27.000Z",
+    "player": "unknown",
+    "round": 0
+  },
+  {
+    "message": "gcochard joined the game.",
+    "timestamp": "2016-01-27T00:57:48.000Z",
+    "player": "gcochard",
+    "round": 0
+  },
+  {
+    "message": "Game started.",
+    "timestamp": "2016-01-27T00:57:48.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-27T00:58:03.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard received 4 troops for 14 territories.",
+    "timestamp": "2016-01-27T00:58:03.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Argentina (gcochard) was reinforced by gcochard with 4 troops.",
+    "timestamp": "2016-01-27T00:58:09.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Argentina (gcochard) attacked Peru (greg<script>alert(2)</script>) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-01-27T01:07:58.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Argentina (gcochard) occupied Peru with 4 troops.",
+    "timestamp": "2016-01-27T01:08:00.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "South Africa (gcochard) was fortified from Madagascar (gcochard) with 2 troops.",
+    "timestamp": "2016-01-27T01:08:14.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Congo (gcochard) was fortified from South Africa (gcochard) with 4 troops.",
+    "timestamp": "2016-01-27T01:08:16.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Alberta (gcochard) was fortified from Alaska (gcochard) with 2 troops.",
+    "timestamp": "2016-01-27T01:08:24.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Alberta (gcochard) was fortified from Siberia (gcochard) with 2 troops.",
+    "timestamp": "2016-01-27T01:08:31.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Alberta (gcochard) was fortified from China (gcochard) with 2 troops.",
+    "timestamp": "2016-01-27T01:08:35.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Alberta (gcochard) was fortified from Irkutsk (gcochard) with 2 troops.",
+    "timestamp": "2016-01-27T01:08:44.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Alberta (gcochard) was fortified from Kamchatka (gcochard) with 2 troops.",
+    "timestamp": "2016-01-27T01:08:48.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-27T01:08:56.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-27T01:08:56.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "greg<script>alert(2)</script> started the turn.",
+    "timestamp": "2016-01-27T01:09:10.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "greg<script>alert(2)</script> received 4 troops for 13 territories.",
+    "timestamp": "2016-01-27T01:09:10.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "Papua New Guinea (greg<script>alert(2)</script>) was reinforced by greg<script>alert(2)</script> with 4 troops.",
+    "timestamp": "2016-01-27T01:09:18.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "Papua New Guinea (greg<script>alert(2)</script>) attacked Western Australia (gcochard) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-27T01:09:24.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "Papua New Guinea (greg<script>alert(2)</script>) occupied Western Australia with 5 troops.",
+    "timestamp": "2016-01-27T01:09:26.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "Western Australia (greg<script>alert(2)</script>) attacked Eastern Australia (Neutral) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-27T01:09:31.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "Western Australia (greg<script>alert(2)</script>) occupied Eastern Australia with 4 troops.",
+    "timestamp": "2016-01-27T01:09:33.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "Northwest Territory (greg<script>alert(2)</script>) was fortified from Western United States (greg<script>alert(2)</script>) with 2 troops.",
+    "timestamp": "2016-01-27T01:09:50.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "Northwest Territory (greg<script>alert(2)</script>) was fortified from Ontario (greg<script>alert(2)</script>) with 2 troops.",
+    "timestamp": "2016-01-27T01:09:54.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "Western Europe (greg<script>alert(2)</script>) was fortified from Northern Europe (greg<script>alert(2)</script>) with 2 troops.",
+    "timestamp": "2016-01-27T01:10:00.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "Western Europe (greg<script>alert(2)</script>) was fortified from East Africa (greg<script>alert(2)</script>) with 2 troops.",
+    "timestamp": "2016-01-27T01:10:04.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "Western Europe (greg<script>alert(2)</script>) was fortified from Egypt (greg<script>alert(2)</script>) with 2 troops.",
+    "timestamp": "2016-01-27T01:10:07.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "Western Europe (greg<script>alert(2)</script>) was fortified from North Africa (greg<script>alert(2)</script>) with 2 troops.",
+    "timestamp": "2016-01-27T01:10:11.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "Kazakhstan (greg<script>alert(2)</script>) was fortified from India (greg<script>alert(2)</script>) with 2 troops.",
+    "timestamp": "2016-01-27T01:10:15.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "Indonesia (greg<script>alert(2)</script>) was fortified from Eastern Australia (greg<script>alert(2)</script>) with 3 troops.",
+    "timestamp": "2016-01-27T01:10:19.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "greg<script>alert(2)</script> received a card.",
+    "timestamp": "2016-01-27T01:10:28.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "greg<script>alert(2)</script> ended the turn.",
+    "timestamp": "2016-01-27T01:10:28.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "Round 2 started.",
+    "timestamp": "2016-01-27T01:10:28.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-27T01:10:36.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "gcochard received 4 troops for 14 territories.",
+    "timestamp": "2016-01-27T01:10:36.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Congo (gcochard) was reinforced by gcochard with 4 troops.",
+    "timestamp": "2016-01-27T01:10:42.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Congo (gcochard) attacked East Africa (greg<script>alert(2)</script>) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T01:10:48.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Congo (gcochard) occupied East Africa with 9 troops.",
+    "timestamp": "2016-01-27T01:10:49.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "East Africa (gcochard) attacked Egypt (greg<script>alert(2)</script>) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T01:10:56.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "East Africa (gcochard) occupied Egypt with 7 troops.",
+    "timestamp": "2016-01-27T01:10:58.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Egypt (gcochard) attacked North Africa (greg<script>alert(2)</script>) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-01-27T01:11:08.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Egypt (gcochard) occupied North Africa with 3 troops.",
+    "timestamp": "2016-01-27T01:11:11.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Alberta (gcochard) attacked Western United States (greg<script>alert(2)</script>) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T01:11:18.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Alberta (gcochard) occupied Western United States with 11 troops.",
+    "timestamp": "2016-01-27T01:11:22.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Western United States (gcochard) attacked Ontario (greg<script>alert(2)</script>) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T01:11:26.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Western United States (gcochard) occupied Ontario with 1 troop.",
+    "timestamp": "2016-01-27T01:11:30.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Central America (gcochard) was fortified from Western United States (gcochard) with 9 troops.",
+    "timestamp": "2016-01-27T01:11:52.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-27T01:12:00.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-27T01:12:00.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "greg<script>alert(2)</script> started the turn.",
+    "timestamp": "2016-01-27T01:12:06.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "greg<script>alert(2)</script> received 3 troops for 10 territories.",
+    "timestamp": "2016-01-27T01:12:06.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "greg<script>alert(2)</script> received 2 troops for holding Australia.",
+    "timestamp": "2016-01-27T01:12:06.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "Western Europe (greg<script>alert(2)</script>) was reinforced by greg<script>alert(2)</script> with 5 troops.",
+    "timestamp": "2016-01-27T01:12:13.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "Western Europe (greg<script>alert(2)</script>) attacked Britain (Neutral) conquering it, killing 3, losing 6.",
+    "timestamp": "2016-01-27T01:12:36.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "Western Europe (greg<script>alert(2)</script>) occupied Britain with 9 troops.",
+    "timestamp": "2016-01-27T01:12:51.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "Britain (greg<script>alert(2)</script>) attacked Iceland (Neutral) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-01-27T01:12:58.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "Britain (greg<script>alert(2)</script>) occupied Iceland with 6 troops.",
+    "timestamp": "2016-01-27T01:13:00.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "Iceland (greg<script>alert(2)</script>) attacked Scandinavia (Neutral) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-27T01:13:03.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "Iceland (greg<script>alert(2)</script>) occupied Scandinavia with 5 troops.",
+    "timestamp": "2016-01-27T01:13:05.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "Scandinavia (greg<script>alert(2)</script>) attacked Ukraine (gcochard) killing 2, losing 4.",
+    "timestamp": "2016-01-27T01:13:10.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "Kazakhstan (greg<script>alert(2)</script>) attacked Ukraine (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T01:13:17.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "Kazakhstan (greg<script>alert(2)</script>) occupied Ukraine with 4 troops.",
+    "timestamp": "2016-01-27T01:13:18.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "Ukraine (greg<script>alert(2)</script>) attacked Southern Europe (Neutral) killing 2, losing 3.",
+    "timestamp": "2016-01-27T01:13:22.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "Northwest Territory (greg<script>alert(2)</script>) attacked Greenland (Neutral) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-01-27T01:13:32.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "Northwest Territory (greg<script>alert(2)</script>) occupied Greenland with 4 troops.",
+    "timestamp": "2016-01-27T01:13:34.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "Indonesia (greg<script>alert(2)</script>) attacked Siam (Neutral) killing 2, losing 5.",
+    "timestamp": "2016-01-27T01:13:40.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "Yakutsk (greg<script>alert(2)</script>) attacked Siberia (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T01:13:49.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "Ukraine (greg<script>alert(2)</script>) was fortified from Greenland (greg<script>alert(2)</script>) with 3 troops.",
+    "timestamp": "2016-01-27T01:14:00.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "greg<script>alert(2)</script> received a card.",
+    "timestamp": "2016-01-27T01:14:08.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "greg<script>alert(2)</script> ended the turn.",
+    "timestamp": "2016-01-27T01:14:08.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "Round 3 started.",
+    "timestamp": "2016-01-27T01:14:08.000Z",
+    "player": "unknown",
+    "round": 3
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-27T01:14:20.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard received 5 troops for 17 territories.",
+    "timestamp": "2016-01-27T01:14:20.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard received 3 troops for holding Africa.",
+    "timestamp": "2016-01-27T01:14:20.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Quebec (gcochard) was reinforced by gcochard with 8 troops.",
+    "timestamp": "2016-01-27T01:14:31.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Central America (gcochard) attacked Venezuela (Neutral) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-27T01:14:46.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Central America (gcochard) occupied Venezuela with 11 troops.",
+    "timestamp": "2016-01-27T01:14:48.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Venezuela (gcochard) attacked Brazil (Neutral) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-27T01:14:53.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Venezuela (gcochard) occupied Brazil with 9 troops.",
+    "timestamp": "2016-01-27T01:14:55.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Quebec (gcochard) attacked Eastern United States (Neutral) conquering it, killing 3, losing 4.",
+    "timestamp": "2016-01-27T01:15:04.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Quebec (gcochard) occupied Eastern United States with 1 troop.",
+    "timestamp": "2016-01-27T01:15:08.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Quebec (gcochard) attacked Greenland (greg<script>alert(2)</script>) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T01:15:13.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Quebec (gcochard) occupied Greenland with 5 troops.",
+    "timestamp": "2016-01-27T01:15:15.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Greenland (gcochard) attacked Northwest Territory (greg<script>alert(2)</script>) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T01:15:18.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Greenland (gcochard) occupied Northwest Territory with 4 troops.",
+    "timestamp": "2016-01-27T01:15:20.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Alaska (gcochard) was fortified from Brazil (gcochard) with 8 troops.",
+    "timestamp": "2016-01-27T01:15:31.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Egypt (gcochard) was fortified from Northwest Territory (gcochard) with 3 troops.",
+    "timestamp": "2016-01-27T01:15:35.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Greenland (gcochard) was fortified from Peru (gcochard) with 3 troops.",
+    "timestamp": "2016-01-27T01:15:43.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "North Africa (gcochard) was fortified from Alaska (gcochard) with 1 troop.",
+    "timestamp": "2016-01-27T01:15:52.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "East Africa (gcochard) was fortified from Alaska (gcochard) with 3 troops.",
+    "timestamp": "2016-01-27T01:16:01.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Kamchatka (gcochard) was fortified from Alaska (gcochard) with 4 troops.",
+    "timestamp": "2016-01-27T01:16:14.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-27T01:16:17.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-27T01:16:17.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "greg<script>alert(2)</script> started the turn.",
+    "timestamp": "2016-01-27T01:16:22.000Z",
+    "player": "unknown",
+    "round": 3
+  },
+  {
+    "message": "greg<script>alert(2)</script> received 4 troops for 14 territories.",
+    "timestamp": "2016-01-27T01:16:22.000Z",
+    "player": "unknown",
+    "round": 3
+  },
+  {
+    "message": "greg<script>alert(2)</script> received 2 troops for holding Australia.",
+    "timestamp": "2016-01-27T01:16:22.000Z",
+    "player": "unknown",
+    "round": 3
+  },
+  {
+    "message": "Ukraine (greg<script>alert(2)</script>) was reinforced by greg<script>alert(2)</script> with 6 troops.",
+    "timestamp": "2016-01-27T01:16:25.000Z",
+    "player": "unknown",
+    "round": 3
+  },
+  {
+    "message": "Ukraine (greg<script>alert(2)</script>) attacked Southern Europe (Neutral) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T01:16:28.000Z",
+    "player": "unknown",
+    "round": 3
+  },
+  {
+    "message": "Ukraine (greg<script>alert(2)</script>) occupied Southern Europe with 9 troops.",
+    "timestamp": "2016-01-27T01:16:30.000Z",
+    "player": "unknown",
+    "round": 3
+  },
+  {
+    "message": "Southern Europe (greg<script>alert(2)</script>) attacked Middle East (Neutral) conquering it, killing 3, losing 5.",
+    "timestamp": "2016-01-27T01:16:41.000Z",
+    "player": "unknown",
+    "round": 3
+  },
+  {
+    "message": "Southern Europe (greg<script>alert(2)</script>) occupied Middle East with 1 troop.",
+    "timestamp": "2016-01-27T01:16:47.000Z",
+    "player": "unknown",
+    "round": 3
+  },
+  {
+    "message": "greg<script>alert(2)</script> received a card.",
+    "timestamp": "2016-01-27T01:17:01.000Z",
+    "player": "unknown",
+    "round": 3
+  },
+  {
+    "message": "greg<script>alert(2)</script> ended the turn.",
+    "timestamp": "2016-01-27T01:17:01.000Z",
+    "player": "unknown",
+    "round": 3
+  },
+  {
+    "message": "Round 4 started.",
+    "timestamp": "2016-01-27T01:17:01.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-27T01:17:06.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard received 7 troops for 22 territories.",
+    "timestamp": "2016-01-27T01:17:06.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard received 3 troops for holding Africa.",
+    "timestamp": "2016-01-27T01:17:06.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard received 2 troops for holding South America.",
+    "timestamp": "2016-01-27T01:17:06.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard received 5 troops for holding North America.",
+    "timestamp": "2016-01-27T01:17:06.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Kamchatka (gcochard) was reinforced by gcochard with 17 troops.",
+    "timestamp": "2016-01-27T01:17:18.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Kamchatka (gcochard) attacked Japan (Neutral) conquering it, killing 3, losing 4.",
+    "timestamp": "2016-01-27T01:17:34.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Kamchatka (gcochard) occupied Japan with 1 troop.",
+    "timestamp": "2016-01-27T01:17:41.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Kamchatka (gcochard) attacked Mongolia (Neutral) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-01-27T01:17:46.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Kamchatka (gcochard) occupied Mongolia with 1 troop.",
+    "timestamp": "2016-01-27T01:17:52.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Kamchatka (gcochard) attacked Yakutsk (greg<script>alert(2)</script>) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T01:17:55.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Kamchatka (gcochard) occupied Yakutsk with 14 troops.",
+    "timestamp": "2016-01-27T01:17:57.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Yakutsk (gcochard) attacked Siberia (greg<script>alert(2)</script>) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T01:18:04.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Yakutsk (gcochard) occupied Siberia with 12 troops.",
+    "timestamp": "2016-01-27T01:18:05.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Siberia (gcochard) attacked Ural (Neutral) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-01-27T01:18:09.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Siberia (gcochard) occupied Ural with 11 troops.",
+    "timestamp": "2016-01-27T01:18:11.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Ural (gcochard) attacked Kazakhstan (greg<script>alert(2)</script>) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T01:18:14.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Ural (gcochard) occupied Kazakhstan with 10 troops.",
+    "timestamp": "2016-01-27T01:18:15.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Kazakhstan (gcochard) attacked Middle East (greg<script>alert(2)</script>) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T01:18:18.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Kazakhstan (gcochard) occupied Middle East with 9 troops.",
+    "timestamp": "2016-01-27T01:18:20.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Middle East (gcochard) attacked India (greg<script>alert(2)</script>) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T01:18:23.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Middle East (gcochard) occupied India with 8 troops.",
+    "timestamp": "2016-01-27T01:18:25.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "India (gcochard) attacked Siam (Neutral) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T01:18:28.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "India (gcochard) occupied Siam with 7 troops.",
+    "timestamp": "2016-01-27T01:18:32.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Siam (gcochard) attacked Indonesia (greg<script>alert(2)</script>) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T01:18:41.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Siam (gcochard) occupied Indonesia with 5 troops.",
+    "timestamp": "2016-01-27T01:18:42.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Indonesia (gcochard) attacked Papua New Guinea (greg<script>alert(2)</script>) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T01:18:46.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Indonesia (gcochard) occupied Papua New Guinea with 4 troops.",
+    "timestamp": "2016-01-27T01:18:48.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Papua New Guinea (gcochard) attacked Eastern Australia (greg<script>alert(2)</script>) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T01:18:51.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Papua New Guinea (gcochard) occupied Eastern Australia with 3 troops.",
+    "timestamp": "2016-01-27T01:18:53.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Eastern Australia (gcochard) attacked Western Australia (greg<script>alert(2)</script>) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T01:19:00.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "North Africa (gcochard) was fortified from East Africa (gcochard) with 1 troop.",
+    "timestamp": "2016-01-27T01:19:17.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Egypt (gcochard) was fortified from East Africa (gcochard) with 1 troop.",
+    "timestamp": "2016-01-27T01:19:22.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Greenland (gcochard) was fortified from East Africa (gcochard) with 1 troop.",
+    "timestamp": "2016-01-27T01:19:29.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-01-27T01:19:31.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-01-27T01:19:31.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "greg<script>alert(2)</script> started the turn.",
+    "timestamp": "2016-01-27T01:19:38.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "greg<script>alert(2)</script> received 3 troops for 7 territories.",
+    "timestamp": "2016-01-27T01:19:38.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "greg<script>alert(2)</script> received 5 troops for holding Europe.",
+    "timestamp": "2016-01-27T01:19:38.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "Southern Europe (greg<script>alert(2)</script>) was reinforced by greg<script>alert(2)</script> with 12 troops.",
+    "timestamp": "2016-01-27T01:19:47.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "Southern Europe (greg<script>alert(2)</script>) attacked Middle East (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T01:19:52.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "Southern Europe (greg<script>alert(2)</script>) occupied Middle East with 14 troops.",
+    "timestamp": "2016-01-27T01:19:53.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "Middle East (greg<script>alert(2)</script>) attacked East Africa (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T01:19:59.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "Middle East (greg<script>alert(2)</script>) occupied East Africa with 1 troop.",
+    "timestamp": "2016-01-27T01:20:03.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "Middle East (greg<script>alert(2)</script>) attacked India (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T01:20:08.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "Middle East (greg<script>alert(2)</script>) occupied India with 10 troops.",
+    "timestamp": "2016-01-27T01:20:11.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "India (greg<script>alert(2)</script>) attacked Siam (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T01:20:17.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "India (greg<script>alert(2)</script>) occupied Siam with 9 troops.",
+    "timestamp": "2016-01-27T01:20:22.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "Siam (greg<script>alert(2)</script>) attacked Indonesia (gcochard) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-27T01:20:27.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "Siam (greg<script>alert(2)</script>) occupied Indonesia with 6 troops.",
+    "timestamp": "2016-01-27T01:20:29.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "Indonesia (greg<script>alert(2)</script>) attacked Papua New Guinea (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T01:20:39.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "Indonesia (greg<script>alert(2)</script>) occupied Papua New Guinea with 5 troops.",
+    "timestamp": "2016-01-27T01:20:41.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "Papua New Guinea (greg<script>alert(2)</script>) attacked Eastern Australia (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T01:20:45.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "Papua New Guinea (greg<script>alert(2)</script>) occupied Eastern Australia with 4 troops.",
+    "timestamp": "2016-01-27T01:20:47.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "Eastern Australia (greg<script>alert(2)</script>) attacked Western Australia (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T01:20:50.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "Eastern Australia (greg<script>alert(2)</script>) occupied Western Australia with 3 troops.",
+    "timestamp": "2016-01-27T01:20:52.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "Iceland (greg<script>alert(2)</script>) was fortified from Western Australia (greg<script>alert(2)</script>) with 2 troops.",
+    "timestamp": "2016-01-27T01:21:00.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "greg<script>alert(2)</script> received a card.",
+    "timestamp": "2016-01-27T01:21:02.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "greg<script>alert(2)</script> ended the turn.",
+    "timestamp": "2016-01-27T01:21:02.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "Round 5 started.",
+    "timestamp": "2016-01-27T01:21:02.000Z",
+    "player": "unknown",
+    "round": 5
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-01-27T16:19:11.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "gcochard received 9 troops for 27 territories.",
+    "timestamp": "2016-01-27T16:19:11.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "gcochard received 5 troops for holding North America.",
+    "timestamp": "2016-01-27T16:19:11.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "gcochard received 2 troops for holding South America.",
+    "timestamp": "2016-01-27T16:19:11.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "gcochard received 2 troops on Northwest Territory",
+    "timestamp": "2016-01-27T16:19:16.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "gcochard received 2 troops on Brazil",
+    "timestamp": "2016-01-27T16:19:16.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Greenland (gcochard) was reinforced by gcochard with 22 troops.",
+    "timestamp": "2016-01-27T16:19:26.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Greenland (gcochard) attacked Iceland (greg<script>alert(2)</script>) conquering it, killing 3, losing 3.",
+    "timestamp": "2016-01-27T16:19:30.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Greenland (gcochard) occupied Iceland with 23 troops.",
+    "timestamp": "2016-01-27T16:19:32.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Iceland (gcochard) attacked Scandinavia (greg<script>alert(2)</script>) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T16:19:40.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Iceland (gcochard) occupied Scandinavia with 21 troops.",
+    "timestamp": "2016-01-27T16:19:41.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Scandinavia (gcochard) attacked Ukraine (greg<script>alert(2)</script>) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T16:19:45.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Scandinavia (gcochard) occupied Ukraine with 20 troops.",
+    "timestamp": "2016-01-27T16:19:50.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Ukraine (gcochard) attacked Northern Europe (greg<script>alert(2)</script>) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T16:19:53.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Ukraine (gcochard) occupied Northern Europe with 19 troops.",
+    "timestamp": "2016-01-27T16:19:55.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Northern Europe (gcochard) attacked Britain (greg<script>alert(2)</script>) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T16:19:58.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Northern Europe (gcochard) occupied Britain with 18 troops.",
+    "timestamp": "2016-01-27T16:19:59.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Britain (gcochard) attacked Western Europe (greg<script>alert(2)</script>) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T16:20:02.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Britain (gcochard) occupied Western Europe with 17 troops.",
+    "timestamp": "2016-01-27T16:20:03.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Western Europe (gcochard) attacked Southern Europe (greg<script>alert(2)</script>) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-01-27T16:20:09.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Western Europe (gcochard) occupied Southern Europe with 13 troops.",
+    "timestamp": "2016-01-27T16:20:10.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Southern Europe (gcochard) attacked Middle East (greg<script>alert(2)</script>) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T16:20:15.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Southern Europe (gcochard) occupied Middle East with 11 troops.",
+    "timestamp": "2016-01-27T16:20:17.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Egypt (gcochard) attacked East Africa (greg<script>alert(2)</script>) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T16:20:20.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Egypt (gcochard) occupied East Africa with 4 troops.",
+    "timestamp": "2016-01-27T16:20:21.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Middle East (gcochard) attacked India (greg<script>alert(2)</script>) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T16:20:26.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Middle East (gcochard) occupied India with 9 troops.",
+    "timestamp": "2016-01-27T16:20:27.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "India (gcochard) attacked Siam (greg<script>alert(2)</script>) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T16:20:30.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "India (gcochard) occupied Siam with 8 troops.",
+    "timestamp": "2016-01-27T16:20:31.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Siam (gcochard) attacked Indonesia (greg<script>alert(2)</script>) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T16:20:34.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Siam (gcochard) occupied Indonesia with 7 troops.",
+    "timestamp": "2016-01-27T16:20:36.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Indonesia (gcochard) attacked Papua New Guinea (greg<script>alert(2)</script>) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-01-27T16:20:40.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Indonesia (gcochard) occupied Papua New Guinea with 5 troops.",
+    "timestamp": "2016-01-27T16:20:41.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Papua New Guinea (gcochard) attacked Eastern Australia (greg<script>alert(2)</script>) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-01-27T16:20:47.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Papua New Guinea (gcochard) occupied Eastern Australia with 2 troops.",
+    "timestamp": "2016-01-27T16:20:48.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Eastern Australia (gcochard) attacked Western Australia (greg<script>alert(2)</script>) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-01-27T16:20:50.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "greg<script>alert(2)</script> was defeated by gcochard.",
+    "timestamp": "2016-01-27T16:20:50.000Z",
+    "player": "unknown",
+    "round": 5
+  },
+  {
+    "message": "Game finished.",
+    "timestamp": "2016-01-27T16:20:50.000Z",
+    "player": "unknown",
+    "round": 5
+  },
+  {
+    "message": "gcochard won the game.",
+    "timestamp": "2016-01-27T16:20:50.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "gcochard received 23 rating.",
+    "timestamp": "2016-01-27T16:20:50.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "gcochard received 20 tokens.",
+    "timestamp": "2016-01-27T16:20:50.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "greg<script>alert(2)</script> lost 23 rating.",
+    "timestamp": "2016-01-27T16:20:50.000Z",
+    "player": "unknown",
+    "round": 5
+  },
+  {
+    "message": "greg<script>alert(2)</script> received 20 tokens.",
+    "timestamp": "2016-01-27T16:20:50.000Z",
+    "player": "unknown",
+    "round": 5
+  },
+  {
+    "message": "greg<script>alert(2)</script> received 4 troops for turning in cards Alaska, Kazakhstan, and Kamchatka.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "unknown",
+    "round": 5
+  },
+  {
+    "message": "gcochard received 6 troops for turning in cards Northwest Territory, Brazil, and Scandinavia.",
+    "timestamp": "2016-01-29T10:51:35.000Z",
+    "player": "gcochard",
+    "round": 5
+  }
+]

--- a/data/622574.json
+++ b/data/622574.json
@@ -1,0 +1,2588 @@
+[
+  {
+    "message": "Game created.",
+    "timestamp": "2016-03-10T17:04:09.000Z",
+    "player": "unknown",
+    "round": 0
+  },
+  {
+    "message": "gcochard joined the game.",
+    "timestamp": "2016-03-10T17:04:09.000Z",
+    "player": "gcochard",
+    "round": 0
+  },
+  {
+    "message": "mmacfreier joined the game.",
+    "timestamp": "2016-03-10T17:04:55.000Z",
+    "player": "mmacfreier",
+    "round": 0
+  },
+  {
+    "message": "tanleach1001 joined the game.",
+    "timestamp": "2016-03-10T17:04:55.000Z",
+    "player": "tanleach1001",
+    "round": 0
+  },
+  {
+    "message": "ryanbmilbourne joined the game.",
+    "timestamp": "2016-03-10T17:05:51.000Z",
+    "player": "ryanbmilbourne",
+    "round": 0
+  },
+  {
+    "message": "jobratt joined the game.",
+    "timestamp": "2016-03-10T18:35:03.000Z",
+    "player": "jobratt",
+    "round": 0
+  },
+  {
+    "message": "jobratt left the game.",
+    "timestamp": "2016-03-10T18:43:45.000Z",
+    "player": "unknown",
+    "round": 0
+  },
+  {
+    "message": "jobratt joined the game.",
+    "timestamp": "2016-03-10T18:43:48.000Z",
+    "player": "jobratt",
+    "round": 0
+  },
+  {
+    "message": "kwren joined the game.",
+    "timestamp": "2016-03-10T19:22:09.000Z",
+    "player": "kwren",
+    "round": 0
+  },
+  {
+    "message": "Game started.",
+    "timestamp": "2016-03-10T19:22:09.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-03-10T19:22:44.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier received 4 troops for 13 territories.",
+    "timestamp": "2016-03-10T19:22:44.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Syddanmark (mmacfreier) was reinforced by mmacfreier with 4 troops.",
+    "timestamp": "2016-03-10T19:23:15.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Syddanmark (mmacfreier) attacked Fyn (tanleach1001) conquering it, killing 3, losing 4.",
+    "timestamp": "2016-03-10T19:23:21.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Syddanmark (mmacfreier) occupied Fyn with 2 troops.",
+    "timestamp": "2016-03-10T19:23:23.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Fyn (mmacfreier) was fortified from Sørlandet (mmacfreier) with 2 troops.",
+    "timestamp": "2016-03-10T19:23:40.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Pärnumaa (mmacfreier) was fortified from Tartumaa (mmacfreier) with 2 troops.",
+    "timestamp": "2016-03-10T19:24:00.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-03-10T19:24:10.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-03-10T19:24:10.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-03-10T19:27:03.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard received 4 troops for 13 territories.",
+    "timestamp": "2016-03-10T19:27:03.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Suvalkija (gcochard) was reinforced by gcochard with 4 troops.",
+    "timestamp": "2016-03-10T19:27:29.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Suvalkija (gcochard) attacked Podlaskie (mmacfreier) conquering it, killing 3, losing 3.",
+    "timestamp": "2016-03-10T19:27:48.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Suvalkija (gcochard) occupied Podlaskie with 3 troops.",
+    "timestamp": "2016-03-10T19:27:52.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Mazowieckie (gcochard) was fortified from Žemaitija (gcochard) with 2 troops.",
+    "timestamp": "2016-03-10T19:28:03.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Skåne (gcochard) was fortified from København (gcochard) with 2 troops.",
+    "timestamp": "2016-03-10T19:28:08.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-03-10T19:28:15.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-03-10T19:28:15.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-03-10T19:28:21.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren received 4 troops for 13 territories.",
+    "timestamp": "2016-03-10T19:28:21.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Uppsala (kwren) was reinforced by kwren with 4 troops.",
+    "timestamp": "2016-03-10T19:28:28.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Uppsala (kwren) attacked Södermanland (gcochard) conquering it, killing 3, losing 4.",
+    "timestamp": "2016-03-10T19:28:45.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Uppsala (kwren) occupied Södermanland with 1 troop.",
+    "timestamp": "2016-03-10T19:28:48.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Uppsala (kwren) attacked Dalarna (gcochard) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-03-10T19:28:53.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Uppsala (kwren) occupied Dalarna with 1 troop.",
+    "timestamp": "2016-03-10T19:28:59.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Örebro (kwren) attacked Värmland (tanleach1001) killing 0, losing 2.",
+    "timestamp": "2016-03-10T19:29:03.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Uppsala (kwren) was fortified from Gävleborg (kwren) with 2 troops.",
+    "timestamp": "2016-03-10T19:29:11.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Uppsala (kwren) was fortified from Stockholm (kwren) with 2 troops.",
+    "timestamp": "2016-03-10T19:30:00.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Kaliningrad (kwren) was fortified from Kujawy (kwren) with 2 troops.",
+    "timestamp": "2016-03-10T19:30:05.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Kaliningrad (kwren) was fortified from Mazurskie (kwren) with 2 troops.",
+    "timestamp": "2016-03-10T19:30:10.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-03-10T19:30:26.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-03-10T19:30:26.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-03-10T19:33:16.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "jobratt received 4 troops for 13 territories.",
+    "timestamp": "2016-03-10T19:33:16.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Aukštaitija (jobratt) was reinforced by jobratt with 4 troops.",
+    "timestamp": "2016-03-10T19:33:28.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Aukštaitija (jobratt) attacked Žemaitija (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T19:33:30.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Aukštaitija (jobratt) occupied Žemaitija with 1 troop.",
+    "timestamp": "2016-03-10T19:34:28.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Aukštaitija (jobratt) attacked Zemgale (ryanbmilbourne) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-03-10T19:34:33.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Aukštaitija (jobratt) occupied Zemgale with 4 troops.",
+    "timestamp": "2016-03-10T19:34:37.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Riga (jobratt) attacked Kurzeme (ryanbmilbourne) killing 0, losing 2.",
+    "timestamp": "2016-03-10T19:39:39.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Riga (jobratt) was fortified from Zemgale (jobratt) with 3 troops.",
+    "timestamp": "2016-03-10T19:39:48.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Riga (jobratt) was fortified from Latgale (jobratt) with 2 troops.",
+    "timestamp": "2016-03-10T19:39:55.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Hrozna (jobratt) was fortified from Brest (jobratt) with 2 troops.",
+    "timestamp": "2016-03-10T19:40:01.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Hrozna (jobratt) was fortified from Borisov (jobratt) with 2 troops.",
+    "timestamp": "2016-03-10T19:40:11.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Brandenburg (jobratt) was fortified from Mecklenburg-Vorpommern (jobratt) with 2 troops.",
+    "timestamp": "2016-03-10T19:40:17.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Kalmar (jobratt) was fortified from Halland (jobratt) with 2 troops.",
+    "timestamp": "2016-03-10T19:40:28.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Kalmar (jobratt) was fortified from Jönköping (jobratt) with 2 troops.",
+    "timestamp": "2016-03-10T19:40:35.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-03-10T19:40:49.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-03-10T19:40:49.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-03-10T19:40:56.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "tanleach1001 received 4 troops for 12 territories.",
+    "timestamp": "2016-03-10T19:40:56.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Helsinki (tanleach1001) was reinforced by tanleach1001 with 4 troops.",
+    "timestamp": "2016-03-10T19:41:15.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Helsinki (tanleach1001) attacked Espoo (mmacfreier) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-03-10T19:41:21.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Helsinki (tanleach1001) occupied Espoo with 16 troops.",
+    "timestamp": "2016-03-10T19:41:47.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Espoo (tanleach1001) attacked Turku (kwren) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-03-10T19:41:51.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Espoo (tanleach1001) occupied Turku with 15 troops.",
+    "timestamp": "2016-03-10T19:41:59.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Turku (tanleach1001) attacked Åland (mmacfreier) conquering it, killing 3, losing 4.",
+    "timestamp": "2016-03-10T19:42:33.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Turku (tanleach1001) occupied Åland with 4 troops.",
+    "timestamp": "2016-03-10T19:42:45.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Turku (tanleach1001) attacked Lahti (ryanbmilbourne) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-03-10T19:42:49.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Turku (tanleach1001) occupied Lahti with 6 troops.",
+    "timestamp": "2016-03-10T19:42:56.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Helsinki (tanleach1001) was fortified from Lahti (tanleach1001) with 5 troops.",
+    "timestamp": "2016-03-10T19:43:09.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Helsinki (tanleach1001) was fortified from Rakvere (tanleach1001) with 2 troops.",
+    "timestamp": "2016-03-10T19:43:13.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Helsinki (tanleach1001) was fortified from Slantsy (tanleach1001) with 2 troops.",
+    "timestamp": "2016-03-10T19:43:16.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Østlandet (tanleach1001) was fortified from Värmland (tanleach1001) with 2 troops.",
+    "timestamp": "2016-03-10T19:44:11.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Helsinki (tanleach1001) was fortified from Åland (tanleach1001) with 1 troop.",
+    "timestamp": "2016-03-10T19:44:20.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-03-10T19:44:27.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-03-10T19:44:27.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-03-10T19:44:39.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 11 territories.",
+    "timestamp": "2016-03-10T19:44:40.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Szczecin (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-03-10T19:46:39.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Szczecin (ryanbmilbourne) attacked Mecklenburg-Vorpommern (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T19:46:43.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Szczecin (ryanbmilbourne) occupied Mecklenburg-Vorpommern with 5 troops.",
+    "timestamp": "2016-03-10T19:46:45.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Östergötland (ryanbmilbourne) attacked Örebro (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-10T19:46:59.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Mecklenburg-Vorpommern (ryanbmilbourne) attacked Brandenburg (jobratt) killing 1, losing 3.",
+    "timestamp": "2016-03-10T19:47:29.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Sachsen-Anhalt (ryanbmilbourne) attacked Brandenburg (jobratt) killing 1, losing 3.",
+    "timestamp": "2016-03-10T19:47:45.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Pskov (ryanbmilbourne) was fortified from Novgorod (ryanbmilbourne) with 2 troops.",
+    "timestamp": "2016-03-10T19:48:08.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Haapsalu (ryanbmilbourne) was fortified from Saaremaa (ryanbmilbourne) with 2 troops.",
+    "timestamp": "2016-03-10T19:48:21.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Haapsalu (ryanbmilbourne) was fortified from Tallinn (ryanbmilbourne) with 2 troops.",
+    "timestamp": "2016-03-10T19:48:27.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-03-10T19:48:35.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-03-10T19:48:35.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Round 2 started.",
+    "timestamp": "2016-03-10T19:48:35.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-03-10T20:45:32.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier received 3 troops for 11 territories.",
+    "timestamp": "2016-03-10T20:45:32.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Fyn (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-03-10T20:45:51.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Fyn (mmacfreier) attacked Sjælland (ryanbmilbourne) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-03-10T20:46:00.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Fyn (mmacfreier) occupied Sjælland with 5 troops.",
+    "timestamp": "2016-03-10T20:46:02.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Sjælland (mmacfreier) attacked København (gcochard) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-03-10T20:46:13.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "København (mmacfreier) was fortified from Midtjylland (mmacfreier) with 3 troops.",
+    "timestamp": "2016-03-10T20:46:45.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Nordjylland (mmacfreier) was fortified from Midtjylland (mmacfreier) with 1 troop.",
+    "timestamp": "2016-03-10T20:46:53.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-03-10T20:46:56.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-03-10T20:46:56.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-03-10T21:10:03.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "gcochard received 3 troops for 10 territories.",
+    "timestamp": "2016-03-10T21:10:03.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Skåne (gcochard) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-03-10T21:10:32.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Skåne (gcochard) attacked Halland (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T21:10:40.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Skåne (gcochard) occupied Halland with 1 troop.",
+    "timestamp": "2016-03-10T21:10:46.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Skåne (gcochard) attacked Bornholm (jobratt) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-03-10T21:10:55.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Skåne (gcochard) occupied Bornholm with 6 troops.",
+    "timestamp": "2016-03-10T21:10:57.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Bornholm (gcochard) attacked Szczecin (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-10T21:11:09.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Bornholm (gcochard) occupied Szczecin with 4 troops.",
+    "timestamp": "2016-03-10T21:11:14.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Szczecin (gcochard) attacked Wielkopolskie (mmacfreier) killing 1, losing 3.",
+    "timestamp": "2016-03-10T21:11:37.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Pomorskie (gcochard) attacked Wielkopolskie (mmacfreier) killing 0, losing 2.",
+    "timestamp": "2016-03-10T21:11:51.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Mazowieckie (gcochard) attacked Kujawy (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T21:11:59.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Mazowieckie (gcochard) occupied Kujawy with 15 troops.",
+    "timestamp": "2016-03-10T21:12:05.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Kujawy (gcochard) attacked Wielkopolskie (mmacfreier) conquering it, killing 2, losing 2.",
+    "timestamp": "2016-03-10T21:12:12.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Kujawy (gcochard) occupied Wielkopolskie with 1 troop.",
+    "timestamp": "2016-03-10T21:12:16.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Kujawy (gcochard) attacked Mazurskie (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T21:12:19.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Kujawy (gcochard) occupied Mazurskie with 11 troops.",
+    "timestamp": "2016-03-10T21:12:22.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Minsk (gcochard) attacked Borisov (jobratt) killing 0, losing 2.",
+    "timestamp": "2016-03-10T21:12:31.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Jotunheimen (gcochard) attacked Oslo (jobratt) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-03-10T21:12:53.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Jotunheimen (gcochard) occupied Oslo with 2 troops.",
+    "timestamp": "2016-03-10T21:12:57.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "St. Petersburg (gcochard) attacked Novgorod (ryanbmilbourne) killing 0, losing 2.",
+    "timestamp": "2016-03-10T21:13:12.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Szczecin (gcochard) was fortified from Oslo (gcochard) with 1 troop.",
+    "timestamp": "2016-03-10T21:13:22.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Szczecin (gcochard) was fortified from Västra Götaland (gcochard) with 2 troops.",
+    "timestamp": "2016-03-10T21:13:27.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Mazowieckie (gcochard) was fortified from Mazurskie (gcochard) with 10 troops.",
+    "timestamp": "2016-03-10T21:13:34.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Wielkopolskie (gcochard) was fortified from Mazowieckie (gcochard) with 2 troops.",
+    "timestamp": "2016-03-10T21:13:43.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Podlaskie (gcochard) was fortified from Szczecin (gcochard) with 1 troop.",
+    "timestamp": "2016-03-10T21:13:51.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Mazowieckie (gcochard) was fortified from Podlaskie (gcochard) with 1 troop.",
+    "timestamp": "2016-03-10T21:13:59.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-03-10T21:14:16.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-03-10T21:14:16.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-03-10T21:31:06.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "kwren received 3 troops for 11 territories.",
+    "timestamp": "2016-03-10T21:31:07.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Uppsala (kwren) was reinforced by kwren with 3 troops.",
+    "timestamp": "2016-03-10T21:31:15.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Uppsala (kwren) attacked Örebro (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T21:31:19.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Uppsala (kwren) occupied Örebro with 5 troops.",
+    "timestamp": "2016-03-10T21:32:12.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Örebro (kwren) attacked Värmland (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-10T21:32:16.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Örebro (kwren) occupied Värmland with 1 troop.",
+    "timestamp": "2016-03-10T21:32:21.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Örebro (kwren) attacked Östergötland (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-10T21:32:25.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Lüneburg (kwren) attacked Sachsen-Anhalt (ryanbmilbourne) killing 2, losing 2.",
+    "timestamp": "2016-03-10T21:32:31.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Kaliningrad (kwren) attacked Suvalkija (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T21:32:41.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Kaliningrad (kwren) occupied Suvalkija with 1 troop.",
+    "timestamp": "2016-03-10T21:32:47.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Dzūkija (kwren) attacked Aukštaitija (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T21:32:50.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Dzūkija (kwren) occupied Aukštaitija with 1 troop.",
+    "timestamp": "2016-03-10T21:32:53.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Vidzeme (kwren) attacked Zemgale (jobratt) killing 0, losing 2.",
+    "timestamp": "2016-03-10T21:32:57.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Hiiumaa (kwren) attacked Saaremaa (ryanbmilbourne) killing 0, losing 2.",
+    "timestamp": "2016-03-10T21:33:06.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Kaliningrad (kwren) was fortified from Dzūkija (kwren) with 1 troop.",
+    "timestamp": "2016-03-10T21:33:12.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-03-10T21:33:22.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-03-10T21:33:22.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-03-10T21:38:58.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "jobratt received 3 troops for 10 territories.",
+    "timestamp": "2016-03-10T21:38:58.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Brandenburg (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-03-10T21:39:04.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Brandenburg (jobratt) attacked Sachsen-Anhalt (ryanbmilbourne) killing 0, losing 5.",
+    "timestamp": "2016-03-10T21:39:10.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Riga (jobratt) attacked Vidzeme (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T21:39:49.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Riga (jobratt) occupied Vidzeme with 1 troop.",
+    "timestamp": "2016-03-10T21:40:04.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Riga (jobratt) attacked Kurzeme (ryanbmilbourne) conquering it, killing 3, losing 4.",
+    "timestamp": "2016-03-10T21:40:10.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Riga (jobratt) occupied Kurzeme with 1 troop.",
+    "timestamp": "2016-03-10T21:40:12.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Hrozna (jobratt) attacked Dzūkija (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-10T21:40:23.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Hrozna (jobratt) occupied Dzūkija with 5 troops.",
+    "timestamp": "2016-03-10T21:40:24.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Dzūkija (jobratt) attacked Aukštaitija (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-10T21:40:28.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Dzūkija (jobratt) occupied Aukštaitija with 3 troops.",
+    "timestamp": "2016-03-10T21:40:30.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Aukštaitija (jobratt) attacked Suvalkija (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T21:40:35.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "Aukštaitija (jobratt) occupied Suvalkija with 2 troops.",
+    "timestamp": "2016-03-10T21:40:37.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-03-10T21:41:18.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-03-10T21:41:18.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-03-10T21:45:08.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 received 5 troops for 15 territories.",
+    "timestamp": "2016-03-10T21:45:08.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Suomi.",
+    "timestamp": "2016-03-10T21:45:08.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Helsinki (tanleach1001) was reinforced by tanleach1001 with 3 troops.",
+    "timestamp": "2016-03-10T21:45:23.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Åland (tanleach1001) was reinforced by tanleach1001 with 5 troops.",
+    "timestamp": "2016-03-10T21:46:33.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Åland (tanleach1001) attacked Saaremaa (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-10T21:46:39.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Åland (tanleach1001) occupied Saaremaa with 6 troops.",
+    "timestamp": "2016-03-10T21:48:52.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Saaremaa (tanleach1001) attacked Pärnumaa (mmacfreier) killing 2, losing 2.",
+    "timestamp": "2016-03-10T21:48:59.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Velikiye Luki (tanleach1001) attacked Novgorod (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T21:50:08.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Velikiye Luki (tanleach1001) occupied Novgorod with 1 troop.",
+    "timestamp": "2016-03-10T21:50:16.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Telemark (tanleach1001) attacked Jotunheimen (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T21:50:28.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Telemark (tanleach1001) occupied Jotunheimen with 1 troop.",
+    "timestamp": "2016-03-10T21:50:31.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Rakvere (tanleach1001) was fortified from Velikiye Luki (tanleach1001) with 1 troop.",
+    "timestamp": "2016-03-10T21:50:57.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Helsinki (tanleach1001) was fortified from Kotka (tanleach1001) with 2 troops.",
+    "timestamp": "2016-03-10T21:50:59.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Saaremaa (tanleach1001) was fortified from Gotland (tanleach1001) with 2 troops.",
+    "timestamp": "2016-03-10T21:51:03.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Saaremaa (tanleach1001) was fortified from Rakvere (tanleach1001) with 1 troop.",
+    "timestamp": "2016-03-10T21:51:26.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Telemark (tanleach1001) was fortified from Østlandet (tanleach1001) with 1 troop.",
+    "timestamp": "2016-03-10T21:52:13.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-03-10T21:52:15.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-03-10T21:52:15.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-03-10T21:53:40.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 6 territories.",
+    "timestamp": "2016-03-10T21:53:40.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Sachsen-Anhalt (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-03-10T21:53:49.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Mecklenburg-Vorpommern (ryanbmilbourne) attacked Brandenburg (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T21:53:53.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Sachsen-Anhalt (ryanbmilbourne) attacked Lüneburg (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T21:53:58.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Sachsen-Anhalt (ryanbmilbourne) occupied Lüneburg with 1 troop.",
+    "timestamp": "2016-03-10T21:54:12.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Haapsalu (ryanbmilbourne) attacked Pärnumaa (mmacfreier) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-03-10T21:54:23.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Haapsalu (ryanbmilbourne) occupied Pärnumaa with 5 troops.",
+    "timestamp": "2016-03-10T21:54:24.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Pärnumaa (ryanbmilbourne) attacked Tartumaa (mmacfreier) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-03-10T21:54:31.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Pärnumaa (ryanbmilbourne) occupied Tartumaa with 2 troops.",
+    "timestamp": "2016-03-10T21:54:33.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Tartumaa (ryanbmilbourne) attacked Vidzeme (jobratt) killing 0, losing 1.",
+    "timestamp": "2016-03-10T21:54:39.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Pskov (ryanbmilbourne) attacked Vidzeme (jobratt) killing 0, losing 1.",
+    "timestamp": "2016-03-10T21:54:43.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Pskov (ryanbmilbourne) attacked Latgale (jobratt) killing 0, losing 1.",
+    "timestamp": "2016-03-10T21:55:14.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-03-10T21:55:21.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-03-10T21:55:21.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Round 3 started.",
+    "timestamp": "2016-03-10T21:55:21.000Z",
+    "player": "unknown",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-03-10T21:56:45.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier received 3 troops for 10 territories.",
+    "timestamp": "2016-03-10T21:56:46.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding Danmark.",
+    "timestamp": "2016-03-10T21:56:46.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Syddanmark (mmacfreier) was reinforced by mmacfreier with 6 troops.",
+    "timestamp": "2016-03-10T21:57:03.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Syddanmark (mmacfreier) attacked Schleswig-Holstein (tanleach1001) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-03-10T21:57:09.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Syddanmark (mmacfreier) occupied Schleswig-Holstein with 4 troops.",
+    "timestamp": "2016-03-10T21:57:11.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Schleswig-Holstein (mmacfreier) was fortified from Niedersachsen (mmacfreier) with 2 troops.",
+    "timestamp": "2016-03-10T21:57:18.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-03-10T21:57:24.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-03-10T21:57:24.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-03-10T21:57:37.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard received 5 troops for 15 territories.",
+    "timestamp": "2016-03-10T21:57:37.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard received 4 troops for holding Polska.",
+    "timestamp": "2016-03-10T21:57:37.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Vitebsk (gcochard) was reinforced by gcochard with 9 troops.",
+    "timestamp": "2016-03-10T21:59:26.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Vitebsk (gcochard) attacked Borisov (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T21:59:33.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Vitebsk (gcochard) occupied Borisov with 11 troops.",
+    "timestamp": "2016-03-10T21:59:35.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Borisov (gcochard) attacked Mahilyow (tanleach1001) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-03-10T21:59:39.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Borisov (gcochard) occupied Mahilyow with 10 troops.",
+    "timestamp": "2016-03-10T21:59:40.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Mahilyow (gcochard) attacked Brest (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T21:59:43.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Mahilyow (gcochard) occupied Brest with 9 troops.",
+    "timestamp": "2016-03-10T21:59:45.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Brest (gcochard) attacked Hrozna (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-10T21:59:49.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Brest (gcochard) occupied Hrozna with 7 troops.",
+    "timestamp": "2016-03-10T21:59:55.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Mazowieckie (gcochard) was fortified from Hrozna (gcochard) with 4 troops.",
+    "timestamp": "2016-03-10T22:00:23.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Vitebsk (gcochard) was fortified from Wielkopolskie (gcochard) with 2 troops.",
+    "timestamp": "2016-03-10T22:00:28.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Hrozna (gcochard) was fortified from Mazowieckie (gcochard) with 2 troops.",
+    "timestamp": "2016-03-10T22:01:05.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Vitebsk (gcochard) was fortified from Szczecin (gcochard) with 2 troops.",
+    "timestamp": "2016-03-10T22:01:17.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-03-10T22:01:36.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-03-10T22:01:36.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-03-10T22:01:49.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren received 3 troops for 11 territories.",
+    "timestamp": "2016-03-10T22:01:49.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren received 4 troops for holding Svealand.",
+    "timestamp": "2016-03-10T22:01:49.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Uppsala (kwren) was reinforced by kwren with 4 troops.",
+    "timestamp": "2016-03-10T22:02:07.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Värmland (kwren) was reinforced by kwren with 3 troops.",
+    "timestamp": "2016-03-10T22:02:14.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Värmland (kwren) attacked Oslo (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-10T22:02:18.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Värmland (kwren) occupied Oslo with 2 troops.",
+    "timestamp": "2016-03-10T22:02:20.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Oslo (kwren) attacked Jotunheimen (tanleach1001) killing 0, losing 1.",
+    "timestamp": "2016-03-10T22:02:24.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Vestlandet (kwren) attacked Jotunheimen (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-10T22:02:29.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Kaliningrad (kwren) attacked Mazurskie (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T22:02:36.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Kaliningrad (kwren) occupied Mazurskie with 6 troops.",
+    "timestamp": "2016-03-10T22:02:40.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Mazurskie (kwren) attacked Mazowieckie (gcochard) conquering it, killing 12, losing 2.",
+    "timestamp": "2016-03-10T22:02:49.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "gcochard was defeated by kwren.",
+    "timestamp": "2016-03-10T22:02:49.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Mazurskie (kwren) occupied Mazowieckie with 3 troops.",
+    "timestamp": "2016-03-10T22:03:12.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren received 2 troops on Uppsala",
+    "timestamp": "2016-03-10T22:03:22.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren received 2 troops on Pomorskie",
+    "timestamp": "2016-03-10T22:03:22.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren received 4 troops for turning in cards Uppsala, Suvalkija, and Pomorskie.",
+    "timestamp": "2016-03-10T22:03:22.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Szczecin (kwren) was reinforced by kwren with 4 troops.",
+    "timestamp": "2016-03-10T22:03:27.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Szczecin (kwren) attacked Brandenburg (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T22:03:30.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Szczecin (kwren) occupied Brandenburg with 4 troops.",
+    "timestamp": "2016-03-10T22:03:32.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Brandenburg (kwren) attacked Sachsen-Anhalt (ryanbmilbourne) killing 2, losing 3.",
+    "timestamp": "2016-03-10T22:03:37.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Vitebsk (kwren) attacked Latgale (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T22:03:47.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Vitebsk (kwren) occupied Latgale with 1 troop.",
+    "timestamp": "2016-03-10T22:04:02.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Brandenburg (kwren) was fortified from Vitebsk (kwren) with 3 troops.",
+    "timestamp": "2016-03-10T22:04:14.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Brandenburg (kwren) was fortified from Hrozna (kwren) with 4 troops.",
+    "timestamp": "2016-03-10T22:04:18.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Brandenburg (kwren) was fortified from Podlaskie (kwren) with 2 troops.",
+    "timestamp": "2016-03-10T22:04:21.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Brandenburg (kwren) was fortified from Mazowieckie (kwren) with 2 troops.",
+    "timestamp": "2016-03-10T22:04:25.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-03-10T22:04:34.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-03-10T22:04:34.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-03-10T22:18:25.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt received 3 troops for 10 territories.",
+    "timestamp": "2016-03-10T22:18:25.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Kalmar (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-03-10T22:18:41.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Kalmar (jobratt) attacked Östergötland (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T22:18:44.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Kalmar (jobratt) occupied Östergötland with 9 troops.",
+    "timestamp": "2016-03-10T22:18:59.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Östergötland (jobratt) attacked Södermanland (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T22:19:02.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Östergötland (jobratt) occupied Södermanland with 8 troops.",
+    "timestamp": "2016-03-10T22:19:04.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Södermanland (jobratt) attacked Uppsala (kwren) killing 2, losing 7.",
+    "timestamp": "2016-03-10T22:19:21.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-03-10T22:19:44.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-03-10T22:19:44.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-03-10T22:19:47.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 received 5 troops for 15 territories.",
+    "timestamp": "2016-03-10T22:19:47.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Suomi.",
+    "timestamp": "2016-03-10T22:19:47.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Helsinki (tanleach1001) was reinforced by tanleach1001 with 4 troops.",
+    "timestamp": "2016-03-10T22:19:55.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Saaremaa (tanleach1001) was reinforced by tanleach1001 with 4 troops.",
+    "timestamp": "2016-03-10T22:19:59.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Saaremaa (tanleach1001) attacked Hiiumaa (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T22:20:09.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Saaremaa (tanleach1001) occupied Hiiumaa with 10 troops.",
+    "timestamp": "2016-03-10T22:20:12.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Hiiumaa (tanleach1001) attacked Haapsalu (ryanbmilbourne) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-03-10T22:20:21.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Hiiumaa (tanleach1001) occupied Haapsalu with 7 troops.",
+    "timestamp": "2016-03-10T22:20:23.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Haapsalu (tanleach1001) attacked Tallinn (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T22:20:26.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Haapsalu (tanleach1001) occupied Tallinn with 6 troops.",
+    "timestamp": "2016-03-10T22:20:30.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Tallinn (tanleach1001) attacked Pärnumaa (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-10T22:20:34.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Tallinn (tanleach1001) occupied Pärnumaa with 4 troops.",
+    "timestamp": "2016-03-10T22:20:38.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Pärnumaa (tanleach1001) attacked Tartumaa (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T22:20:41.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Pärnumaa (tanleach1001) occupied Tartumaa with 3 troops.",
+    "timestamp": "2016-03-10T22:20:45.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Tartumaa (tanleach1001) attacked Vidzeme (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-10T22:20:51.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-03-10T22:21:17.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-03-10T22:21:17.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-03-10T22:21:25.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 5 territories.",
+    "timestamp": "2016-03-10T22:21:25.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Sachsen-Anhalt (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-03-10T22:21:29.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Sachsen-Anhalt (ryanbmilbourne) attacked Brandenburg (kwren) killing 3, losing 11.",
+    "timestamp": "2016-03-10T22:21:57.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Pskov (ryanbmilbourne) attacked Tartumaa (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T22:22:24.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Pskov (ryanbmilbourne) occupied Tartumaa with 2 troops.",
+    "timestamp": "2016-03-10T22:22:25.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Vyborg (ryanbmilbourne) attacked Kotka (tanleach1001) killing 0, losing 2.",
+    "timestamp": "2016-03-10T22:22:34.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Tartumaa (ryanbmilbourne) attacked Vidzeme (tanleach1001) killing 0, losing 1.",
+    "timestamp": "2016-03-10T22:22:48.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-03-10T22:22:59.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-03-10T22:22:59.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Round 4 started.",
+    "timestamp": "2016-03-10T22:22:59.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-03-10T22:23:34.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier received 3 troops for 11 territories.",
+    "timestamp": "2016-03-10T22:23:34.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier received 3 troops for holding Danmark.",
+    "timestamp": "2016-03-10T22:23:34.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Schleswig-Holstein (mmacfreier) was reinforced by mmacfreier with 6 troops.",
+    "timestamp": "2016-03-10T22:23:43.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Schleswig-Holstein (mmacfreier) attacked Lüneburg (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-10T22:24:00.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Schleswig-Holstein (mmacfreier) occupied Lüneburg with 10 troops.",
+    "timestamp": "2016-03-10T22:24:02.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Lüneburg (mmacfreier) attacked Sachsen-Anhalt (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T22:24:06.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne was defeated by mmacfreier.",
+    "timestamp": "2016-03-10T22:24:06.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "Lüneburg (mmacfreier) occupied Sachsen-Anhalt with 9 troops.",
+    "timestamp": "2016-03-10T22:24:12.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier received 2 troops on København",
+    "timestamp": "2016-03-10T22:24:24.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier received 6 troops for turning in cards Aukštaitija, Vitebsk, and København.",
+    "timestamp": "2016-03-10T22:24:24.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier received 2 troops on Sjælland",
+    "timestamp": "2016-03-10T22:24:29.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier received 8 troops for turning in cards Mazowieckie, Sjælland, and Telemark.",
+    "timestamp": "2016-03-10T22:24:29.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Tartumaa (mmacfreier) was reinforced by mmacfreier with 14 troops.",
+    "timestamp": "2016-03-10T22:25:36.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Tartumaa (mmacfreier) attacked Vidzeme (tanleach1001) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-03-10T22:25:45.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Tartumaa (mmacfreier) occupied Vidzeme with 11 troops.",
+    "timestamp": "2016-03-10T22:25:47.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Vidzeme (mmacfreier) attacked Riga (jobratt) conquering it, killing 11, losing 7.",
+    "timestamp": "2016-03-10T22:26:01.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "jobratt was defeated by mmacfreier.",
+    "timestamp": "2016-03-10T22:26:01.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Vidzeme (mmacfreier) occupied Riga with 3 troops.",
+    "timestamp": "2016-03-10T22:26:07.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Sovetsk (mmacfreier) attacked Mazurskie (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-10T22:26:49.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Midtjylland (mmacfreier) was fortified from Sjælland (mmacfreier) with 2 troops.",
+    "timestamp": "2016-03-10T22:27:12.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Midtjylland (mmacfreier) was fortified from Sachsen-Anhalt (mmacfreier) with 4 troops.",
+    "timestamp": "2016-03-10T22:27:35.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Schleswig-Holstein (mmacfreier) was fortified from Sachsen-Anhalt (mmacfreier) with 4 troops.",
+    "timestamp": "2016-03-10T22:27:38.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Södermanland (mmacfreier) was fortified from Öland (mmacfreier) with 2 troops.",
+    "timestamp": "2016-03-10T22:27:50.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Mazurskie (mmacfreier) was fortified from Riga (mmacfreier) with 2 troops.",
+    "timestamp": "2016-03-10T22:27:56.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Mazurskie (mmacfreier) was fortified from Suvalkija (mmacfreier) with 1 troop.",
+    "timestamp": "2016-03-10T22:27:59.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-03-10T22:28:04.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-03-10T22:28:04.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-03-10T22:28:08.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "kwren received 9 troops for 29 territories.",
+    "timestamp": "2016-03-10T22:28:08.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "kwren received 3 troops for holding Bielaruś.",
+    "timestamp": "2016-03-10T22:28:08.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Brandenburg (kwren) was reinforced by kwren with 12 troops.",
+    "timestamp": "2016-03-10T22:28:45.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Brandenburg (kwren) attacked Mecklenburg-Vorpommern (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-10T22:28:51.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Brandenburg (kwren) occupied Mecklenburg-Vorpommern with 19 troops.",
+    "timestamp": "2016-03-10T22:28:52.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Mecklenburg-Vorpommern (kwren) attacked Schleswig-Holstein (mmacfreier) conquering it, killing 5, losing 5.",
+    "timestamp": "2016-03-10T22:29:06.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Mecklenburg-Vorpommern (kwren) occupied Schleswig-Holstein with 13 troops.",
+    "timestamp": "2016-03-10T22:29:07.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Schleswig-Holstein (kwren) attacked Syddanmark (mmacfreier) conquering it, killing 1, losing 4.",
+    "timestamp": "2016-03-10T22:29:22.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Schleswig-Holstein (kwren) occupied Syddanmark with 8 troops.",
+    "timestamp": "2016-03-10T22:29:25.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Syddanmark (kwren) attacked Midtjylland (mmacfreier) killing 3, losing 7.",
+    "timestamp": "2016-03-10T22:29:31.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Uppsala (kwren) attacked Södermanland (mmacfreier) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-03-10T22:29:46.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Uppsala (kwren) occupied Södermanland with 1 troop.",
+    "timestamp": "2016-03-10T22:29:52.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "Uppsala (kwren) was fortified from Pomorskie (kwren) with 2 troops.",
+    "timestamp": "2016-03-10T22:30:22.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-03-10T22:30:27.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-03-10T22:30:27.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-03-10T22:30:33.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 received 6 troops for 19 territories.",
+    "timestamp": "2016-03-10T22:30:33.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Suomi.",
+    "timestamp": "2016-03-10T22:30:33.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Telemark (tanleach1001) was reinforced by tanleach1001 with 9 troops.",
+    "timestamp": "2016-03-10T22:30:50.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Telemark (tanleach1001) attacked Sørlandet (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T22:30:54.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Telemark (tanleach1001) occupied Sørlandet with 11 troops.",
+    "timestamp": "2016-03-10T22:30:56.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Sørlandet (tanleach1001) attacked Nordjylland (mmacfreier) conquering it, killing 4, losing 2.",
+    "timestamp": "2016-03-10T22:31:07.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Sørlandet (tanleach1001) occupied Nordjylland with 8 troops.",
+    "timestamp": "2016-03-10T22:31:10.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Nordjylland (tanleach1001) attacked Midtjylland (mmacfreier) killing 1, losing 7.",
+    "timestamp": "2016-03-10T22:31:16.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-03-10T22:31:35.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-03-10T22:31:35.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Round 5 started.",
+    "timestamp": "2016-03-10T22:31:35.000Z",
+    "player": "unknown",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-03-10T22:31:50.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier received 8 troops for 24 territories.",
+    "timestamp": "2016-03-10T22:31:50.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier received 2 troops on Tartumaa",
+    "timestamp": "2016-03-10T22:31:55.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier received 10 troops for turning in cards Åland, Kujawy, and Tartumaa.",
+    "timestamp": "2016-03-10T22:31:55.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Midtjylland (mmacfreier) was reinforced by mmacfreier with 18 troops.",
+    "timestamp": "2016-03-10T22:32:11.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Midtjylland (mmacfreier) attacked Nordjylland (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T22:32:16.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Midtjylland (mmacfreier) occupied Nordjylland with 11 troops.",
+    "timestamp": "2016-03-10T22:32:24.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Midtjylland (mmacfreier) attacked Syddanmark (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-03-10T22:32:30.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Midtjylland (mmacfreier) occupied Syddanmark with 6 troops.",
+    "timestamp": "2016-03-10T22:32:38.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Nordjylland (mmacfreier) attacked Sørlandet (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-10T22:32:44.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Nordjylland (mmacfreier) occupied Sørlandet with 1 troop.",
+    "timestamp": "2016-03-10T22:32:47.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Midtjylland (mmacfreier) was fortified from Nordjylland (mmacfreier) with 3 troops.",
+    "timestamp": "2016-03-10T22:33:07.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Mazurskie (mmacfreier) was fortified from Tartumaa (mmacfreier) with 2 troops.",
+    "timestamp": "2016-03-10T22:33:18.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-03-10T22:33:25.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-03-10T22:33:25.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-03-10T22:33:31.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received 10 troops for 32 territories.",
+    "timestamp": "2016-03-10T22:33:31.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received 3 troops for holding Bielaruś.",
+    "timestamp": "2016-03-10T22:33:31.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received 4 troops for holding Svealand.",
+    "timestamp": "2016-03-10T22:33:31.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received 2 troops on Vestlandet",
+    "timestamp": "2016-03-10T22:33:35.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received 2 troops on Minsk",
+    "timestamp": "2016-03-10T22:33:35.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received 12 troops for turning in cards Riga, Vestlandet, and Minsk.",
+    "timestamp": "2016-03-10T22:33:35.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Vestlandet (kwren) was reinforced by kwren with 29 troops.",
+    "timestamp": "2016-03-10T22:34:00.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Vestlandet (kwren) attacked Sørlandet (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-10T22:34:03.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Vestlandet (kwren) occupied Sørlandet with 30 troops.",
+    "timestamp": "2016-03-10T22:34:05.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Sørlandet (kwren) attacked Nordjylland (mmacfreier) conquering it, killing 6, losing 4.",
+    "timestamp": "2016-03-10T22:34:10.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Sørlandet (kwren) occupied Nordjylland with 25 troops.",
+    "timestamp": "2016-03-10T22:34:12.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Nordjylland (kwren) attacked Midtjylland (mmacfreier) conquering it, killing 14, losing 2.",
+    "timestamp": "2016-03-10T22:34:45.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier was defeated by kwren.",
+    "timestamp": "2016-03-10T22:34:45.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Nordjylland (kwren) occupied Midtjylland with 1 troop.",
+    "timestamp": "2016-03-10T22:35:13.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Uppsala (kwren) was fortified from Nordjylland (kwren) with 21 troops.",
+    "timestamp": "2016-03-10T22:36:34.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Uppsala (kwren) was fortified from København (kwren) with 5 troops.",
+    "timestamp": "2016-03-10T22:36:39.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Uppsala (kwren) was fortified from Syddanmark (kwren) with 5 troops.",
+    "timestamp": "2016-03-10T22:36:45.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-03-10T22:36:55.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-03-10T22:36:55.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-03-10T22:37:01.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received 6 troops for 19 territories.",
+    "timestamp": "2016-03-10T22:37:01.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Suomi.",
+    "timestamp": "2016-03-10T22:37:01.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received 2 troops on Pärnumaa",
+    "timestamp": "2016-03-10T22:37:08.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received 12 troops for turning in cards Pärnumaa, Mecklenburg-Vorpommern, and Örebro.",
+    "timestamp": "2016-03-10T22:37:08.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Østlandet (tanleach1001) was reinforced by tanleach1001 with 21 troops.",
+    "timestamp": "2016-03-10T22:38:05.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Østlandet (tanleach1001) attacked Värmland (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T22:38:11.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Østlandet (tanleach1001) occupied Värmland with 24 troops.",
+    "timestamp": "2016-03-10T22:38:13.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Värmland (tanleach1001) attacked Örebro (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T22:38:18.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Värmland (tanleach1001) occupied Örebro with 23 troops.",
+    "timestamp": "2016-03-10T22:38:21.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Örebro (tanleach1001) attacked Uppsala (kwren) killing 23, losing 22.",
+    "timestamp": "2016-03-10T22:39:42.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Helsinki (tanleach1001) was fortified from Pärnumaa (tanleach1001) with 2 troops.",
+    "timestamp": "2016-03-10T22:39:50.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-03-10T22:40:09.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-03-10T22:40:09.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Round 6 started.",
+    "timestamp": "2016-03-10T22:40:09.000Z",
+    "player": "unknown",
+    "round": 6
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-03-10T22:40:14.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 19 troops for 57 territories.",
+    "timestamp": "2016-03-10T22:40:14.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 3 troops for holding Danmark.",
+    "timestamp": "2016-03-10T22:40:14.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 3 troops for holding Deutschland.",
+    "timestamp": "2016-03-10T22:40:14.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 4 troops for holding Polska.",
+    "timestamp": "2016-03-10T22:40:14.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 1 troop for holding Kaliningrad Oblast.",
+    "timestamp": "2016-03-10T22:40:14.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 5 troops for holding Latvija/Lietuva.",
+    "timestamp": "2016-03-10T22:40:14.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 3 troops for holding Bielaruś.",
+    "timestamp": "2016-03-10T22:40:14.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 1 troop for holding Danmark+Bornholm.",
+    "timestamp": "2016-03-10T22:40:14.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 2 troops on Stockholm",
+    "timestamp": "2016-03-10T22:40:17.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 2 troops on Fyn",
+    "timestamp": "2016-03-10T22:40:17.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 12 troops for turning in cards Stockholm, Fyn, and Turku.",
+    "timestamp": "2016-03-10T22:40:17.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Vyborg (kwren) was reinforced by kwren with 51 troops.",
+    "timestamp": "2016-03-10T22:40:21.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Vyborg (kwren) attacked Kotka (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-10T22:40:23.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Vyborg (kwren) occupied Kotka with 51 troops.",
+    "timestamp": "2016-03-10T22:40:25.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Kotka (kwren) attacked Helsinki (tanleach1001) conquering it, killing 22, losing 21.",
+    "timestamp": "2016-03-10T22:40:59.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 was defeated by kwren.",
+    "timestamp": "2016-03-10T22:40:59.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Game finished.",
+    "timestamp": "2016-03-10T22:40:59.000Z",
+    "player": "unknown",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier lost 22 rating.",
+    "timestamp": "2016-03-10T22:40:59.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier received 20 tokens.",
+    "timestamp": "2016-03-10T22:40:59.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "gcochard lost 13 rating.",
+    "timestamp": "2016-03-10T22:40:59.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "gcochard received 20 tokens.",
+    "timestamp": "2016-03-10T22:40:59.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "kwren won the game.",
+    "timestamp": "2016-03-10T22:40:59.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 95 rating.",
+    "timestamp": "2016-03-10T22:40:59.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 20 tokens.",
+    "timestamp": "2016-03-10T22:40:59.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "jobratt lost 27 rating.",
+    "timestamp": "2016-03-10T22:40:59.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "jobratt received 20 tokens.",
+    "timestamp": "2016-03-10T22:40:59.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 lost 15 rating.",
+    "timestamp": "2016-03-10T22:40:59.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 received 20 tokens.",
+    "timestamp": "2016-03-10T22:40:59.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne lost 18 rating.",
+    "timestamp": "2016-03-10T22:40:59.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne received 20 tokens.",
+    "timestamp": "2016-03-10T22:40:59.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  }
+]

--- a/data/622960.json
+++ b/data/622960.json
@@ -1,0 +1,8066 @@
+[
+  {
+    "message": "Game created.",
+    "timestamp": "2016-03-11T21:11:42.000Z",
+    "player": "unknown",
+    "round": 0
+  },
+  {
+    "message": "gcochard joined the game.",
+    "timestamp": "2016-03-11T21:11:42.000Z",
+    "player": "gcochard",
+    "round": 0
+  },
+  {
+    "message": "kwren joined the game.",
+    "timestamp": "2016-03-11T21:12:19.000Z",
+    "player": "kwren",
+    "round": 0
+  },
+  {
+    "message": "tanleach1001 joined the game.",
+    "timestamp": "2016-03-11T21:12:41.000Z",
+    "player": "tanleach1001",
+    "round": 0
+  },
+  {
+    "message": "mmacfreier joined the game.",
+    "timestamp": "2016-03-11T21:13:56.000Z",
+    "player": "mmacfreier",
+    "round": 0
+  },
+  {
+    "message": "ryanbmilbourne joined the game.",
+    "timestamp": "2016-03-11T21:16:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 0
+  },
+  {
+    "message": "jobratt joined the game.",
+    "timestamp": "2016-03-11T21:18:08.000Z",
+    "player": "jobratt",
+    "round": 0
+  },
+  {
+    "message": "Game started.",
+    "timestamp": "2016-03-11T21:18:08.000Z",
+    "player": "unknown",
+    "round": 1
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-03-11T21:18:36.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "tanleach1001 received 4 troops for 13 territories.",
+    "timestamp": "2016-03-11T21:18:36.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Minsk (tanleach1001) was reinforced by tanleach1001 with 4 troops.",
+    "timestamp": "2016-03-11T21:18:54.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Minsk (tanleach1001) attacked Mahilyow (kwren) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-03-11T21:19:02.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Minsk (tanleach1001) occupied Mahilyow with 1 troop.",
+    "timestamp": "2016-03-11T21:19:16.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Minsk (tanleach1001) attacked Borisov (ryanbmilbourne) killing 1, losing 3.",
+    "timestamp": "2016-03-11T21:19:23.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Vitebsk (tanleach1001) attacked Borisov (ryanbmilbourne) killing 1, losing 1.",
+    "timestamp": "2016-03-11T21:19:30.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Minsk (tanleach1001) attacked Borisov (ryanbmilbourne) killing 0, losing 1.",
+    "timestamp": "2016-03-11T21:19:35.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Vitebsk (tanleach1001) attacked Borisov (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-11T21:19:44.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "Vitebsk (tanleach1001) was fortified from Brest (tanleach1001) with 2 troops.",
+    "timestamp": "2016-03-11T21:20:21.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-03-11T21:20:22.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-03-11T21:20:22.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-03-11T21:23:35.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren received 4 troops for 12 territories.",
+    "timestamp": "2016-03-11T21:23:35.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Mazurskie (kwren) was reinforced by kwren with 4 troops.",
+    "timestamp": "2016-03-11T21:23:43.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Mazurskie (kwren) attacked Sovetsk (ryanbmilbourne) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-03-11T21:23:47.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Mazurskie (kwren) occupied Sovetsk with 5 troops.",
+    "timestamp": "2016-03-11T21:23:49.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "Kaliningrad (kwren) was fortified from Wielkopolskie (kwren) with 2 troops.",
+    "timestamp": "2016-03-11T21:24:32.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-03-11T21:24:32.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-03-11T21:24:32.000Z",
+    "player": "kwren",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-03-11T21:39:10.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier received 4 troops for 13 territories.",
+    "timestamp": "2016-03-11T21:39:10.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Gotland (mmacfreier) was reinforced by mmacfreier with 4 troops.",
+    "timestamp": "2016-03-11T21:39:57.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Gotland (mmacfreier) attacked Saaremaa (tanleach1001) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-03-11T21:40:03.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "Gotland (mmacfreier) occupied Saaremaa with 4 troops.",
+    "timestamp": "2016-03-11T21:40:04.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "St. Petersburg (ryanbmilbourne) was fortified from Vyborg (mmacfreier) with 2 troops.",
+    "timestamp": "2016-03-11T21:40:29.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-03-11T21:40:29.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-03-11T21:40:29.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-03-11T21:41:30.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "jobratt received 4 troops for 13 territories.",
+    "timestamp": "2016-03-11T21:41:30.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Syddanmark (jobratt) was reinforced by jobratt with 4 troops.",
+    "timestamp": "2016-03-11T21:42:01.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Syddanmark (jobratt) attacked Fyn (gcochard) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-03-11T21:42:07.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Syddanmark (jobratt) occupied Fyn with 1 troop.",
+    "timestamp": "2016-03-11T21:42:11.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "Hrozna (tanleach1001) was fortified from Novgorod (jobratt) with 2 troops.",
+    "timestamp": "2016-03-11T21:43:40.000Z",
+    "player": "tanleach1001",
+    "round": 1
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-03-11T21:43:40.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-03-11T21:43:40.000Z",
+    "player": "jobratt",
+    "round": 1
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-03-11T21:44:16.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard received 4 troops for 12 territories.",
+    "timestamp": "2016-03-11T21:44:16.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Østlandet (gcochard) was reinforced by gcochard with 4 troops.",
+    "timestamp": "2016-03-11T21:44:25.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Østlandet (gcochard) attacked Värmland (ryanbmilbourne) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-03-11T21:44:30.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Østlandet (gcochard) occupied Värmland with 5 troops.",
+    "timestamp": "2016-03-11T21:44:32.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Värmland (gcochard) attacked Örebro (jobratt) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-03-11T21:45:50.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Värmland (gcochard) occupied Örebro with 3 troops.",
+    "timestamp": "2016-03-11T21:46:05.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Åland (gcochard) attacked Stockholm (mmacfreier) killing 0, losing 2.",
+    "timestamp": "2016-03-11T21:46:09.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Pomorskie (gcochard) attacked Szczecin (mmacfreier) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-03-11T21:47:00.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Pomorskie (gcochard) occupied Szczecin with 2 troops.",
+    "timestamp": "2016-03-11T21:47:03.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "Åland (gcochard) was fortified from Turku (gcochard) with 2 troops.",
+    "timestamp": "2016-03-11T21:47:54.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-03-11T21:47:55.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-03-11T21:47:55.000Z",
+    "player": "gcochard",
+    "round": 1
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-03-11T22:01:03.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 10 territories.",
+    "timestamp": "2016-03-11T22:01:03.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "St. Petersburg (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-03-11T22:01:27.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "St. Petersburg (ryanbmilbourne) attacked Slantsy (kwren) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-03-11T22:01:31.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "St. Petersburg (ryanbmilbourne) occupied Slantsy with 4 troops.",
+    "timestamp": "2016-03-11T22:01:39.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "St. Petersburg (ryanbmilbourne) attacked Vyborg (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-11T22:01:42.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "St. Petersburg (ryanbmilbourne) occupied Vyborg with 3 troops.",
+    "timestamp": "2016-03-11T22:01:43.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Pskov (ryanbmilbourne) attacked Novgorod (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-11T22:01:53.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Pskov (ryanbmilbourne) occupied Novgorod with 1 troop.",
+    "timestamp": "2016-03-11T22:02:01.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Tartumaa (ryanbmilbourne) attacked Rakvere (tanleach1001) killing 1, losing 2.",
+    "timestamp": "2016-03-11T22:02:56.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Pärnumaa (mmacfreier) was fortified from Hiiumaa (ryanbmilbourne) with 2 troops.",
+    "timestamp": "2016-03-11T22:03:15.000Z",
+    "player": "mmacfreier",
+    "round": 1
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-03-11T22:03:15.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-03-11T22:03:15.000Z",
+    "player": "ryanbmilbourne",
+    "round": 1
+  },
+  {
+    "message": "Round 2 started.",
+    "timestamp": "2016-03-11T22:03:15.000Z",
+    "player": "unknown",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-03-11T22:05:29.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 received 4 troops for 14 territories.",
+    "timestamp": "2016-03-11T22:05:29.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Bielaruś.",
+    "timestamp": "2016-03-11T22:05:29.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Vitebsk (tanleach1001) was reinforced by tanleach1001 with 4 troops.",
+    "timestamp": "2016-03-11T22:05:55.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Hrozna (tanleach1001) was reinforced by tanleach1001 with 2 troops.",
+    "timestamp": "2016-03-11T22:06:08.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Lahti (tanleach1001) was reinforced by tanleach1001 with 1 troop.",
+    "timestamp": "2016-03-11T22:06:11.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Lahti (tanleach1001) attacked Turku (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-11T22:06:13.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Lahti (tanleach1001) occupied Turku with 3 troops.",
+    "timestamp": "2016-03-11T22:06:17.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "Kalmar (tanleach1001) was fortified from Jönköping (tanleach1001) with 2 troops.",
+    "timestamp": "2016-03-11T22:06:58.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-03-11T22:06:58.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-03-11T22:06:58.000Z",
+    "player": "tanleach1001",
+    "round": 2
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-03-11T22:07:11.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "kwren received 4 troops for 12 territories.",
+    "timestamp": "2016-03-11T22:07:11.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "kwren received 1 troop for holding Kaliningrad Oblast.",
+    "timestamp": "2016-03-11T22:07:11.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Uppsala (kwren) was reinforced by kwren with 2 troops.",
+    "timestamp": "2016-03-11T22:07:18.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Sovetsk (kwren) was reinforced by kwren with 1 troop.",
+    "timestamp": "2016-03-11T22:07:22.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Öland (kwren) was reinforced by kwren with 1 troop.",
+    "timestamp": "2016-03-11T22:07:36.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Kujawy (kwren) was reinforced by kwren with 1 troop.",
+    "timestamp": "2016-03-11T22:07:44.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Uppsala (kwren) attacked Stockholm (mmacfreier) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-03-11T22:07:52.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Uppsala (kwren) occupied Stockholm with 2 troops.",
+    "timestamp": "2016-03-11T22:07:54.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Öland (kwren) attacked Gotland (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-11T22:08:08.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Öland (kwren) occupied Gotland with 3 troops.",
+    "timestamp": "2016-03-11T22:08:09.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Kujawy (kwren) attacked Mazowieckie (jobratt) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-03-11T22:08:19.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Kujawy (kwren) occupied Mazowieckie with 3 troops.",
+    "timestamp": "2016-03-11T22:08:21.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "Södermanland (gcochard) was fortified from Dalarna (kwren) with 2 troops.",
+    "timestamp": "2016-03-11T22:08:56.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-03-11T22:08:56.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-03-11T22:08:56.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-03-11T22:11:19.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier received 3 troops for 10 territories.",
+    "timestamp": "2016-03-11T22:11:19.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Saaremaa (mmacfreier) was reinforced by mmacfreier with 1 troop.",
+    "timestamp": "2016-03-11T22:11:28.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Pärnumaa (mmacfreier) was reinforced by mmacfreier with 2 troops.",
+    "timestamp": "2016-03-11T22:11:30.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Saaremaa (mmacfreier) attacked Hiiumaa (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-11T22:11:35.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Saaremaa (mmacfreier) occupied Hiiumaa with 1 troop.",
+    "timestamp": "2016-03-11T22:11:37.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Pärnumaa (mmacfreier) attacked Tallinn (jobratt) conquering it, killing 3, losing 3.",
+    "timestamp": "2016-03-11T22:11:43.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Pärnumaa (mmacfreier) occupied Tallinn with 1 troop.",
+    "timestamp": "2016-03-11T22:11:49.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Pärnumaa (mmacfreier) attacked Rakvere (tanleach1001) conquering it, killing 2, losing 0.",
+    "timestamp": "2016-03-11T22:11:55.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Pärnumaa (mmacfreier) occupied Rakvere with 1 troop.",
+    "timestamp": "2016-03-11T22:11:58.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Vidzeme (mmacfreier) attacked Tartumaa (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-11T22:12:03.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Vidzeme (mmacfreier) occupied Tartumaa with 1 troop.",
+    "timestamp": "2016-03-11T22:12:15.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "Saaremaa (mmacfreier) was fortified from Haapsalu (mmacfreier) with 2 troops.",
+    "timestamp": "2016-03-11T22:12:22.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-03-11T22:12:22.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-03-11T22:12:22.000Z",
+    "player": "mmacfreier",
+    "round": 2
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-03-11T22:22:21.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "jobratt received 3 troops for 10 territories.",
+    "timestamp": "2016-03-11T22:22:21.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "København (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-03-11T22:22:47.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "København (jobratt) attacked Sjælland (mmacfreier) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-03-11T22:23:11.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "København (jobratt) occupied Sjælland with 1 troop.",
+    "timestamp": "2016-03-11T22:23:15.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "København (jobratt) was fortified from Midtjylland (jobratt) with 2 troops.",
+    "timestamp": "2016-03-11T22:24:47.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-03-11T22:24:47.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-03-11T22:24:47.000Z",
+    "player": "jobratt",
+    "round": 2
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-03-11T22:27:23.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "gcochard received 4 troops for 14 territories.",
+    "timestamp": "2016-03-11T22:27:23.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Åland (gcochard) was reinforced by gcochard with 4 troops.",
+    "timestamp": "2016-03-11T22:27:43.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Åland (gcochard) attacked Stockholm (kwren) conquering it, killing 2, losing 0.",
+    "timestamp": "2016-03-11T22:27:45.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Åland (gcochard) occupied Stockholm with 6 troops.",
+    "timestamp": "2016-03-11T22:27:47.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Gävleborg (gcochard) attacked Dalarna (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-11T22:27:54.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Gävleborg (gcochard) occupied Dalarna with 2 troops.",
+    "timestamp": "2016-03-11T22:27:57.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Örebro (gcochard) attacked Uppsala (kwren) killing 0, losing 2.",
+    "timestamp": "2016-03-11T22:28:02.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Dalarna (gcochard) attacked Uppsala (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-11T22:28:08.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Kotka (gcochard) attacked Lahti (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-11T22:28:38.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Kotka (gcochard) occupied Lahti with 2 troops.",
+    "timestamp": "2016-03-11T22:28:40.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "Mazowieckie (kwren) was fortified from Podlaskie (gcochard) with 2 troops.",
+    "timestamp": "2016-03-11T22:33:21.000Z",
+    "player": "kwren",
+    "round": 2
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-03-11T22:33:21.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-03-11T22:33:21.000Z",
+    "player": "gcochard",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-03-11T22:49:17.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 11 territories.",
+    "timestamp": "2016-03-11T22:49:17.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Pskov (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-03-11T22:49:32.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Pskov (ryanbmilbourne) attacked Velikiye Luki (jobratt) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-03-11T22:49:36.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Pskov (ryanbmilbourne) occupied Velikiye Luki with 4 troops.",
+    "timestamp": "2016-03-11T22:49:38.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Slantsy (ryanbmilbourne) attacked Kotka (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-11T22:49:50.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Slantsy (ryanbmilbourne) occupied Kotka with 3 troops.",
+    "timestamp": "2016-03-11T22:49:54.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Västra Götaland (ryanbmilbourne) attacked Örebro (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-11T22:50:15.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Västra Götaland (ryanbmilbourne) occupied Örebro with 1 troop.",
+    "timestamp": "2016-03-11T22:50:41.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Kotka (ryanbmilbourne) was fortified from Vyborg (ryanbmilbourne) with 2 troops.",
+    "timestamp": "2016-03-11T22:50:54.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-03-11T22:50:54.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-03-11T22:50:54.000Z",
+    "player": "ryanbmilbourne",
+    "round": 2
+  },
+  {
+    "message": "Round 3 started.",
+    "timestamp": "2016-03-11T22:50:54.000Z",
+    "player": "unknown",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-03-11T22:51:00.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 received 4 troops for 13 territories.",
+    "timestamp": "2016-03-11T22:51:00.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Bielaruś.",
+    "timestamp": "2016-03-11T22:51:00.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Hrozna (tanleach1001) was reinforced by tanleach1001 with 2 troops.",
+    "timestamp": "2016-03-11T22:51:13.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Vitebsk (tanleach1001) was reinforced by tanleach1001 with 5 troops.",
+    "timestamp": "2016-03-11T22:52:09.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Vitebsk (tanleach1001) attacked Velikiye Luki (ryanbmilbourne) conquering it, killing 4, losing 1.",
+    "timestamp": "2016-03-11T22:52:17.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Vitebsk (tanleach1001) occupied Velikiye Luki with 1 troop.",
+    "timestamp": "2016-03-11T22:52:23.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Hrozna (tanleach1001) attacked Podlaskie (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-11T22:52:26.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Hrozna (tanleach1001) occupied Podlaskie with 1 troop.",
+    "timestamp": "2016-03-11T22:52:34.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Hrozna (tanleach1001) attacked Dzūkija (ryanbmilbourne) killing 0, losing 2.",
+    "timestamp": "2016-03-11T22:56:46.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Vitebsk (tanleach1001) attacked Dzūkija (ryanbmilbourne) killing 2, losing 3.",
+    "timestamp": "2016-03-11T22:57:05.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Aukštaitija (tanleach1001) attacked Dzūkija (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-11T22:57:10.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Aukštaitija (tanleach1001) occupied Dzūkija with 1 troop.",
+    "timestamp": "2016-03-11T22:57:18.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Dzūkija (tanleach1001) was fortified from Hrozna (tanleach1001) with 5 troops.",
+    "timestamp": "2016-03-11T22:57:52.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-03-11T22:57:52.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-03-11T22:57:52.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-03-11T22:58:05.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren received 4 troops for 12 territories.",
+    "timestamp": "2016-03-11T22:58:05.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren received 1 troop for holding Kaliningrad Oblast.",
+    "timestamp": "2016-03-11T22:58:05.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Wielkopolskie (kwren) was reinforced by kwren with 5 troops.",
+    "timestamp": "2016-03-11T23:01:04.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Wielkopolskie (kwren) attacked Pomorskie (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-11T23:01:08.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Wielkopolskie (kwren) occupied Pomorskie with 1 troop.",
+    "timestamp": "2016-03-11T23:01:17.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Wielkopolskie (kwren) attacked Szczecin (gcochard) conquering it, killing 2, losing 1.",
+    "timestamp": "2016-03-11T23:01:22.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Wielkopolskie (kwren) occupied Szczecin with 2 troops.",
+    "timestamp": "2016-03-11T23:01:26.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Mazowieckie (kwren) attacked Podlaskie (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-11T23:01:31.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Mazowieckie (kwren) occupied Podlaskie with 3 troops.",
+    "timestamp": "2016-03-11T23:01:33.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Szczecin (kwren) was fortified from Žemaitija (kwren) with 2 troops.",
+    "timestamp": "2016-03-11T23:02:36.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-03-11T23:02:36.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-03-11T23:02:36.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-03-11T23:03:41.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier received 4 troops for 13 territories.",
+    "timestamp": "2016-03-11T23:03:41.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Eesti.",
+    "timestamp": "2016-03-11T23:03:41.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Zemgale (mmacfreier) was reinforced by mmacfreier with 8 troops.",
+    "timestamp": "2016-03-11T23:03:56.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Zemgale (mmacfreier) attacked Latgale (gcochard) conquering it, killing 3, losing 3.",
+    "timestamp": "2016-03-11T23:04:03.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Zemgale (mmacfreier) occupied Latgale with 7 troops.",
+    "timestamp": "2016-03-11T23:04:06.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Latgale (mmacfreier) attacked Vitebsk (tanleach1001) killing 4, losing 6.",
+    "timestamp": "2016-03-11T23:04:16.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "Vidzeme (mmacfreier) was fortified from Kurzeme (mmacfreier) with 2 troops.",
+    "timestamp": "2016-03-11T23:04:26.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-03-11T23:04:26.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-03-11T23:04:26.000Z",
+    "player": "mmacfreier",
+    "round": 3
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-03-11T23:06:23.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt received 3 troops for 10 territories.",
+    "timestamp": "2016-03-11T23:06:23.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt received 3 troops for holding Danmark.",
+    "timestamp": "2016-03-11T23:06:23.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Vitebsk (tanleach1001) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-03-11T23:07:15.000Z",
+    "player": "tanleach1001",
+    "round": 3
+  },
+  {
+    "message": "Nordjylland (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-03-11T23:08:56.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Nordjylland (jobratt) attacked Västra Götaland (ryanbmilbourne) conquering it, killing 2, losing 0.",
+    "timestamp": "2016-03-11T23:08:58.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Nordjylland (jobratt) occupied Västra Götaland with 5 troops.",
+    "timestamp": "2016-03-11T23:09:18.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "Sørlandet (jobratt) was fortified from Halland (jobratt) with 2 troops.",
+    "timestamp": "2016-03-11T23:09:38.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-03-11T23:09:39.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-03-11T23:09:39.000Z",
+    "player": "jobratt",
+    "round": 3
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-03-11T23:45:51.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard received 4 troops for 12 territories.",
+    "timestamp": "2016-03-11T23:45:51.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Wielkopolskie (kwren) was reinforced by gcochard with 1 troop.",
+    "timestamp": "2016-03-11T23:45:58.000Z",
+    "player": "kwren",
+    "round": 3
+  },
+  {
+    "message": "Södermanland (gcochard) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-03-11T23:46:05.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Södermanland (gcochard) attacked Örebro (ryanbmilbourne) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-03-11T23:46:09.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Södermanland (gcochard) occupied Örebro with 3 troops.",
+    "timestamp": "2016-03-11T23:46:18.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "Värmland (gcochard) was fortified from Stockholm (gcochard) with 2 troops.",
+    "timestamp": "2016-03-11T23:46:41.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-03-11T23:46:41.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-03-11T23:46:41.000Z",
+    "player": "gcochard",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-03-12T00:59:40.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 10 territories.",
+    "timestamp": "2016-03-12T00:59:40.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Pskov (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-03-12T00:59:58.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Pskov (ryanbmilbourne) attacked Velikiye Luki (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-12T01:00:01.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Pskov (ryanbmilbourne) occupied Velikiye Luki with 3 troops.",
+    "timestamp": "2016-03-12T01:00:03.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Skåne (ryanbmilbourne) attacked Halland (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-12T01:00:15.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Skåne (ryanbmilbourne) occupied Halland with 2 troops.",
+    "timestamp": "2016-03-12T01:00:25.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Halland (ryanbmilbourne) was fortified from Bornholm (ryanbmilbourne) with 2 troops.",
+    "timestamp": "2016-03-12T01:01:23.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-03-12T01:01:23.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-03-12T01:01:23.000Z",
+    "player": "ryanbmilbourne",
+    "round": 3
+  },
+  {
+    "message": "Round 4 started.",
+    "timestamp": "2016-03-12T01:01:23.000Z",
+    "player": "unknown",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-03-12T05:52:06.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 received 4 troops for 14 territories.",
+    "timestamp": "2016-03-12T05:52:06.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Bielaruś.",
+    "timestamp": "2016-03-12T05:52:06.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Dzūkija (tanleach1001) was reinforced by tanleach1001 with 3 troops.",
+    "timestamp": "2016-03-12T05:52:33.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Vitebsk (tanleach1001) was reinforced by tanleach1001 with 4 troops.",
+    "timestamp": "2016-03-12T05:52:38.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Vitebsk (tanleach1001) attacked Latgale (mmacfreier) killing 0, losing 1.",
+    "timestamp": "2016-03-12T05:52:50.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Dzūkija (tanleach1001) attacked Latgale (mmacfreier) killing 0, losing 1.",
+    "timestamp": "2016-03-12T05:52:55.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Vitebsk (tanleach1001) attacked Latgale (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-12T05:52:59.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Vitebsk (tanleach1001) occupied Latgale with 8 troops.",
+    "timestamp": "2016-03-12T05:53:05.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Latgale (tanleach1001) attacked Pskov (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-12T05:53:08.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Latgale (tanleach1001) occupied Pskov with 7 troops.",
+    "timestamp": "2016-03-12T05:53:14.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Pskov (tanleach1001) attacked Rakvere (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-12T05:53:17.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Pskov (tanleach1001) occupied Rakvere with 1 troop.",
+    "timestamp": "2016-03-12T05:53:24.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Vitebsk (tanleach1001) was fortified from Pskov (tanleach1001) with 5 troops.",
+    "timestamp": "2016-03-12T05:53:45.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-03-12T05:53:46.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-03-12T05:53:46.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "kwren missed the turn.",
+    "timestamp": "2016-03-13T05:53:47.000Z",
+    "player": "kwren",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-03-13T16:41:34.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier received 4 troops for 12 territories.",
+    "timestamp": "2016-03-13T16:41:34.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Pärnumaa (mmacfreier) was reinforced by mmacfreier with 4 troops.",
+    "timestamp": "2016-03-13T16:43:06.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Pärnumaa (mmacfreier) attacked Rakvere (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-13T16:43:11.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Pärnumaa (mmacfreier) occupied Rakvere with 5 troops.",
+    "timestamp": "2016-03-13T16:43:14.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Rakvere (mmacfreier) attacked Pskov (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-13T16:43:19.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Rakvere (mmacfreier) occupied Pskov with 4 troops.",
+    "timestamp": "2016-03-13T16:43:20.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Pskov (mmacfreier) attacked Latgale (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-13T16:43:24.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Pskov (mmacfreier) occupied Latgale with 3 troops.",
+    "timestamp": "2016-03-13T16:43:26.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "Latgale (mmacfreier) was fortified from Saaremaa (mmacfreier) with 4 troops.",
+    "timestamp": "2016-03-13T16:43:37.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-03-13T16:43:37.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-03-13T16:43:37.000Z",
+    "player": "mmacfreier",
+    "round": 4
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-03-13T22:07:56.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "jobratt received 3 troops for 10 territories.",
+    "timestamp": "2016-03-13T22:07:56.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "jobratt received 3 troops for holding Danmark.",
+    "timestamp": "2016-03-13T22:07:56.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Vitebsk (tanleach1001) was reinforced by jobratt with 2 troops.",
+    "timestamp": "2016-03-13T22:08:59.000Z",
+    "player": "tanleach1001",
+    "round": 4
+  },
+  {
+    "message": "Västra Götaland (jobratt) was reinforced by jobratt with 4 troops.",
+    "timestamp": "2016-03-13T22:09:13.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Västra Götaland (jobratt) attacked Värmland (gcochard) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-03-13T22:09:28.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Västra Götaland (jobratt) occupied Värmland with 1 troop.",
+    "timestamp": "2016-03-13T22:10:13.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "Syddanmark (jobratt) was fortified from Östergötland (jobratt) with 2 troops.",
+    "timestamp": "2016-03-13T22:10:37.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-03-13T22:10:37.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-03-13T22:10:37.000Z",
+    "player": "jobratt",
+    "round": 4
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-03-14T00:25:23.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard received 4 troops for 12 territories.",
+    "timestamp": "2016-03-14T00:25:23.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Örebro (gcochard) was reinforced by gcochard with 4 troops.",
+    "timestamp": "2016-03-14T00:25:31.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Örebro (gcochard) attacked Värmland (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-14T00:25:35.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Örebro (gcochard) occupied Värmland with 3 troops.",
+    "timestamp": "2016-03-14T00:25:39.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "Värmland (gcochard) was fortified from Stockholm (gcochard) with 2 troops.",
+    "timestamp": "2016-03-14T00:26:36.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-03-14T00:26:37.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-03-14T00:26:37.000Z",
+    "player": "gcochard",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-03-14T16:20:32.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 11 territories.",
+    "timestamp": "2016-03-14T16:20:32.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "Velikiye Luki (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-03-14T16:20:46.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "Velikiye Luki (ryanbmilbourne) attacked Pskov (mmacfreier) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-03-14T16:20:59.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "Velikiye Luki (ryanbmilbourne) occupied Pskov with 1 troop.",
+    "timestamp": "2016-03-14T16:21:02.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-03-14T16:21:13.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-03-14T16:21:13.000Z",
+    "player": "ryanbmilbourne",
+    "round": 4
+  },
+  {
+    "message": "Round 5 started.",
+    "timestamp": "2016-03-14T16:21:13.000Z",
+    "player": "unknown",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-03-14T17:08:46.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received 4 troops for 14 territories.",
+    "timestamp": "2016-03-14T17:08:46.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Bielaruś.",
+    "timestamp": "2016-03-14T17:08:46.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "Jotunheimen (tanleach1001) was reinforced by tanleach1001 with 5 troops.",
+    "timestamp": "2016-03-14T17:09:52.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "København (jobratt) was reinforced by tanleach1001 with 2 troops.",
+    "timestamp": "2016-03-14T17:09:59.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Östergötland (jobratt) was fortified from Kalmar (tanleach1001) with 4 troops.",
+    "timestamp": "2016-03-14T17:10:21.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-03-14T17:10:21.000Z",
+    "player": "tanleach1001",
+    "round": 5
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-03-14T18:30:12.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received 5 troops for 15 territories.",
+    "timestamp": "2016-03-14T18:30:12.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received 4 troops for holding Polska.",
+    "timestamp": "2016-03-14T18:30:12.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren received 1 troop for holding Kaliningrad Oblast.",
+    "timestamp": "2016-03-14T18:30:12.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Örebro (gcochard) was reinforced by kwren with 1 troop.",
+    "timestamp": "2016-03-14T18:30:20.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Öland (kwren) was reinforced by kwren with 9 troops.",
+    "timestamp": "2016-03-14T18:30:23.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Öland (kwren) attacked Kalmar (tanleach1001) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-03-14T18:30:28.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Öland (kwren) occupied Kalmar with 7 troops.",
+    "timestamp": "2016-03-14T18:30:29.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Kalmar (kwren) attacked Östergötland (jobratt) conquering it, killing 5, losing 0.",
+    "timestamp": "2016-03-14T18:30:35.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Kalmar (kwren) occupied Östergötland with 6 troops.",
+    "timestamp": "2016-03-14T18:30:39.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "Värmland (gcochard) was fortified from Sovetsk (kwren) with 5 troops.",
+    "timestamp": "2016-03-14T18:39:37.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-03-14T18:39:37.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-03-14T18:39:37.000Z",
+    "player": "kwren",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-03-14T18:39:54.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier received 4 troops for 14 territories.",
+    "timestamp": "2016-03-14T18:39:54.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Eesti.",
+    "timestamp": "2016-03-14T18:39:54.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Vidzeme (mmacfreier) was reinforced by mmacfreier with 8 troops.",
+    "timestamp": "2016-03-14T18:40:17.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Vidzeme (mmacfreier) attacked Riga (gcochard) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-03-14T18:40:21.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Vidzeme (mmacfreier) occupied Riga with 1 troop.",
+    "timestamp": "2016-03-14T18:40:24.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "Saaremaa (mmacfreier) was fortified from Vidzeme (mmacfreier) with 6 troops.",
+    "timestamp": "2016-03-14T18:40:36.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-03-14T18:40:36.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-03-14T18:40:36.000Z",
+    "player": "mmacfreier",
+    "round": 5
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-03-14T18:47:20.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "jobratt received 3 troops for 9 territories.",
+    "timestamp": "2016-03-14T18:47:20.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "jobratt received 3 troops for holding Danmark.",
+    "timestamp": "2016-03-14T18:47:20.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "jobratt received 4 troops for turning in cards Riga, Kotka, and Dalarna.",
+    "timestamp": "2016-03-14T18:47:24.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Västra Götaland (jobratt) was reinforced by jobratt with 10 troops.",
+    "timestamp": "2016-03-14T18:47:33.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Västra Götaland (jobratt) attacked Örebro (gcochard) conquering it, killing 5, losing 3.",
+    "timestamp": "2016-03-14T18:47:44.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Västra Götaland (jobratt) occupied Örebro with 1 troop.",
+    "timestamp": "2016-03-14T18:48:10.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Sørlandet (jobratt) attacked Vestlandet (kwren) killing 0, losing 2.",
+    "timestamp": "2016-03-14T18:49:00.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "København (jobratt) attacked Skåne (ryanbmilbourne) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-03-14T18:49:19.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "København (jobratt) occupied Skåne with 1 troop.",
+    "timestamp": "2016-03-14T18:49:23.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "Nordjylland (jobratt) was fortified from Västra Götaland (jobratt) with 12 troops.",
+    "timestamp": "2016-03-14T18:50:18.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-03-14T18:50:18.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-03-14T18:50:18.000Z",
+    "player": "jobratt",
+    "round": 5
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-03-14T18:50:58.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "gcochard received 3 troops for 11 territories.",
+    "timestamp": "2016-03-14T18:50:58.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Värmland (gcochard) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-03-14T18:53:09.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Värmland (gcochard) attacked Örebro (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-14T18:53:13.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Värmland (gcochard) occupied Örebro with 5 troops.",
+    "timestamp": "2016-03-14T18:53:39.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Kronoberg (gcochard) attacked Jönköping (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-14T18:54:00.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "Stockholm (gcochard) was fortified from Södermanland (gcochard) with 2 troops.",
+    "timestamp": "2016-03-14T18:54:51.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-03-14T18:54:51.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-03-14T18:54:51.000Z",
+    "player": "gcochard",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-03-14T18:55:04.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 11 territories.",
+    "timestamp": "2016-03-14T18:55:04.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne received 4 troops for holding Rossiya.",
+    "timestamp": "2016-03-14T18:55:04.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Kotka (ryanbmilbourne) was reinforced by ryanbmilbourne with 7 troops.",
+    "timestamp": "2016-03-14T18:56:02.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Kotka (ryanbmilbourne) attacked Lahti (gcochard) conquering it, killing 2, losing 1.",
+    "timestamp": "2016-03-14T18:56:07.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Kotka (ryanbmilbourne) occupied Lahti with 1 troop.",
+    "timestamp": "2016-03-14T18:56:12.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Kotka (ryanbmilbourne) attacked Helsinki (jobratt) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-03-14T18:56:23.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Kotka (ryanbmilbourne) occupied Helsinki with 1 troop.",
+    "timestamp": "2016-03-14T18:56:26.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Brandenburg (ryanbmilbourne) was fortified from Lüneburg (ryanbmilbourne) with 2 troops.",
+    "timestamp": "2016-03-14T18:56:51.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-03-14T18:56:51.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-03-14T18:56:51.000Z",
+    "player": "ryanbmilbourne",
+    "round": 5
+  },
+  {
+    "message": "Round 6 started.",
+    "timestamp": "2016-03-14T18:56:51.000Z",
+    "player": "unknown",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-03-14T20:23:16.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 received 4 troops for 12 territories.",
+    "timestamp": "2016-03-14T20:23:16.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Bielaruś.",
+    "timestamp": "2016-03-14T20:23:16.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Turku (tanleach1001) was reinforced by tanleach1001 with 4 troops.",
+    "timestamp": "2016-03-14T20:23:25.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "København (jobratt) was reinforced by tanleach1001 with 3 troops.",
+    "timestamp": "2016-03-14T20:23:31.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Turku (tanleach1001) attacked Åland (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-14T20:23:36.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Turku (tanleach1001) occupied Åland with 1 troop.",
+    "timestamp": "2016-03-14T20:23:55.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Jotunheimen (tanleach1001) attacked Vestlandet (kwren) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-03-14T20:24:28.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "Jotunheimen (tanleach1001) occupied Vestlandet with 1 troop.",
+    "timestamp": "2016-03-14T20:24:38.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-03-14T20:25:33.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-03-14T20:25:33.000Z",
+    "player": "tanleach1001",
+    "round": 6
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-03-14T20:28:55.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 5 troops for 16 territories.",
+    "timestamp": "2016-03-14T20:28:55.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 4 troops for holding Polska.",
+    "timestamp": "2016-03-14T20:28:55.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren received 1 troop for holding Kaliningrad Oblast.",
+    "timestamp": "2016-03-14T20:28:55.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Stockholm (gcochard) was reinforced by kwren with 2 troops.",
+    "timestamp": "2016-03-14T20:29:03.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Szczecin (kwren) was reinforced by kwren with 8 troops.",
+    "timestamp": "2016-03-14T20:29:08.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Szczecin (kwren) attacked Bornholm (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-14T20:29:17.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Szczecin (kwren) occupied Bornholm with 1 troop.",
+    "timestamp": "2016-03-14T20:29:21.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Szczecin (kwren) attacked Brandenburg (ryanbmilbourne) conquering it, killing 5, losing 4.",
+    "timestamp": "2016-03-14T20:29:33.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Szczecin (kwren) occupied Brandenburg with 1 troop.",
+    "timestamp": "2016-03-14T20:29:36.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Stockholm (gcochard) was fortified from Podlaskie (kwren) with 2 troops.",
+    "timestamp": "2016-03-14T20:36:38.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-03-14T20:36:38.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-03-14T20:36:38.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-03-14T20:37:34.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier received 5 troops for 15 territories.",
+    "timestamp": "2016-03-14T20:37:34.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Eesti.",
+    "timestamp": "2016-03-14T20:37:34.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier received 2 troops on Oslo",
+    "timestamp": "2016-03-14T20:37:46.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier received 2 troops on Zemgale",
+    "timestamp": "2016-03-14T20:37:46.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier received 6 troops for turning in cards Oslo, Sachsen-Anhalt, and Zemgale.",
+    "timestamp": "2016-03-14T20:37:46.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Saaremaa (mmacfreier) was reinforced by mmacfreier with 15 troops.",
+    "timestamp": "2016-03-14T20:38:59.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Saaremaa (mmacfreier) attacked Gotland (kwren) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-03-14T20:39:10.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Saaremaa (mmacfreier) occupied Gotland with 14 troops.",
+    "timestamp": "2016-03-14T20:39:25.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Gotland (mmacfreier) attacked Kaliningrad (kwren) conquering it, killing 5, losing 1.",
+    "timestamp": "2016-03-14T20:39:32.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Gotland (mmacfreier) occupied Kaliningrad with 9 troops.",
+    "timestamp": "2016-03-14T20:39:41.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Kaliningrad (mmacfreier) attacked Mazurskie (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-03-14T20:40:14.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Kaliningrad (mmacfreier) occupied Mazurskie with 1 troop.",
+    "timestamp": "2016-03-14T20:40:25.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Kaliningrad (mmacfreier) attacked Sovetsk (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-14T20:40:33.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Kaliningrad (mmacfreier) occupied Sovetsk with 5 troops.",
+    "timestamp": "2016-03-14T20:40:39.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "Kaliningrad (mmacfreier) was fortified from Zemgale (mmacfreier) with 2 troops.",
+    "timestamp": "2016-03-14T20:41:05.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-03-14T20:41:05.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-03-14T20:41:05.000Z",
+    "player": "mmacfreier",
+    "round": 6
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-03-14T21:44:23.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "jobratt received 3 troops for 9 territories.",
+    "timestamp": "2016-03-14T21:44:23.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "jobratt received 3 troops for holding Danmark.",
+    "timestamp": "2016-03-14T21:44:23.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Skåne (jobratt) was reinforced by jobratt with 6 troops.",
+    "timestamp": "2016-03-14T21:45:15.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Skåne (jobratt) attacked Bornholm (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-14T21:45:19.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Skåne (jobratt) occupied Bornholm with 4 troops.",
+    "timestamp": "2016-03-14T21:45:35.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "Skåne (jobratt) was fortified from København (jobratt) with 6 troops.",
+    "timestamp": "2016-03-14T21:46:20.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-03-14T21:46:21.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-03-14T21:46:21.000Z",
+    "player": "jobratt",
+    "round": 6
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-03-14T21:52:31.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "gcochard received 3 troops for 11 territories.",
+    "timestamp": "2016-03-14T21:52:31.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "gcochard received 4 troops for holding Svealand.",
+    "timestamp": "2016-03-14T21:52:31.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "gcochard received 8 troops for turning in cards Kujawy, Vidzeme, and Hiiumaa.",
+    "timestamp": "2016-03-14T21:52:45.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Szczecin (kwren) was reinforced by gcochard with 1 troop.",
+    "timestamp": "2016-03-14T21:53:40.000Z",
+    "player": "kwren",
+    "round": 6
+  },
+  {
+    "message": "Örebro (gcochard) was reinforced by gcochard with 14 troops.",
+    "timestamp": "2016-03-14T21:54:03.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Örebro (gcochard) attacked Västra Götaland (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-14T21:54:09.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Örebro (gcochard) occupied Västra Götaland with 17 troops.",
+    "timestamp": "2016-03-14T21:54:15.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Västra Götaland (gcochard) attacked Nordjylland (jobratt) killing 8, losing 16.",
+    "timestamp": "2016-03-14T21:56:24.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "Värmland (gcochard) was fortified from Stockholm (gcochard) with 2 troops.",
+    "timestamp": "2016-03-14T22:00:02.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-03-14T22:00:02.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-03-14T22:00:02.000Z",
+    "player": "gcochard",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-03-14T22:15:54.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 11 territories.",
+    "timestamp": "2016-03-14T22:15:54.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne received 4 troops for holding Rossiya.",
+    "timestamp": "2016-03-14T22:15:54.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne received 10 troops for turning in cards Pomorskie, Kaliningrad, and Minsk.",
+    "timestamp": "2016-03-14T22:16:00.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Lahti (ryanbmilbourne) was reinforced by ryanbmilbourne with 17 troops.",
+    "timestamp": "2016-03-14T22:16:08.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Lahti (ryanbmilbourne) attacked Turku (tanleach1001) conquering it, killing 6, losing 5.",
+    "timestamp": "2016-03-14T22:16:15.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Lahti (ryanbmilbourne) occupied Turku with 12 troops.",
+    "timestamp": "2016-03-14T22:16:17.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Turku (ryanbmilbourne) attacked Espoo (kwren) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-03-14T22:16:29.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Turku (ryanbmilbourne) occupied Espoo with 1 troop.",
+    "timestamp": "2016-03-14T22:16:41.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Turku (ryanbmilbourne) attacked Åland (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-14T22:16:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Turku (ryanbmilbourne) occupied Åland with 9 troops.",
+    "timestamp": "2016-03-14T22:16:52.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Åland (ryanbmilbourne) was fortified from Kotka (ryanbmilbourne) with 6 troops.",
+    "timestamp": "2016-03-14T22:18:07.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-03-14T22:18:08.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-03-14T22:18:09.000Z",
+    "player": "ryanbmilbourne",
+    "round": 6
+  },
+  {
+    "message": "Round 7 started.",
+    "timestamp": "2016-03-14T22:18:09.000Z",
+    "player": "unknown",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-03-14T22:18:51.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 received 4 troops for 12 territories.",
+    "timestamp": "2016-03-14T22:18:51.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Bielaruś.",
+    "timestamp": "2016-03-14T22:18:51.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 received 12 troops for turning in cards Fyn, Uppsala, and Örebro.",
+    "timestamp": "2016-03-14T22:19:23.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Mecklenburg-Vorpommern (tanleach1001) was reinforced by tanleach1001 with 8 troops.",
+    "timestamp": "2016-03-14T22:20:14.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Sachsen-Anhalt (tanleach1001) was reinforced by tanleach1001 with 11 troops.",
+    "timestamp": "2016-03-14T22:20:18.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Sachsen-Anhalt (tanleach1001) attacked Niedersachsen (gcochard) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-03-14T22:20:30.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Sachsen-Anhalt (tanleach1001) occupied Niedersachsen with 1 troop.",
+    "timestamp": "2016-03-14T22:20:39.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Sachsen-Anhalt (tanleach1001) attacked Lüneburg (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-14T22:20:43.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Sachsen-Anhalt (tanleach1001) occupied Lüneburg with 10 troops.",
+    "timestamp": "2016-03-14T22:21:21.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Mecklenburg-Vorpommern (tanleach1001) attacked Schleswig-Holstein (mmacfreier) killing 1, losing 3.",
+    "timestamp": "2016-03-14T22:21:44.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Lüneburg (tanleach1001) attacked Schleswig-Holstein (mmacfreier) conquering it, killing 2, losing 1.",
+    "timestamp": "2016-03-14T22:21:51.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Lüneburg (tanleach1001) occupied Schleswig-Holstein with 1 troop.",
+    "timestamp": "2016-03-14T22:21:57.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Lüneburg (tanleach1001) attacked Brandenburg (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-14T22:22:01.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Lüneburg (tanleach1001) occupied Brandenburg with 7 troops.",
+    "timestamp": "2016-03-14T22:22:04.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Jotunheimen (tanleach1001) attacked Østlandet (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-14T22:22:57.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Jotunheimen (tanleach1001) occupied Østlandet with 1 troop.",
+    "timestamp": "2016-03-14T22:23:07.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "Hrozna (tanleach1001) was fortified from Dzūkija (tanleach1001) with 7 troops.",
+    "timestamp": "2016-03-14T22:23:29.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-03-14T22:23:30.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-03-14T22:23:30.000Z",
+    "player": "tanleach1001",
+    "round": 7
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-03-15T00:20:25.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren received 3 troops for 11 territories.",
+    "timestamp": "2016-03-15T00:20:25.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren received 2 troops on Öland",
+    "timestamp": "2016-03-15T00:20:31.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren received 12 troops for turning in cards Tartumaa, Stockholm, and Öland.",
+    "timestamp": "2016-03-15T00:20:31.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Östergötland (kwren) was reinforced by kwren with 10 troops.",
+    "timestamp": "2016-03-15T00:20:52.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Öland (kwren) was reinforced by kwren with 5 troops.",
+    "timestamp": "2016-03-15T00:20:55.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Östergötland (kwren) attacked Jönköping (gcochard) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-03-15T00:20:59.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Östergötland (kwren) occupied Jönköping with 13 troops.",
+    "timestamp": "2016-03-15T00:21:01.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Jönköping (kwren) attacked Västra Götaland (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T00:21:04.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Jönköping (kwren) occupied Västra Götaland with 12 troops.",
+    "timestamp": "2016-03-15T00:21:06.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Västra Götaland (kwren) attacked Nordjylland (jobratt) conquering it, killing 5, losing 0.",
+    "timestamp": "2016-03-15T00:21:10.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Västra Götaland (kwren) occupied Nordjylland with 11 troops.",
+    "timestamp": "2016-03-15T00:21:12.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Nordjylland (kwren) attacked Midtjylland (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-15T00:21:16.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Nordjylland (kwren) occupied Midtjylland with 9 troops.",
+    "timestamp": "2016-03-15T00:21:17.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Midtjylland (kwren) attacked Syddanmark (jobratt) conquering it, killing 7, losing 4.",
+    "timestamp": "2016-03-15T00:21:26.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Midtjylland (kwren) occupied Syddanmark with 4 troops.",
+    "timestamp": "2016-03-15T00:21:27.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Syddanmark (kwren) attacked Schleswig-Holstein (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T00:21:30.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Syddanmark (kwren) occupied Schleswig-Holstein with 3 troops.",
+    "timestamp": "2016-03-15T00:21:33.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Öland (kwren) attacked Gotland (mmacfreier) conquering it, killing 4, losing 2.",
+    "timestamp": "2016-03-15T00:21:41.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Öland (kwren) occupied Gotland with 5 troops.",
+    "timestamp": "2016-03-15T00:21:43.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Gotland (kwren) attacked Saaremaa (mmacfreier) killing 2, losing 4.",
+    "timestamp": "2016-03-15T00:21:49.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Szczecin (kwren) attacked Mecklenburg-Vorpommern (tanleach1001) killing 3, losing 5.",
+    "timestamp": "2016-03-15T00:22:07.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Suvalkija (kwren) attacked Sovetsk (mmacfreier) killing 2, losing 2.",
+    "timestamp": "2016-03-15T00:22:27.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "Örebro (gcochard) was fortified from Schleswig-Holstein (kwren) with 2 troops.",
+    "timestamp": "2016-03-15T00:22:50.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-03-15T00:22:50.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-03-15T00:22:50.000Z",
+    "player": "kwren",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-03-15T00:28:47.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier received 5 troops for 17 territories.",
+    "timestamp": "2016-03-15T00:28:47.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier received 1 troop for holding Kaliningrad Oblast.",
+    "timestamp": "2016-03-15T00:28:47.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Eesti.",
+    "timestamp": "2016-03-15T00:28:47.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Zemgale (mmacfreier) was reinforced by mmacfreier with 10 troops.",
+    "timestamp": "2016-03-15T00:30:23.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Zemgale (mmacfreier) attacked Žemaitija (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T00:30:27.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Zemgale (mmacfreier) occupied Žemaitija with 10 troops.",
+    "timestamp": "2016-03-15T00:30:29.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Žemaitija (mmacfreier) attacked Suvalkija (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T00:30:32.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Žemaitija (mmacfreier) occupied Suvalkija with 9 troops.",
+    "timestamp": "2016-03-15T00:30:40.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "Saaremaa (mmacfreier) was fortified from Suvalkija (mmacfreier) with 8 troops.",
+    "timestamp": "2016-03-15T00:31:12.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-03-15T00:31:12.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-03-15T00:31:12.000Z",
+    "player": "mmacfreier",
+    "round": 7
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-03-15T00:43:01.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "jobratt received 3 troops for 6 territories.",
+    "timestamp": "2016-03-15T00:43:01.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Sørlandet (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-03-15T00:43:26.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Sørlandet (jobratt) attacked Nordjylland (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T00:43:33.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Sørlandet (jobratt) occupied Nordjylland with 5 troops.",
+    "timestamp": "2016-03-15T00:43:37.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Nordjylland (jobratt) attacked Midtjylland (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T00:43:42.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Nordjylland (jobratt) occupied Midtjylland with 4 troops.",
+    "timestamp": "2016-03-15T00:43:44.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Midtjylland (jobratt) attacked Syddanmark (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T00:43:49.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Midtjylland (jobratt) occupied Syddanmark with 3 troops.",
+    "timestamp": "2016-03-15T00:43:51.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Syddanmark (jobratt) attacked Schleswig-Holstein (kwren) killing 0, losing 2.",
+    "timestamp": "2016-03-15T00:43:57.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Bornholm (jobratt) attacked Szczecin (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T00:45:01.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "Bornholm (jobratt) occupied Szczecin with 3 troops.",
+    "timestamp": "2016-03-15T00:45:18.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-03-15T00:53:58.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-03-15T00:53:58.000Z",
+    "player": "jobratt",
+    "round": 7
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-03-15T16:54:59.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "gcochard received 3 troops for 8 territories.",
+    "timestamp": "2016-03-15T16:54:59.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "gcochard received 4 troops for holding Svealand.",
+    "timestamp": "2016-03-15T16:54:59.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "gcochard received 12 troops for turning in cards Schleswig-Holstein, Vyborg, and Halland.",
+    "timestamp": "2016-03-15T16:56:11.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Örebro (gcochard) was reinforced by gcochard with 2 troops.",
+    "timestamp": "2016-03-15T16:56:23.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Södermanland (gcochard) was reinforced by gcochard with 4 troops.",
+    "timestamp": "2016-03-15T16:56:46.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Värmland (gcochard) was reinforced by gcochard with 13 troops.",
+    "timestamp": "2016-03-15T16:58:34.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Värmland (gcochard) attacked Østlandet (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T16:58:40.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Värmland (gcochard) occupied Østlandet with 22 troops.",
+    "timestamp": "2016-03-15T16:58:44.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Østlandet (gcochard) attacked Jotunheimen (tanleach1001) conquering it, killing 5, losing 3.",
+    "timestamp": "2016-03-15T16:58:54.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Østlandet (gcochard) occupied Jotunheimen with 18 troops.",
+    "timestamp": "2016-03-15T16:59:32.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Jotunheimen (gcochard) attacked Oslo (mmacfreier) conquering it, killing 5, losing 5.",
+    "timestamp": "2016-03-15T16:59:53.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Jotunheimen (gcochard) occupied Oslo with 1 troop.",
+    "timestamp": "2016-03-15T16:59:58.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Jotunheimen (gcochard) attacked Telemark (mmacfreier) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-03-15T17:00:08.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Jotunheimen (gcochard) occupied Telemark with 9 troops.",
+    "timestamp": "2016-03-15T17:00:51.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Telemark (gcochard) attacked Vestlandet (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T17:00:56.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Telemark (gcochard) occupied Vestlandet with 8 troops.",
+    "timestamp": "2016-03-15T17:01:03.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Vestlandet (gcochard) attacked Sørlandet (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-15T17:01:08.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Vestlandet (gcochard) occupied Sørlandet with 6 troops.",
+    "timestamp": "2016-03-15T17:01:13.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Sørlandet (gcochard) attacked Nordjylland (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T17:01:17.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Sørlandet (gcochard) occupied Nordjylland with 1 troop.",
+    "timestamp": "2016-03-15T17:01:26.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "Stockholm (gcochard) was fortified from Södermanland (gcochard) with 4 troops.",
+    "timestamp": "2016-03-15T17:02:08.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-03-15T17:02:08.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-03-15T17:02:08.000Z",
+    "player": "gcochard",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-03-15T17:02:36.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne received 4 troops for 13 territories.",
+    "timestamp": "2016-03-15T17:02:36.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for holding Suomi.",
+    "timestamp": "2016-03-15T17:02:36.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne received 4 troops for holding Rossiya.",
+    "timestamp": "2016-03-15T17:02:36.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Åland (ryanbmilbourne) was reinforced by ryanbmilbourne with 11 troops.",
+    "timestamp": "2016-03-15T17:03:55.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Åland (ryanbmilbourne) attacked Stockholm (gcochard) conquering it, killing 10, losing 14.",
+    "timestamp": "2016-03-15T17:05:27.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Åland (ryanbmilbourne) occupied Stockholm with 1 troop.",
+    "timestamp": "2016-03-15T17:05:38.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Halland (ryanbmilbourne) attacked Västra Götaland (kwren) killing 0, losing 1.",
+    "timestamp": "2016-03-15T17:05:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-03-15T17:06:07.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-03-15T17:06:08.000Z",
+    "player": "ryanbmilbourne",
+    "round": 7
+  },
+  {
+    "message": "Round 8 started.",
+    "timestamp": "2016-03-15T17:06:08.000Z",
+    "player": "unknown",
+    "round": 8
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-03-15T17:24:54.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "tanleach1001 received 4 troops for 13 territories.",
+    "timestamp": "2016-03-15T17:24:54.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Bielaruś.",
+    "timestamp": "2016-03-15T17:24:54.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Mecklenburg-Vorpommern (tanleach1001) was reinforced by tanleach1001 with 2 troops.",
+    "timestamp": "2016-03-15T17:25:07.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Szczecin (jobratt) was reinforced by tanleach1001 with 5 troops.",
+    "timestamp": "2016-03-15T17:33:23.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Mecklenburg-Vorpommern (tanleach1001) attacked Schleswig-Holstein (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T17:33:30.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Mecklenburg-Vorpommern (tanleach1001) occupied Schleswig-Holstein with 3 troops.",
+    "timestamp": "2016-03-15T17:34:14.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "Mecklenburg-Vorpommern (tanleach1001) was fortified from Brandenburg (tanleach1001) with 1 troop.",
+    "timestamp": "2016-03-15T17:34:44.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-03-15T17:34:44.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-03-15T17:34:44.000Z",
+    "player": "tanleach1001",
+    "round": 8
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-03-15T18:44:11.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received 3 troops for 11 territories.",
+    "timestamp": "2016-03-15T18:44:11.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received 2 troops on Wielkopolskie",
+    "timestamp": "2016-03-15T18:44:15.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren received 12 troops for turning in cards Lüneburg, Wielkopolskie, and Sovetsk.",
+    "timestamp": "2016-03-15T18:44:15.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Östergötland (kwren) was reinforced by kwren with 3 troops.",
+    "timestamp": "2016-03-15T18:44:24.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Pomorskie (kwren) was reinforced by kwren with 12 troops.",
+    "timestamp": "2016-03-15T18:44:45.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Pomorskie (kwren) attacked Mazurskie (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T18:44:50.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Pomorskie (kwren) occupied Mazurskie with 12 troops.",
+    "timestamp": "2016-03-15T18:44:56.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Mazurskie (kwren) attacked Kaliningrad (mmacfreier) conquering it, killing 3, losing 5.",
+    "timestamp": "2016-03-15T18:45:25.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Mazurskie (kwren) occupied Kaliningrad with 6 troops.",
+    "timestamp": "2016-03-15T18:45:27.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Kaliningrad (kwren) attacked Sovetsk (mmacfreier) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-03-15T18:45:34.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Kaliningrad (kwren) occupied Sovetsk with 5 troops.",
+    "timestamp": "2016-03-15T18:45:47.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Sovetsk (kwren) attacked Suvalkija (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-15T18:45:52.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Sovetsk (kwren) occupied Suvalkija with 1 troop.",
+    "timestamp": "2016-03-15T18:45:56.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Östergötland (kwren) attacked Södermanland (gcochard) killing 0, losing 3.",
+    "timestamp": "2016-03-15T18:46:13.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "Södermanland (gcochard) was fortified from Wielkopolskie (kwren) with 4 troops.",
+    "timestamp": "2016-03-15T18:46:44.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-03-15T18:46:45.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-03-15T18:46:45.000Z",
+    "player": "kwren",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-03-15T20:07:56.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier received 4 troops for 13 territories.",
+    "timestamp": "2016-03-15T20:07:56.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Eesti.",
+    "timestamp": "2016-03-15T20:07:56.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier received 12 troops for turning in cards Vestlandet, Mazurskie, and Novgorod.",
+    "timestamp": "2016-03-15T20:08:28.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Zemgale (mmacfreier) was reinforced by mmacfreier with 20 troops.",
+    "timestamp": "2016-03-15T20:08:45.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Zemgale (mmacfreier) attacked Aukštaitija (tanleach1001) conquering it, killing 2, losing 0.",
+    "timestamp": "2016-03-15T20:08:49.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Zemgale (mmacfreier) occupied Aukštaitija with 20 troops.",
+    "timestamp": "2016-03-15T20:08:52.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Aukštaitija (mmacfreier) attacked Suvalkija (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T20:08:55.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Aukštaitija (mmacfreier) occupied Suvalkija with 19 troops.",
+    "timestamp": "2016-03-15T20:08:59.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Suvalkija (mmacfreier) attacked Podlaskie (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T20:09:03.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Suvalkija (mmacfreier) occupied Podlaskie with 1 troop.",
+    "timestamp": "2016-03-15T20:09:10.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Suvalkija (mmacfreier) attacked Sovetsk (kwren) conquering it, killing 3, losing 0.",
+    "timestamp": "2016-03-15T20:09:15.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Suvalkija (mmacfreier) occupied Sovetsk with 1 troop.",
+    "timestamp": "2016-03-15T20:09:29.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Suvalkija (mmacfreier) attacked Dzūkija (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T20:09:33.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Suvalkija (mmacfreier) occupied Dzūkija with 10 troops.",
+    "timestamp": "2016-03-15T20:09:46.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Dzūkija (mmacfreier) was fortified from Vidzeme (mmacfreier) with 4 troops.",
+    "timestamp": "2016-03-15T20:10:09.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-03-15T20:10:10.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-03-15T20:10:10.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-03-15T20:10:19.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "jobratt received 3 troops for 8 territories.",
+    "timestamp": "2016-03-15T20:10:19.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "jobratt received 12 troops for turning in cards Saaremaa, Tallinn, and Kalmar.",
+    "timestamp": "2016-03-15T20:10:24.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Midtjylland (jobratt) was reinforced by jobratt with 4 troops.",
+    "timestamp": "2016-03-15T20:10:30.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Szczecin (jobratt) was reinforced by jobratt with 11 troops.",
+    "timestamp": "2016-03-15T20:10:55.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Szczecin (jobratt) attacked Pomorskie (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T20:10:58.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Szczecin (jobratt) occupied Pomorskie with 18 troops.",
+    "timestamp": "2016-03-15T20:11:01.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Pomorskie (jobratt) attacked Wielkopolskie (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T20:11:20.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Pomorskie (jobratt) occupied Wielkopolskie with 17 troops.",
+    "timestamp": "2016-03-15T20:11:30.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Wielkopolskie (jobratt) attacked Kujawy (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-15T20:11:36.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Wielkopolskie (jobratt) occupied Kujawy with 15 troops.",
+    "timestamp": "2016-03-15T20:11:37.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Kujawy (jobratt) attacked Mazurskie (kwren) killing 0, losing 3.",
+    "timestamp": "2016-03-15T20:11:45.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Kujawy (jobratt) attacked Mazowieckie (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-15T20:11:51.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Kujawy (jobratt) occupied Mazowieckie with 10 troops.",
+    "timestamp": "2016-03-15T20:12:02.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Mazowieckie (jobratt) attacked Mazurskie (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T20:12:07.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Mazowieckie (jobratt) occupied Mazurskie with 9 troops.",
+    "timestamp": "2016-03-15T20:12:14.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Mazurskie (jobratt) attacked Podlaskie (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T20:12:18.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Mazurskie (jobratt) occupied Podlaskie with 8 troops.",
+    "timestamp": "2016-03-15T20:12:43.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Midtjylland (jobratt) attacked Nordjylland (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T20:12:48.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Midtjylland (jobratt) occupied Nordjylland with 4 troops.",
+    "timestamp": "2016-03-15T20:12:53.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "Mazurskie (jobratt) was fortified from Skåne (jobratt) with 7 troops.",
+    "timestamp": "2016-03-15T20:13:49.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-03-15T20:13:49.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-03-15T20:13:49.000Z",
+    "player": "jobratt",
+    "round": 8
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-03-15T20:22:35.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "gcochard received 4 troops for 13 territories.",
+    "timestamp": "2016-03-15T20:22:35.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "gcochard received 3 troops for holding Norge.",
+    "timestamp": "2016-03-15T20:22:35.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "Södermanland (gcochard) was reinforced by gcochard with 7 troops.",
+    "timestamp": "2016-03-15T20:22:42.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "Södermanland (gcochard) attacked Stockholm (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T20:22:46.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "Södermanland (gcochard) occupied Stockholm with 11 troops.",
+    "timestamp": "2016-03-15T20:22:48.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "Stockholm (gcochard) was fortified from Sørlandet (gcochard) with 4 troops.",
+    "timestamp": "2016-03-15T21:05:54.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-03-15T21:05:54.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-03-15T21:05:54.000Z",
+    "player": "gcochard",
+    "round": 8
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-03-15T21:09:17.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "ryanbmilbourne received 4 troops for 13 territories.",
+    "timestamp": "2016-03-15T21:09:17.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for holding Suomi.",
+    "timestamp": "2016-03-15T21:09:17.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "ryanbmilbourne received 4 troops for holding Rossiya.",
+    "timestamp": "2016-03-15T21:09:17.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "ryanbmilbourne received 2 troops on Åland",
+    "timestamp": "2016-03-15T21:09:23.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "ryanbmilbourne received 12 troops for turning in cards Bornholm, Dzūkija, and Åland.",
+    "timestamp": "2016-03-15T21:09:23.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Latgale (mmacfreier) was reinforced by ryanbmilbourne with 4 troops.",
+    "timestamp": "2016-03-15T21:09:35.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Suvalkija (mmacfreier) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-03-15T21:09:41.000Z",
+    "player": "mmacfreier",
+    "round": 8
+  },
+  {
+    "message": "Halland (ryanbmilbourne) was reinforced by ryanbmilbourne with 16 troops.",
+    "timestamp": "2016-03-15T21:09:50.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Halland (ryanbmilbourne) attacked Skåne (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T21:09:53.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Halland (ryanbmilbourne) occupied Skåne with 18 troops.",
+    "timestamp": "2016-03-15T21:09:55.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Skåne (ryanbmilbourne) attacked København (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T21:09:59.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Skåne (ryanbmilbourne) occupied København with 1 troop.",
+    "timestamp": "2016-03-15T21:10:02.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Skåne (ryanbmilbourne) attacked Bornholm (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T21:10:05.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Skåne (ryanbmilbourne) occupied Bornholm with 16 troops.",
+    "timestamp": "2016-03-15T21:10:07.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Bornholm (ryanbmilbourne) attacked Szczecin (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-15T21:10:13.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Bornholm (ryanbmilbourne) occupied Szczecin with 14 troops.",
+    "timestamp": "2016-03-15T21:10:22.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Szczecin (ryanbmilbourne) attacked Mecklenburg-Vorpommern (tanleach1001) conquering it, killing 5, losing 1.",
+    "timestamp": "2016-03-15T21:10:38.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Szczecin (ryanbmilbourne) occupied Mecklenburg-Vorpommern with 1 troop.",
+    "timestamp": "2016-03-15T21:10:49.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Åland (ryanbmilbourne) was fortified from Velikiye Luki (ryanbmilbourne) with 1 troop.",
+    "timestamp": "2016-03-15T21:11:38.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-03-15T21:11:39.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-03-15T21:11:39.000Z",
+    "player": "ryanbmilbourne",
+    "round": 8
+  },
+  {
+    "message": "Round 9 started.",
+    "timestamp": "2016-03-15T21:11:39.000Z",
+    "player": "unknown",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-03-15T21:32:00.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 received 3 troops for 11 territories.",
+    "timestamp": "2016-03-15T21:32:00.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Bielaruś.",
+    "timestamp": "2016-03-15T21:32:00.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 received 12 troops for turning in cards Podlaskie, Latgale, and Rakvere.",
+    "timestamp": "2016-03-15T21:32:03.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Brandenburg (tanleach1001) was reinforced by tanleach1001 with 18 troops.",
+    "timestamp": "2016-03-15T21:32:10.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Brandenburg (tanleach1001) attacked Mecklenburg-Vorpommern (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T21:32:13.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Brandenburg (tanleach1001) occupied Mecklenburg-Vorpommern with 23 troops.",
+    "timestamp": "2016-03-15T21:32:15.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Mecklenburg-Vorpommern (tanleach1001) attacked Szczecin (ryanbmilbourne) conquering it, killing 12, losing 18.",
+    "timestamp": "2016-03-15T21:32:42.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Mecklenburg-Vorpommern (tanleach1001) occupied Szczecin with 4 troops.",
+    "timestamp": "2016-03-15T21:32:47.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Szczecin (tanleach1001) attacked Bornholm (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T21:32:50.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Szczecin (tanleach1001) occupied Bornholm with 3 troops.",
+    "timestamp": "2016-03-15T21:32:52.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "Podlaskie (jobratt) was fortified from Hrozna (tanleach1001) with 7 troops.",
+    "timestamp": "2016-03-15T21:33:54.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-03-15T21:33:54.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-03-15T21:33:54.000Z",
+    "player": "tanleach1001",
+    "round": 9
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-03-15T22:07:37.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren received 3 troops for 7 territories.",
+    "timestamp": "2016-03-15T22:07:37.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Östergötland (kwren) was reinforced by kwren with 3 troops.",
+    "timestamp": "2016-03-15T22:07:41.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-03-15T22:07:50.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-03-15T22:08:06.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier received 5 troops for 17 territories.",
+    "timestamp": "2016-03-15T22:08:06.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Eesti.",
+    "timestamp": "2016-03-15T22:08:06.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier received 5 troops for holding Latvija/Lietuva.",
+    "timestamp": "2016-03-15T22:08:06.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Latgale (mmacfreier) was reinforced by mmacfreier with 3 troops.",
+    "timestamp": "2016-03-15T22:08:27.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Suvalkija (mmacfreier) was reinforced by mmacfreier with 11 troops.",
+    "timestamp": "2016-03-15T22:08:30.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Suvalkija (mmacfreier) attacked Podlaskie (jobratt) killing 2, losing 8.",
+    "timestamp": "2016-03-15T22:08:39.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Dzūkija (mmacfreier) attacked Podlaskie (jobratt) killing 7, losing 5.",
+    "timestamp": "2016-03-15T22:08:51.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Suvalkija (mmacfreier) attacked Podlaskie (jobratt) conquering it, killing 6, losing 2.",
+    "timestamp": "2016-03-15T22:09:01.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Suvalkija (mmacfreier) occupied Podlaskie with 1 troop.",
+    "timestamp": "2016-03-15T22:09:14.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Suvalkija (mmacfreier) attacked Kaliningrad (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T22:09:20.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Suvalkija (mmacfreier) occupied Kaliningrad with 1 troop.",
+    "timestamp": "2016-03-15T22:09:23.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "Dzūkija (mmacfreier) was fortified from Suvalkija (mmacfreier) with 3 troops.",
+    "timestamp": "2016-03-15T22:10:00.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-03-15T22:10:00.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-03-15T22:10:00.000Z",
+    "player": "mmacfreier",
+    "round": 9
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-03-15T22:14:04.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "jobratt received 3 troops for 10 territories.",
+    "timestamp": "2016-03-15T22:14:04.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Sjælland (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-03-15T22:14:08.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Sjælland (jobratt) attacked København (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-15T22:14:23.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Sjælland (jobratt) occupied København with 2 troops.",
+    "timestamp": "2016-03-15T22:14:28.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Mazurskie (jobratt) attacked Podlaskie (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-15T22:15:25.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "Mazurskie (jobratt) occupied Podlaskie with 7 troops.",
+    "timestamp": "2016-03-15T22:16:06.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "København (jobratt) was fortified from Podlaskie (jobratt) with 6 troops.",
+    "timestamp": "2016-03-15T22:17:28.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-03-15T22:17:29.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-03-15T22:17:29.000Z",
+    "player": "jobratt",
+    "round": 9
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-03-15T22:37:28.000Z",
+    "player": "gcochard",
+    "round": 9
+  },
+  {
+    "message": "gcochard received 4 troops for 14 territories.",
+    "timestamp": "2016-03-15T22:37:28.000Z",
+    "player": "gcochard",
+    "round": 9
+  },
+  {
+    "message": "gcochard received 3 troops for holding Norge.",
+    "timestamp": "2016-03-15T22:37:28.000Z",
+    "player": "gcochard",
+    "round": 9
+  },
+  {
+    "message": "gcochard received 4 troops for holding Svealand.",
+    "timestamp": "2016-03-15T22:37:28.000Z",
+    "player": "gcochard",
+    "round": 9
+  },
+  {
+    "message": "Stockholm (gcochard) was reinforced by gcochard with 8 troops.",
+    "timestamp": "2016-03-15T22:37:48.000Z",
+    "player": "gcochard",
+    "round": 9
+  },
+  {
+    "message": "Östergötland (kwren) was reinforced by gcochard with 3 troops.",
+    "timestamp": "2016-03-15T22:38:03.000Z",
+    "player": "kwren",
+    "round": 9
+  },
+  {
+    "message": "Stockholm (gcochard) attacked Åland (ryanbmilbourne) conquering it, killing 14, losing 7.",
+    "timestamp": "2016-03-15T22:38:36.000Z",
+    "player": "gcochard",
+    "round": 9
+  },
+  {
+    "message": "Stockholm (gcochard) occupied Åland with 1 troop.",
+    "timestamp": "2016-03-15T22:39:45.000Z",
+    "player": "gcochard",
+    "round": 9
+  },
+  {
+    "message": "Stockholm (gcochard) was fortified from Örebro (gcochard) with 4 troops.",
+    "timestamp": "2016-03-15T22:40:30.000Z",
+    "player": "gcochard",
+    "round": 9
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-03-15T22:40:30.000Z",
+    "player": "gcochard",
+    "round": 9
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-03-15T22:40:30.000Z",
+    "player": "gcochard",
+    "round": 9
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-03-16T00:16:01.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "ryanbmilbourne received 4 troops for 13 territories.",
+    "timestamp": "2016-03-16T00:16:01.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "ryanbmilbourne received 4 troops for holding Rossiya.",
+    "timestamp": "2016-03-16T00:16:01.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "Turku (ryanbmilbourne) was reinforced by ryanbmilbourne with 8 troops.",
+    "timestamp": "2016-03-16T00:16:09.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "Turku (ryanbmilbourne) attacked Åland (gcochard) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-03-16T00:16:15.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "Turku (ryanbmilbourne) occupied Åland with 6 troops.",
+    "timestamp": "2016-03-16T00:16:29.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-03-16T00:16:55.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-03-16T00:16:55.000Z",
+    "player": "ryanbmilbourne",
+    "round": 9
+  },
+  {
+    "message": "Round 10 started.",
+    "timestamp": "2016-03-16T00:16:55.000Z",
+    "player": "unknown",
+    "round": 10
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-03-16T02:18:15.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "tanleach1001 received 4 troops for 14 territories.",
+    "timestamp": "2016-03-16T02:18:15.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Deutschland.",
+    "timestamp": "2016-03-16T02:18:15.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Bielaruś.",
+    "timestamp": "2016-03-16T02:18:15.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Hrozna (tanleach1001) was reinforced by tanleach1001 with 10 troops.",
+    "timestamp": "2016-03-16T02:18:28.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Bornholm (tanleach1001) attacked Skåne (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-16T02:18:32.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Bornholm (tanleach1001) occupied Skåne with 2 troops.",
+    "timestamp": "2016-03-16T02:18:39.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Skåne (tanleach1001) attacked Halland (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-16T02:18:42.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Hrozna (tanleach1001) attacked Podlaskie (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-16T02:18:48.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Hrozna (tanleach1001) occupied Podlaskie with 10 troops.",
+    "timestamp": "2016-03-16T02:18:51.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Podlaskie (tanleach1001) attacked Suvalkija (mmacfreier) conquering it, killing 6, losing 5.",
+    "timestamp": "2016-03-16T02:19:05.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Podlaskie (tanleach1001) occupied Suvalkija with 1 troop.",
+    "timestamp": "2016-03-16T02:19:13.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Podlaskie (tanleach1001) attacked Sovetsk (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-16T02:19:17.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Podlaskie (tanleach1001) occupied Sovetsk with 1 troop.",
+    "timestamp": "2016-03-16T02:19:27.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "Podlaskie (tanleach1001) was fortified from Vitebsk (tanleach1001) with 7 troops.",
+    "timestamp": "2016-03-16T02:19:37.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-03-16T02:19:37.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-03-16T02:19:37.000Z",
+    "player": "tanleach1001",
+    "round": 10
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-03-16T02:20:00.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "kwren received 3 troops for 6 territories.",
+    "timestamp": "2016-03-16T02:20:00.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Gotland (kwren) was reinforced by kwren with 3 troops.",
+    "timestamp": "2016-03-16T02:20:05.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Gotland (kwren) attacked Kaliningrad (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-16T02:20:11.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Gotland (kwren) occupied Kaliningrad with 1 troop.",
+    "timestamp": "2016-03-16T02:20:16.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Stockholm (gcochard) was fortified from Gotland (kwren) with 1 troop.",
+    "timestamp": "2016-03-16T02:20:24.000Z",
+    "player": "gcochard",
+    "round": 10
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-03-16T02:20:24.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-03-16T02:20:24.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-03-16T16:10:58.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received 5 troops for 15 territories.",
+    "timestamp": "2016-03-16T16:10:58.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Eesti.",
+    "timestamp": "2016-03-16T16:10:58.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Dzūkija (mmacfreier) was reinforced by mmacfreier with 9 troops.",
+    "timestamp": "2016-03-16T16:11:16.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Dzūkija (mmacfreier) attacked Podlaskie (tanleach1001) conquering it, killing 10, losing 8.",
+    "timestamp": "2016-03-16T16:11:29.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Dzūkija (mmacfreier) occupied Podlaskie with 1 troop.",
+    "timestamp": "2016-03-16T16:11:35.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Dzūkija (mmacfreier) attacked Suvalkija (tanleach1001) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-03-16T16:11:42.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Dzūkija (mmacfreier) occupied Suvalkija with 4 troops.",
+    "timestamp": "2016-03-16T16:11:59.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "Åland (ryanbmilbourne) was fortified from Latgale (mmacfreier) with 8 troops.",
+    "timestamp": "2016-03-16T16:12:10.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-03-16T16:12:10.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-03-16T16:12:10.000Z",
+    "player": "mmacfreier",
+    "round": 10
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-03-16T16:15:19.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "jobratt received 3 troops for 11 territories.",
+    "timestamp": "2016-03-16T16:15:19.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "jobratt received 3 troops for holding Danmark.",
+    "timestamp": "2016-03-16T16:15:19.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "København (jobratt) was reinforced by jobratt with 6 troops.",
+    "timestamp": "2016-03-16T16:17:00.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "København (jobratt) attacked Skåne (tanleach1001) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-03-16T16:17:10.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "København (jobratt) occupied Skåne with 11 troops.",
+    "timestamp": "2016-03-16T16:17:11.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Skåne (jobratt) attacked Bornholm (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-16T16:17:15.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "Skåne (jobratt) occupied Bornholm with 1 troop.",
+    "timestamp": "2016-03-16T16:17:24.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-03-16T16:17:53.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-03-16T16:17:53.000Z",
+    "player": "jobratt",
+    "round": 10
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-03-16T18:48:18.000Z",
+    "player": "gcochard",
+    "round": 10
+  },
+  {
+    "message": "gcochard received 4 troops for 14 territories.",
+    "timestamp": "2016-03-16T18:48:18.000Z",
+    "player": "gcochard",
+    "round": 10
+  },
+  {
+    "message": "gcochard received 3 troops for holding Norge.",
+    "timestamp": "2016-03-16T18:48:18.000Z",
+    "player": "gcochard",
+    "round": 10
+  },
+  {
+    "message": "gcochard received 4 troops for holding Svealand.",
+    "timestamp": "2016-03-16T18:48:18.000Z",
+    "player": "gcochard",
+    "round": 10
+  },
+  {
+    "message": "Östergötland (kwren) was reinforced by gcochard with 2 troops.",
+    "timestamp": "2016-03-16T18:50:03.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "Oslo (gcochard) was reinforced by gcochard with 5 troops.",
+    "timestamp": "2016-03-16T18:50:16.000Z",
+    "player": "gcochard",
+    "round": 10
+  },
+  {
+    "message": "Stockholm (gcochard) was reinforced by gcochard with 4 troops.",
+    "timestamp": "2016-03-16T18:50:26.000Z",
+    "player": "gcochard",
+    "round": 10
+  },
+  {
+    "message": "Stockholm (gcochard) attacked Åland (ryanbmilbourne) killing 5, losing 3.",
+    "timestamp": "2016-03-16T18:51:26.000Z",
+    "player": "gcochard",
+    "round": 10
+  },
+  {
+    "message": "Oslo (gcochard) attacked Västra Götaland (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-03-16T18:52:30.000Z",
+    "player": "gcochard",
+    "round": 10
+  },
+  {
+    "message": "Oslo (gcochard) occupied Västra Götaland with 1 troop.",
+    "timestamp": "2016-03-16T18:52:34.000Z",
+    "player": "gcochard",
+    "round": 10
+  },
+  {
+    "message": "Östergötland (kwren) was fortified from Oslo (gcochard) with 1 troop.",
+    "timestamp": "2016-03-16T18:53:23.000Z",
+    "player": "kwren",
+    "round": 10
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-03-16T18:53:23.000Z",
+    "player": "gcochard",
+    "round": 10
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-03-16T18:53:23.000Z",
+    "player": "gcochard",
+    "round": 10
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-03-16T19:08:38.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "ryanbmilbourne received 4 troops for 12 territories.",
+    "timestamp": "2016-03-16T19:08:38.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for holding Suomi.",
+    "timestamp": "2016-03-16T19:08:38.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "ryanbmilbourne received 4 troops for holding Rossiya.",
+    "timestamp": "2016-03-16T19:08:38.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "Åland (ryanbmilbourne) was reinforced by ryanbmilbourne with 11 troops.",
+    "timestamp": "2016-03-16T19:09:04.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "Åland (ryanbmilbourne) attacked Stockholm (gcochard) killing 1, losing 5.",
+    "timestamp": "2016-03-16T19:09:13.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-03-16T19:09:23.000Z",
+    "player": "ryanbmilbourne",
+    "round": 10
+  },
+  {
+    "message": "Round 11 started.",
+    "timestamp": "2016-03-16T19:09:23.000Z",
+    "player": "unknown",
+    "round": 11
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-03-16T19:11:01.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "tanleach1001 received 5 troops for 15 territories.",
+    "timestamp": "2016-03-16T19:11:01.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Deutschland.",
+    "timestamp": "2016-03-16T19:11:01.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Bielaruś.",
+    "timestamp": "2016-03-16T19:11:01.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "Sovetsk (tanleach1001) was reinforced by tanleach1001 with 11 troops.",
+    "timestamp": "2016-03-16T19:11:03.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "Sovetsk (tanleach1001) attacked Suvalkija (mmacfreier) conquering it, killing 4, losing 2.",
+    "timestamp": "2016-03-16T19:11:10.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "Sovetsk (tanleach1001) occupied Suvalkija with 1 troop.",
+    "timestamp": "2016-03-16T19:11:15.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "Sovetsk (tanleach1001) attacked Kaliningrad (kwren) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-03-16T19:11:32.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "Sovetsk (tanleach1001) occupied Kaliningrad with 3 troops.",
+    "timestamp": "2016-03-16T19:11:51.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "Suvalkija (tanleach1001) was fortified from Schleswig-Holstein (tanleach1001) with 2 troops.",
+    "timestamp": "2016-03-16T19:12:39.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-03-16T19:12:39.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-03-16T19:12:39.000Z",
+    "player": "tanleach1001",
+    "round": 11
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-03-16T19:27:37.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "kwren received 3 troops for 5 territories.",
+    "timestamp": "2016-03-16T19:27:37.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Jönköping (kwren) was reinforced by kwren with 3 troops.",
+    "timestamp": "2016-03-16T19:27:40.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Jönköping (kwren) attacked Halland (tanleach1001) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-16T19:27:50.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Jönköping (kwren) occupied Halland with 1 troop.",
+    "timestamp": "2016-03-16T19:27:53.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "Oslo (gcochard) was fortified from Jönköping (kwren) with 1 troop.",
+    "timestamp": "2016-03-16T19:27:59.000Z",
+    "player": "gcochard",
+    "round": 11
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-03-16T19:27:59.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-03-16T19:27:59.000Z",
+    "player": "kwren",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-03-16T19:40:11.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 5 troops for 16 territories.",
+    "timestamp": "2016-03-16T19:40:11.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Eesti.",
+    "timestamp": "2016-03-16T19:40:11.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received 12 troops for turning in cards Jotunheimen, Nordjylland, and Szczecin.",
+    "timestamp": "2016-03-16T19:40:29.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Latgale (mmacfreier) was reinforced by mmacfreier with 1 troop.",
+    "timestamp": "2016-03-16T19:40:48.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Dzūkija (mmacfreier) was reinforced by mmacfreier with 20 troops.",
+    "timestamp": "2016-03-16T19:40:50.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Dzūkija (mmacfreier) attacked Suvalkija (tanleach1001) conquering it, killing 3, losing 4.",
+    "timestamp": "2016-03-16T19:40:58.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Dzūkija (mmacfreier) occupied Suvalkija with 14 troops.",
+    "timestamp": "2016-03-16T19:41:05.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Suvalkija (mmacfreier) attacked Sovetsk (tanleach1001) conquering it, killing 4, losing 2.",
+    "timestamp": "2016-03-16T19:41:10.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Suvalkija (mmacfreier) occupied Sovetsk with 11 troops.",
+    "timestamp": "2016-03-16T19:41:12.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Sovetsk (mmacfreier) attacked Kaliningrad (tanleach1001) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-03-16T19:41:18.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Sovetsk (mmacfreier) occupied Kaliningrad with 4 troops.",
+    "timestamp": "2016-03-16T19:41:36.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "Suvalkija (mmacfreier) was fortified from Saaremaa (mmacfreier) with 4 troops.",
+    "timestamp": "2016-03-16T19:42:02.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-03-16T19:42:02.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-03-16T19:42:02.000Z",
+    "player": "mmacfreier",
+    "round": 11
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-03-16T23:41:59.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "jobratt received 4 troops for 13 territories.",
+    "timestamp": "2016-03-16T23:41:59.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "jobratt received 3 troops for holding Danmark.",
+    "timestamp": "2016-03-16T23:41:59.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "jobratt received 1 troop for holding Danmark+Bornholm.",
+    "timestamp": "2016-03-16T23:41:59.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Mazurskie (jobratt) was reinforced by jobratt with 8 troops.",
+    "timestamp": "2016-03-16T23:42:22.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Mazurskie (jobratt) attacked Podlaskie (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-16T23:42:27.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Mazurskie (jobratt) occupied Podlaskie with 8 troops.",
+    "timestamp": "2016-03-16T23:42:47.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "Podlaskie (jobratt) attacked Suvalkija (mmacfreier) killing 3, losing 7.",
+    "timestamp": "2016-03-16T23:43:06.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-03-16T23:45:26.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-03-16T23:45:26.000Z",
+    "player": "jobratt",
+    "round": 11
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-03-17T14:41:15.000Z",
+    "player": "gcochard",
+    "round": 11
+  },
+  {
+    "message": "gcochard received 5 troops for 15 territories.",
+    "timestamp": "2016-03-17T14:41:15.000Z",
+    "player": "gcochard",
+    "round": 11
+  },
+  {
+    "message": "gcochard received 3 troops for holding Norge.",
+    "timestamp": "2016-03-17T14:41:15.000Z",
+    "player": "gcochard",
+    "round": 11
+  },
+  {
+    "message": "gcochard received 4 troops for holding Svealand.",
+    "timestamp": "2016-03-17T14:41:15.000Z",
+    "player": "gcochard",
+    "round": 11
+  },
+  {
+    "message": "gcochard received 12 troops for turning in cards Midtjylland, Haapsalu, and Gotland.",
+    "timestamp": "2016-03-17T14:41:29.000Z",
+    "player": "gcochard",
+    "round": 11
+  },
+  {
+    "message": "Oslo (gcochard) was reinforced by gcochard with 7 troops.",
+    "timestamp": "2016-03-17T14:42:01.000Z",
+    "player": "gcochard",
+    "round": 11
+  },
+  {
+    "message": "Stockholm (gcochard) was reinforced by gcochard with 17 troops.",
+    "timestamp": "2016-03-17T14:42:48.000Z",
+    "player": "gcochard",
+    "round": 11
+  },
+  {
+    "message": "Stockholm (gcochard) attacked Åland (ryanbmilbourne) conquering it, killing 15, losing 20.",
+    "timestamp": "2016-03-17T14:43:12.000Z",
+    "player": "gcochard",
+    "round": 11
+  },
+  {
+    "message": "Stockholm (gcochard) occupied Åland with 1 troop.",
+    "timestamp": "2016-03-17T14:43:17.000Z",
+    "player": "gcochard",
+    "round": 11
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-03-17T14:43:52.000Z",
+    "player": "gcochard",
+    "round": 11
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-03-17T14:43:52.000Z",
+    "player": "gcochard",
+    "round": 11
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-03-17T16:08:57.000Z",
+    "player": "ryanbmilbourne",
+    "round": 11
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 11 territories.",
+    "timestamp": "2016-03-17T16:08:57.000Z",
+    "player": "ryanbmilbourne",
+    "round": 11
+  },
+  {
+    "message": "ryanbmilbourne received 4 troops for holding Rossiya.",
+    "timestamp": "2016-03-17T16:08:57.000Z",
+    "player": "ryanbmilbourne",
+    "round": 11
+  },
+  {
+    "message": "Turku (ryanbmilbourne) was reinforced by ryanbmilbourne with 7 troops.",
+    "timestamp": "2016-03-17T16:09:02.000Z",
+    "player": "ryanbmilbourne",
+    "round": 11
+  },
+  {
+    "message": "Turku (ryanbmilbourne) attacked Åland (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-17T16:09:06.000Z",
+    "player": "ryanbmilbourne",
+    "round": 11
+  },
+  {
+    "message": "Turku (ryanbmilbourne) occupied Åland with 7 troops.",
+    "timestamp": "2016-03-17T16:09:07.000Z",
+    "player": "ryanbmilbourne",
+    "round": 11
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-03-17T16:09:19.000Z",
+    "player": "ryanbmilbourne",
+    "round": 11
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-03-17T16:09:19.000Z",
+    "player": "ryanbmilbourne",
+    "round": 11
+  },
+  {
+    "message": "Round 12 started.",
+    "timestamp": "2016-03-17T16:09:19.000Z",
+    "player": "unknown",
+    "round": 12
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-03-17T16:09:40.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "tanleach1001 received 4 troops for 13 territories.",
+    "timestamp": "2016-03-17T16:09:40.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Deutschland.",
+    "timestamp": "2016-03-17T16:09:40.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Bielaruś.",
+    "timestamp": "2016-03-17T16:09:40.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "tanleach1001 received 2 troops on Mecklenburg-Vorpommern",
+    "timestamp": "2016-03-17T16:09:44.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "tanleach1001 received 12 troops for turning in cards Mecklenburg-Vorpommern, Žemaitija, and Velikiye Luki.",
+    "timestamp": "2016-03-17T16:09:44.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "Hrozna (tanleach1001) was reinforced by tanleach1001 with 22 troops.",
+    "timestamp": "2016-03-17T16:09:54.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "Hrozna (tanleach1001) attacked Podlaskie (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-17T16:09:57.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "Hrozna (tanleach1001) occupied Podlaskie with 22 troops.",
+    "timestamp": "2016-03-17T16:10:00.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "Podlaskie (tanleach1001) attacked Suvalkija (mmacfreier) conquering it, killing 2, losing 0.",
+    "timestamp": "2016-03-17T16:10:03.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "Podlaskie (tanleach1001) occupied Suvalkija with 21 troops.",
+    "timestamp": "2016-03-17T16:10:33.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "Suvalkija (tanleach1001) attacked Kaliningrad (mmacfreier) killing 1, losing 9.",
+    "timestamp": "2016-03-17T16:11:22.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "Suvalkija (tanleach1001) attacked Aukštaitija (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-17T16:13:24.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "Suvalkija (tanleach1001) occupied Aukštaitija with 1 troop.",
+    "timestamp": "2016-03-17T16:13:29.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "Suvalkija (tanleach1001) attacked Žemaitija (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-17T16:13:33.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "Suvalkija (tanleach1001) occupied Žemaitija with 1 troop.",
+    "timestamp": "2016-03-17T16:13:44.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "Mazurskie (jobratt) was fortified from Mecklenburg-Vorpommern (tanleach1001) with 2 troops.",
+    "timestamp": "2016-03-17T16:14:29.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-03-17T16:14:29.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-03-17T16:14:29.000Z",
+    "player": "tanleach1001",
+    "round": 12
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-03-17T18:37:43.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "kwren received 3 troops for 6 territories.",
+    "timestamp": "2016-03-17T18:37:43.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "kwren received 12 troops for turning in cards Sørlandet, Suvalkija, and Gävleborg.",
+    "timestamp": "2016-03-17T18:37:47.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Gotland (kwren) was reinforced by kwren with 15 troops.",
+    "timestamp": "2016-03-17T18:37:50.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Gotland (kwren) attacked Saaremaa (mmacfreier) conquering it, killing 8, losing 9.",
+    "timestamp": "2016-03-17T18:38:03.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Gotland (kwren) occupied Saaremaa with 1 troop.",
+    "timestamp": "2016-03-17T18:38:07.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "Stockholm (gcochard) was fortified from Gotland (kwren) with 5 troops.",
+    "timestamp": "2016-03-17T18:38:29.000Z",
+    "player": "gcochard",
+    "round": 12
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-03-17T18:38:29.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-03-17T18:38:29.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-03-17T19:58:54.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "mmacfreier received 4 troops for 14 territories.",
+    "timestamp": "2016-03-17T19:58:54.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "mmacfreier received 1 troop for holding Kaliningrad Oblast.",
+    "timestamp": "2016-03-17T19:58:54.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Hiiumaa (mmacfreier) was reinforced by mmacfreier with 5 troops.",
+    "timestamp": "2016-03-17T19:59:04.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Hiiumaa (mmacfreier) attacked Saaremaa (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-17T19:59:07.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Hiiumaa (mmacfreier) occupied Saaremaa with 5 troops.",
+    "timestamp": "2016-03-17T19:59:09.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "Dzūkija (mmacfreier) was fortified from Latgale (mmacfreier) with 6 troops.",
+    "timestamp": "2016-03-17T19:59:29.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-03-17T19:59:29.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-03-17T19:59:29.000Z",
+    "player": "mmacfreier",
+    "round": 12
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-03-17T20:27:56.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "jobratt received 4 troops for 13 territories.",
+    "timestamp": "2016-03-17T20:27:57.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "jobratt received 3 troops for holding Danmark.",
+    "timestamp": "2016-03-17T20:27:57.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "jobratt received 1 troop for holding Danmark+Bornholm.",
+    "timestamp": "2016-03-17T20:27:57.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "jobratt received 2 troops on Skåne",
+    "timestamp": "2016-03-17T20:28:02.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "jobratt received 12 troops for turning in cards Södermanland, Västra Götaland, and Skåne.",
+    "timestamp": "2016-03-17T20:28:02.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Pomorskie (jobratt) was reinforced by jobratt with 4 troops.",
+    "timestamp": "2016-03-17T20:28:23.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Mazurskie (jobratt) was reinforced by jobratt with 16 troops.",
+    "timestamp": "2016-03-17T20:28:27.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Pomorskie (jobratt) attacked Szczecin (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-17T20:28:31.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Pomorskie (jobratt) occupied Szczecin with 1 troop.",
+    "timestamp": "2016-03-17T20:28:37.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Mazurskie (jobratt) attacked Kaliningrad (mmacfreier) conquering it, killing 3, losing 1.",
+    "timestamp": "2016-03-17T20:28:43.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Mazurskie (jobratt) occupied Kaliningrad with 1 troop.",
+    "timestamp": "2016-03-17T20:29:50.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Mazurskie (jobratt) attacked Podlaskie (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-17T20:29:56.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Mazurskie (jobratt) occupied Podlaskie with 16 troops.",
+    "timestamp": "2016-03-17T20:29:59.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Podlaskie (jobratt) attacked Sovetsk (mmacfreier) conquering it, killing 5, losing 0.",
+    "timestamp": "2016-03-17T20:30:14.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Podlaskie (jobratt) occupied Sovetsk with 1 troop.",
+    "timestamp": "2016-03-17T20:30:51.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Podlaskie (jobratt) attacked Dzūkija (mmacfreier) killing 9, losing 5.",
+    "timestamp": "2016-03-17T20:31:45.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "Podlaskie (jobratt) was fortified from Pomorskie (jobratt) with 3 troops.",
+    "timestamp": "2016-03-17T20:32:17.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-03-17T20:32:17.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-03-17T20:32:17.000Z",
+    "player": "jobratt",
+    "round": 12
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-03-18T00:37:02.000Z",
+    "player": "gcochard",
+    "round": 12
+  },
+  {
+    "message": "gcochard received 5 troops for 15 territories.",
+    "timestamp": "2016-03-18T00:37:02.000Z",
+    "player": "gcochard",
+    "round": 12
+  },
+  {
+    "message": "gcochard received 3 troops for holding Norge.",
+    "timestamp": "2016-03-18T00:37:02.000Z",
+    "player": "gcochard",
+    "round": 12
+  },
+  {
+    "message": "gcochard received 4 troops for holding Svealand.",
+    "timestamp": "2016-03-18T00:37:02.000Z",
+    "player": "gcochard",
+    "round": 12
+  },
+  {
+    "message": "Oslo (gcochard) was reinforced by gcochard with 6 troops.",
+    "timestamp": "2016-03-18T00:37:23.000Z",
+    "player": "gcochard",
+    "round": 12
+  },
+  {
+    "message": "Stockholm (gcochard) was reinforced by gcochard with 6 troops.",
+    "timestamp": "2016-03-18T00:37:26.000Z",
+    "player": "gcochard",
+    "round": 12
+  },
+  {
+    "message": "Stockholm (gcochard) attacked Åland (ryanbmilbourne) conquering it, killing 7, losing 0.",
+    "timestamp": "2016-03-18T00:37:32.000Z",
+    "player": "gcochard",
+    "round": 12
+  },
+  {
+    "message": "Stockholm (gcochard) occupied Åland with 11 troops.",
+    "timestamp": "2016-03-18T00:41:19.000Z",
+    "player": "gcochard",
+    "round": 12
+  },
+  {
+    "message": "Åland (gcochard) attacked Saaremaa (mmacfreier) conquering it, killing 5, losing 7.",
+    "timestamp": "2016-03-18T00:41:41.000Z",
+    "player": "gcochard",
+    "round": 12
+  },
+  {
+    "message": "Åland (gcochard) occupied Saaremaa with 3 troops.",
+    "timestamp": "2016-03-18T00:41:45.000Z",
+    "player": "gcochard",
+    "round": 12
+  },
+  {
+    "message": "Östergötland (kwren) was fortified from Saaremaa (gcochard) with 2 troops.",
+    "timestamp": "2016-03-18T00:44:23.000Z",
+    "player": "kwren",
+    "round": 12
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-03-18T00:44:23.000Z",
+    "player": "gcochard",
+    "round": 12
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-03-18T00:44:23.000Z",
+    "player": "gcochard",
+    "round": 12
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-03-18T00:44:33.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 11 territories.",
+    "timestamp": "2016-03-18T00:44:33.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "ryanbmilbourne received 4 troops for holding Rossiya.",
+    "timestamp": "2016-03-18T00:44:33.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "ryanbmilbourne received 2 troops on Turku",
+    "timestamp": "2016-03-18T00:44:36.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "ryanbmilbourne received 12 troops for turning in cards Borisov, Aukštaitija, and Turku.",
+    "timestamp": "2016-03-18T00:44:36.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "Turku (ryanbmilbourne) was reinforced by ryanbmilbourne with 19 troops.",
+    "timestamp": "2016-03-18T00:44:39.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "Turku (ryanbmilbourne) attacked Åland (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-18T00:44:43.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "Turku (ryanbmilbourne) occupied Åland with 20 troops.",
+    "timestamp": "2016-03-18T00:44:44.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "Åland (ryanbmilbourne) attacked Saaremaa (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-18T00:44:48.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "Åland (ryanbmilbourne) occupied Saaremaa with 1 troop.",
+    "timestamp": "2016-03-18T00:44:52.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "Åland (ryanbmilbourne) attacked Stockholm (gcochard) conquering it, killing 16, losing 7.",
+    "timestamp": "2016-03-18T00:45:05.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "Åland (ryanbmilbourne) occupied Stockholm with 11 troops.",
+    "timestamp": "2016-03-18T00:45:07.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "Stockholm (ryanbmilbourne) attacked Södermanland (gcochard) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-03-18T00:45:11.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "Stockholm (ryanbmilbourne) occupied Södermanland with 8 troops.",
+    "timestamp": "2016-03-18T00:45:14.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "Södermanland (ryanbmilbourne) attacked Örebro (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-18T00:45:20.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "Södermanland (ryanbmilbourne) occupied Örebro with 1 troop.",
+    "timestamp": "2016-03-18T00:45:28.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "Åland (ryanbmilbourne) was fortified from Södermanland (ryanbmilbourne) with 5 troops.",
+    "timestamp": "2016-03-18T00:45:34.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-03-18T00:45:34.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-03-18T00:45:34.000Z",
+    "player": "ryanbmilbourne",
+    "round": 12
+  },
+  {
+    "message": "Round 13 started.",
+    "timestamp": "2016-03-18T00:45:34.000Z",
+    "player": "unknown",
+    "round": 13
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-03-18T01:01:53.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "tanleach1001 received 5 troops for 15 territories.",
+    "timestamp": "2016-03-18T01:01:53.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Deutschland.",
+    "timestamp": "2016-03-18T01:01:53.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Bielaruś.",
+    "timestamp": "2016-03-18T01:01:53.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "Aukštaitija (tanleach1001) was reinforced by tanleach1001 with 11 troops.",
+    "timestamp": "2016-03-18T01:01:57.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "Aukštaitija (tanleach1001) attacked Zemgale (mmacfreier) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-03-18T01:02:07.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "Aukštaitija (tanleach1001) occupied Zemgale with 9 troops.",
+    "timestamp": "2016-03-18T01:02:17.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "Zemgale (tanleach1001) attacked Latgale (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-18T01:02:22.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "Zemgale (tanleach1001) occupied Latgale with 6 troops.",
+    "timestamp": "2016-03-18T01:03:11.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "Suvalkija (tanleach1001) attacked Dzūkija (mmacfreier) killing 2, losing 0.",
+    "timestamp": "2016-03-18T01:03:16.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "Zemgale (tanleach1001) attacked Vidzeme (mmacfreier) killing 0, losing 1.",
+    "timestamp": "2016-03-18T01:05:29.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "Latgale (tanleach1001) attacked Vidzeme (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-18T01:05:34.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "Latgale (tanleach1001) occupied Vidzeme with 1 troop.",
+    "timestamp": "2016-03-18T01:05:38.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "Aukštaitija (tanleach1001) was fortified from Suvalkija (tanleach1001) with 2 troops.",
+    "timestamp": "2016-03-18T01:06:01.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-03-18T01:06:01.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-03-18T01:06:01.000Z",
+    "player": "tanleach1001",
+    "round": 13
+  },
+  {
+    "message": "kwren started the turn.",
+    "timestamp": "2016-03-18T01:06:17.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "kwren received 3 troops for 6 territories.",
+    "timestamp": "2016-03-18T01:06:17.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Östergötland (kwren) was reinforced by kwren with 3 troops.",
+    "timestamp": "2016-03-18T01:06:20.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Östergötland (kwren) attacked Södermanland (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-18T01:06:23.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Östergötland (kwren) occupied Södermanland with 14 troops.",
+    "timestamp": "2016-03-18T01:06:24.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Södermanland (kwren) attacked Örebro (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-18T01:06:30.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Södermanland (kwren) occupied Örebro with 1 troop.",
+    "timestamp": "2016-03-18T01:06:34.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Södermanland (kwren) attacked Stockholm (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-18T01:06:38.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Södermanland (kwren) occupied Stockholm with 10 troops.",
+    "timestamp": "2016-03-18T01:07:07.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Stockholm (kwren) attacked Åland (ryanbmilbourne) killing 4, losing 9.",
+    "timestamp": "2016-03-18T01:07:16.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "kwren received a card.",
+    "timestamp": "2016-03-18T01:07:23.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "kwren ended the turn.",
+    "timestamp": "2016-03-18T01:07:23.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-03-18T06:31:00.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "mmacfreier received 3 troops for 9 territories.",
+    "timestamp": "2016-03-18T06:31:00.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "mmacfreier received 12 troops for turning in cards Telemark, Niedersachsen, and Värmland.",
+    "timestamp": "2016-03-18T06:31:08.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Pärnumaa (mmacfreier) was reinforced by mmacfreier with 15 troops.",
+    "timestamp": "2016-03-18T06:31:41.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Pärnumaa (mmacfreier) attacked Saaremaa (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-18T06:32:05.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Pärnumaa (mmacfreier) occupied Saaremaa with 15 troops.",
+    "timestamp": "2016-03-18T06:32:07.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Saaremaa (mmacfreier) attacked Gotland (kwren) killing 0, losing 1.",
+    "timestamp": "2016-03-18T06:32:32.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "Åland (ryanbmilbourne) was fortified from Saaremaa (mmacfreier) with 6 troops.",
+    "timestamp": "2016-03-18T06:33:07.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-03-18T06:33:07.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-03-18T06:33:07.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-03-18T16:52:13.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt received 5 troops for 17 territories.",
+    "timestamp": "2016-03-18T16:52:14.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt received 3 troops for holding Danmark.",
+    "timestamp": "2016-03-18T16:52:14.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt received 4 troops for holding Polska.",
+    "timestamp": "2016-03-18T16:52:14.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt received 1 troop for holding Kaliningrad Oblast.",
+    "timestamp": "2016-03-18T16:52:14.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt received 1 troop for holding Danmark+Bornholm.",
+    "timestamp": "2016-03-18T16:52:14.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt received 12 troops for turning in cards Slantsy, St. Petersburg, and Kronoberg.",
+    "timestamp": "2016-03-18T16:52:23.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Kaliningrad (jobratt) was reinforced by jobratt with 26 troops.",
+    "timestamp": "2016-03-18T16:53:02.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Kaliningrad (jobratt) attacked Gotland (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-18T16:53:15.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Kaliningrad (jobratt) occupied Gotland with 25 troops.",
+    "timestamp": "2016-03-18T16:53:25.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Gotland (jobratt) attacked Öland (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-18T16:53:54.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Gotland (jobratt) occupied Öland with 24 troops.",
+    "timestamp": "2016-03-18T16:53:56.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Öland (jobratt) attacked Kalmar (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-18T16:53:59.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Öland (jobratt) occupied Kalmar with 22 troops.",
+    "timestamp": "2016-03-18T16:54:01.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Kalmar (jobratt) attacked Östergötland (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-18T16:54:05.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Kalmar (jobratt) occupied Östergötland with 20 troops.",
+    "timestamp": "2016-03-18T16:54:13.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Östergötland (jobratt) attacked Jönköping (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-18T16:54:22.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Östergötland (jobratt) occupied Jönköping with 11 troops.",
+    "timestamp": "2016-03-18T16:55:17.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Jönköping (jobratt) attacked Kronoberg (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-18T16:56:42.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Jönköping (jobratt) occupied Kronoberg with 1 troop.",
+    "timestamp": "2016-03-18T16:56:53.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Skåne (jobratt) attacked Halland (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-18T16:56:59.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Skåne (jobratt) occupied Halland with 1 troop.",
+    "timestamp": "2016-03-18T16:57:01.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Jönköping (jobratt) attacked Västra Götaland (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-18T16:57:06.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Jönköping (jobratt) occupied Västra Götaland with 9 troops.",
+    "timestamp": "2016-03-18T16:57:13.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "Västra Götaland (jobratt) was fortified from Podlaskie (jobratt) with 9 troops.",
+    "timestamp": "2016-03-18T17:03:36.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-03-18T17:03:36.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-03-18T17:03:36.000Z",
+    "player": "jobratt",
+    "round": 13
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-03-18T20:38:54.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "gcochard received 3 troops for 10 territories.",
+    "timestamp": "2016-03-18T20:38:54.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "gcochard received 3 troops for holding Norge.",
+    "timestamp": "2016-03-18T20:38:54.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "Uppsala (gcochard) was reinforced by gcochard with 6 troops.",
+    "timestamp": "2016-03-18T20:39:06.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "Uppsala (gcochard) attacked Stockholm (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-18T20:39:12.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "Uppsala (gcochard) occupied Stockholm with 5 troops.",
+    "timestamp": "2016-03-18T20:39:19.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "Stockholm (gcochard) attacked Södermanland (kwren) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-18T20:39:25.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "Stockholm (gcochard) occupied Södermanland with 3 troops.",
+    "timestamp": "2016-03-18T20:39:27.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "Södermanland (gcochard) attacked Örebro (kwren) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-18T20:39:33.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "kwren was defeated by gcochard.",
+    "timestamp": "2016-03-18T20:39:33.000Z",
+    "player": "kwren",
+    "round": 13
+  },
+  {
+    "message": "Södermanland (gcochard) occupied Örebro with 2 troops.",
+    "timestamp": "2016-03-18T20:39:41.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "gcochard received 12 troops for turning in cards Lahti, Syddanmark, and Helsinki.",
+    "timestamp": "2016-03-18T20:39:52.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "Oslo (gcochard) was reinforced by gcochard with 12 troops.",
+    "timestamp": "2016-03-18T20:40:02.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "Oslo (gcochard) attacked Västra Götaland (jobratt) conquering it, killing 18, losing 7.",
+    "timestamp": "2016-03-18T20:40:48.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "Oslo (gcochard) occupied Västra Götaland with 20 troops.",
+    "timestamp": "2016-03-18T20:40:52.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "Västra Götaland (gcochard) attacked Jönköping (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-18T20:40:58.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "Västra Götaland (gcochard) occupied Jönköping with 19 troops.",
+    "timestamp": "2016-03-18T20:41:01.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "Jönköping (gcochard) attacked Östergötland (jobratt) conquering it, killing 9, losing 9.",
+    "timestamp": "2016-03-18T20:41:20.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "Jönköping (gcochard) occupied Östergötland with 9 troops.",
+    "timestamp": "2016-03-18T20:41:29.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "Stockholm (gcochard) was fortified from Östergötland (gcochard) with 8 troops.",
+    "timestamp": "2016-03-18T20:42:06.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-03-18T20:42:06.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-03-18T20:42:07.000Z",
+    "player": "gcochard",
+    "round": 13
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-03-18T20:54:54.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "ryanbmilbourne received 4 troops for 12 territories.",
+    "timestamp": "2016-03-18T20:54:54.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for holding Suomi.",
+    "timestamp": "2016-03-18T20:54:54.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "ryanbmilbourne received 4 troops for holding Rossiya.",
+    "timestamp": "2016-03-18T20:54:54.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "Pskov (ryanbmilbourne) was reinforced by ryanbmilbourne with 11 troops.",
+    "timestamp": "2016-03-18T20:55:31.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "Pskov (ryanbmilbourne) attacked Vidzeme (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-18T20:55:34.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "Pskov (ryanbmilbourne) occupied Vidzeme with 11 troops.",
+    "timestamp": "2016-03-18T20:55:36.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "Vidzeme (ryanbmilbourne) attacked Zemgale (tanleach1001) conquering it, killing 2, losing 0.",
+    "timestamp": "2016-03-18T20:55:39.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "Vidzeme (ryanbmilbourne) occupied Zemgale with 1 troop.",
+    "timestamp": "2016-03-18T20:55:58.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "Vidzeme (ryanbmilbourne) attacked Latgale (tanleach1001) conquering it, killing 5, losing 1.",
+    "timestamp": "2016-03-18T20:56:05.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "Vidzeme (ryanbmilbourne) occupied Latgale with 1 troop.",
+    "timestamp": "2016-03-18T20:56:47.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "Riga (mmacfreier) was fortified from Vidzeme (ryanbmilbourne) with 7 troops.",
+    "timestamp": "2016-03-18T20:57:28.000Z",
+    "player": "mmacfreier",
+    "round": 13
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-03-18T20:57:28.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-03-18T20:57:28.000Z",
+    "player": "ryanbmilbourne",
+    "round": 13
+  },
+  {
+    "message": "Round 14 started.",
+    "timestamp": "2016-03-18T20:57:28.000Z",
+    "player": "unknown",
+    "round": 14
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-03-18T21:00:22.000Z",
+    "player": "tanleach1001",
+    "round": 14
+  },
+  {
+    "message": "tanleach1001 received 5 troops for 15 territories.",
+    "timestamp": "2016-03-18T21:00:22.000Z",
+    "player": "tanleach1001",
+    "round": 14
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Deutschland.",
+    "timestamp": "2016-03-18T21:00:22.000Z",
+    "player": "tanleach1001",
+    "round": 14
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Bielaruś.",
+    "timestamp": "2016-03-18T21:00:22.000Z",
+    "player": "tanleach1001",
+    "round": 14
+  },
+  {
+    "message": "Suvalkija (tanleach1001) was reinforced by tanleach1001 with 2 troops.",
+    "timestamp": "2016-03-18T21:00:32.000Z",
+    "player": "tanleach1001",
+    "round": 14
+  },
+  {
+    "message": "Gotland (jobratt) was reinforced by tanleach1001 with 9 troops.",
+    "timestamp": "2016-03-18T21:00:35.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "Suvalkija (tanleach1001) attacked Dzūkija (mmacfreier) conquering it, killing 2, losing 0.",
+    "timestamp": "2016-03-18T21:00:39.000Z",
+    "player": "tanleach1001",
+    "round": 14
+  },
+  {
+    "message": "Suvalkija (tanleach1001) occupied Dzūkija with 1 troop.",
+    "timestamp": "2016-03-18T21:00:48.000Z",
+    "player": "tanleach1001",
+    "round": 14
+  },
+  {
+    "message": "Gotland (jobratt) was fortified from Aukštaitija (tanleach1001) with 2 troops.",
+    "timestamp": "2016-03-18T21:01:28.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-03-18T21:01:30.000Z",
+    "player": "tanleach1001",
+    "round": 14
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-03-18T21:01:30.000Z",
+    "player": "tanleach1001",
+    "round": 14
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-03-18T21:52:29.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "mmacfreier received 3 troops for 9 territories.",
+    "timestamp": "2016-03-18T21:52:29.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Eesti.",
+    "timestamp": "2016-03-18T21:52:29.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Riga (mmacfreier) was reinforced by mmacfreier with 7 troops.",
+    "timestamp": "2016-03-18T21:52:58.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Riga (mmacfreier) attacked Vidzeme (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-18T21:53:03.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Riga (mmacfreier) occupied Vidzeme with 14 troops.",
+    "timestamp": "2016-03-18T21:53:05.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Vidzeme (mmacfreier) attacked Latgale (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-18T21:53:09.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Vidzeme (mmacfreier) occupied Latgale with 13 troops.",
+    "timestamp": "2016-03-18T21:53:12.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Latgale (mmacfreier) attacked Zemgale (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-18T21:53:15.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Latgale (mmacfreier) occupied Zemgale with 12 troops.",
+    "timestamp": "2016-03-18T21:53:18.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Zemgale (mmacfreier) attacked Aukštaitija (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-18T21:53:23.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Zemgale (mmacfreier) occupied Aukštaitija with 11 troops.",
+    "timestamp": "2016-03-18T21:53:28.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Aukštaitija (mmacfreier) attacked Dzūkija (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-18T21:53:40.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Aukštaitija (mmacfreier) occupied Dzūkija with 10 troops.",
+    "timestamp": "2016-03-18T21:53:44.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Dzūkija (mmacfreier) attacked Podlaskie (jobratt) conquering it, killing 4, losing 5.",
+    "timestamp": "2016-03-18T21:54:07.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Dzūkija (mmacfreier) occupied Podlaskie with 4 troops.",
+    "timestamp": "2016-03-18T21:54:17.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Podlaskie (mmacfreier) attacked Sovetsk (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-18T21:54:52.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Podlaskie (mmacfreier) occupied Sovetsk with 3 troops.",
+    "timestamp": "2016-03-18T21:54:58.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "Zemgale (mmacfreier) was fortified from Sovetsk (mmacfreier) with 2 troops.",
+    "timestamp": "2016-03-18T21:55:10.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "mmacfreier received a card.",
+    "timestamp": "2016-03-18T21:55:10.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-03-18T21:55:11.000Z",
+    "player": "mmacfreier",
+    "round": 14
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-03-19T03:48:54.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "jobratt received 6 troops for 20 territories.",
+    "timestamp": "2016-03-19T03:48:54.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "jobratt received 3 troops for holding Danmark.",
+    "timestamp": "2016-03-19T03:48:54.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "jobratt received 1 troop for holding Danmark+Bornholm.",
+    "timestamp": "2016-03-19T03:48:54.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "Mazurskie (jobratt) was reinforced by jobratt with 10 troops.",
+    "timestamp": "2016-03-19T03:50:40.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "Mazurskie (jobratt) attacked Sovetsk (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-19T03:50:44.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "Mazurskie (jobratt) occupied Sovetsk with 1 troop.",
+    "timestamp": "2016-03-19T03:50:48.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "Mazurskie (jobratt) attacked Podlaskie (mmacfreier) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-03-19T03:50:54.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "Mazurskie (jobratt) occupied Podlaskie with 6 troops.",
+    "timestamp": "2016-03-19T03:50:56.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "Nordjylland (jobratt) was fortified from Skåne (jobratt) with 2 troops.",
+    "timestamp": "2016-03-19T03:52:11.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-03-19T03:52:11.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-03-19T03:52:11.000Z",
+    "player": "jobratt",
+    "round": 14
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-03-20T03:07:39.000Z",
+    "player": "gcochard",
+    "round": 14
+  },
+  {
+    "message": "gcochard received 5 troops for 16 territories.",
+    "timestamp": "2016-03-20T03:07:39.000Z",
+    "player": "gcochard",
+    "round": 14
+  },
+  {
+    "message": "gcochard received 3 troops for holding Norge.",
+    "timestamp": "2016-03-20T03:07:39.000Z",
+    "player": "gcochard",
+    "round": 14
+  },
+  {
+    "message": "gcochard received 4 troops for holding Svealand.",
+    "timestamp": "2016-03-20T03:07:39.000Z",
+    "player": "gcochard",
+    "round": 14
+  },
+  {
+    "message": "gcochard received 2 troops on Jönköping",
+    "timestamp": "2016-03-20T03:07:49.000Z",
+    "player": "gcochard",
+    "round": 14
+  },
+  {
+    "message": "gcochard received 12 troops for turning in cards Hrozna, Mahilyow, and Jönköping.",
+    "timestamp": "2016-03-20T03:07:49.000Z",
+    "player": "gcochard",
+    "round": 14
+  },
+  {
+    "message": "Sørlandet (gcochard) was reinforced by gcochard with 8 troops.",
+    "timestamp": "2016-03-20T03:08:05.000Z",
+    "player": "gcochard",
+    "round": 14
+  },
+  {
+    "message": "Stockholm (gcochard) was reinforced by gcochard with 8 troops.",
+    "timestamp": "2016-03-20T03:08:24.000Z",
+    "player": "gcochard",
+    "round": 14
+  },
+  {
+    "message": "Jönköping (gcochard) was reinforced by gcochard with 8 troops.",
+    "timestamp": "2016-03-20T03:08:31.000Z",
+    "player": "gcochard",
+    "round": 14
+  },
+  {
+    "message": "Jönköping (gcochard) attacked Halland (jobratt) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-03-20T03:08:46.000Z",
+    "player": "gcochard",
+    "round": 14
+  },
+  {
+    "message": "Jönköping (gcochard) occupied Halland with 1 troop.",
+    "timestamp": "2016-03-20T03:08:56.000Z",
+    "player": "gcochard",
+    "round": 14
+  },
+  {
+    "message": "Västra Götaland (gcochard) was fortified from Jönköping (gcochard) with 7 troops.",
+    "timestamp": "2016-03-20T03:09:11.000Z",
+    "player": "gcochard",
+    "round": 14
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-03-20T03:09:11.000Z",
+    "player": "gcochard",
+    "round": 14
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-03-20T03:09:11.000Z",
+    "player": "gcochard",
+    "round": 14
+  },
+  {
+    "message": "ryanbmilbourne missed the turn.",
+    "timestamp": "2016-03-21T03:09:12.000Z",
+    "player": "ryanbmilbourne",
+    "round": 14
+  },
+  {
+    "message": "Round 15 started.",
+    "timestamp": "2016-03-21T03:09:12.000Z",
+    "player": "unknown",
+    "round": 15
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-03-21T17:23:25.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "tanleach1001 received 4 troops for 14 territories.",
+    "timestamp": "2016-03-21T17:23:25.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Deutschland.",
+    "timestamp": "2016-03-21T17:23:25.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Bielaruś.",
+    "timestamp": "2016-03-21T17:23:25.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "tanleach1001 received 2 troops on Brest",
+    "timestamp": "2016-03-21T17:23:32.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "tanleach1001 received 12 troops for turning in cards Østlandet, Brest, and Kurzeme.",
+    "timestamp": "2016-03-21T17:23:32.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Podlaskie (jobratt) was reinforced by tanleach1001 with 3 troops.",
+    "timestamp": "2016-03-21T17:23:50.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "Suvalkija (tanleach1001) was reinforced by tanleach1001 with 19 troops.",
+    "timestamp": "2016-03-21T17:23:55.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Suvalkija (tanleach1001) attacked Dzūkija (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T17:23:59.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Suvalkija (tanleach1001) occupied Dzūkija with 27 troops.",
+    "timestamp": "2016-03-21T17:24:04.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Dzūkija (tanleach1001) attacked Latgale (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T17:24:08.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Dzūkija (tanleach1001) occupied Latgale with 26 troops.",
+    "timestamp": "2016-03-21T17:24:45.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Latgale (tanleach1001) attacked Zemgale (mmacfreier) conquering it, killing 3, losing 3.",
+    "timestamp": "2016-03-21T17:24:57.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Latgale (tanleach1001) occupied Zemgale with 22 troops.",
+    "timestamp": "2016-03-21T17:25:05.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Zemgale (tanleach1001) attacked Aukštaitija (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T17:25:10.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Zemgale (tanleach1001) occupied Aukštaitija with 1 troop.",
+    "timestamp": "2016-03-21T17:25:25.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Zemgale (tanleach1001) attacked Kurzeme (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T17:25:31.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Zemgale (tanleach1001) occupied Kurzeme with 1 troop.",
+    "timestamp": "2016-03-21T17:25:39.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Zemgale (tanleach1001) attacked Riga (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-21T17:25:47.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Zemgale (tanleach1001) occupied Riga with 1 troop.",
+    "timestamp": "2016-03-21T17:25:53.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Zemgale (tanleach1001) attacked Vidzeme (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T17:25:57.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Zemgale (tanleach1001) occupied Vidzeme with 17 troops.",
+    "timestamp": "2016-03-21T17:26:04.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Latgale (tanleach1001) was fortified from Vidzeme (tanleach1001) with 6 troops.",
+    "timestamp": "2016-03-21T17:26:53.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-03-21T17:26:53.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-03-21T17:26:53.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-03-21T17:39:55.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "mmacfreier received 3 troops for 7 territories.",
+    "timestamp": "2016-03-21T17:39:55.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Eesti.",
+    "timestamp": "2016-03-21T17:39:55.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "Haapsalu (mmacfreier) was reinforced by mmacfreier with 7 troops.",
+    "timestamp": "2016-03-21T17:42:07.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-03-21T17:42:11.000Z",
+    "player": "mmacfreier",
+    "round": 15
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-03-21T17:49:05.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "jobratt received 7 troops for 21 territories.",
+    "timestamp": "2016-03-21T17:49:05.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "jobratt received 3 troops for holding Danmark.",
+    "timestamp": "2016-03-21T17:49:05.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "jobratt received 4 troops for holding Polska.",
+    "timestamp": "2016-03-21T17:49:05.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "jobratt received 1 troop for holding Kaliningrad Oblast.",
+    "timestamp": "2016-03-21T17:49:05.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "jobratt received 1 troop for holding Danmark+Bornholm.",
+    "timestamp": "2016-03-21T17:49:05.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "Nordjylland (jobratt) was reinforced by jobratt with 12 troops.",
+    "timestamp": "2016-03-21T17:49:31.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "Kalmar (jobratt) was reinforced by jobratt with 3 troops.",
+    "timestamp": "2016-03-21T17:50:02.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "Vidzeme (tanleach1001) was reinforced by jobratt with 1 troop.",
+    "timestamp": "2016-03-21T17:50:20.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "Kalmar (jobratt) attacked Östergötland (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T17:50:24.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "Kalmar (jobratt) occupied Östergötland with 3 troops.",
+    "timestamp": "2016-03-21T17:50:42.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "Latgale (tanleach1001) was fortified from Podlaskie (jobratt) with 8 troops.",
+    "timestamp": "2016-03-21T17:51:18.000Z",
+    "player": "tanleach1001",
+    "round": 15
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-03-21T17:51:19.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-03-21T17:51:19.000Z",
+    "player": "jobratt",
+    "round": 15
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-03-21T17:51:51.000Z",
+    "player": "gcochard",
+    "round": 15
+  },
+  {
+    "message": "gcochard received 5 troops for 16 territories.",
+    "timestamp": "2016-03-21T17:51:52.000Z",
+    "player": "gcochard",
+    "round": 15
+  },
+  {
+    "message": "gcochard received 3 troops for holding Norge.",
+    "timestamp": "2016-03-21T17:51:52.000Z",
+    "player": "gcochard",
+    "round": 15
+  },
+  {
+    "message": "gcochard received 4 troops for holding Svealand.",
+    "timestamp": "2016-03-21T17:51:52.000Z",
+    "player": "gcochard",
+    "round": 15
+  },
+  {
+    "message": "Sørlandet (gcochard) was reinforced by gcochard with 12 troops.",
+    "timestamp": "2016-03-21T17:52:11.000Z",
+    "player": "gcochard",
+    "round": 15
+  },
+  {
+    "message": "Sørlandet (gcochard) attacked Nordjylland (jobratt) conquering it, killing 18, losing 10.",
+    "timestamp": "2016-03-21T17:52:30.000Z",
+    "player": "gcochard",
+    "round": 15
+  },
+  {
+    "message": "Sørlandet (gcochard) occupied Nordjylland with 10 troops.",
+    "timestamp": "2016-03-21T17:52:32.000Z",
+    "player": "gcochard",
+    "round": 15
+  },
+  {
+    "message": "Stockholm (gcochard) attacked Åland (ryanbmilbourne) conquering it, killing 8, losing 9.",
+    "timestamp": "2016-03-21T17:53:22.000Z",
+    "player": "gcochard",
+    "round": 15
+  },
+  {
+    "message": "Stockholm (gcochard) occupied Åland with 1 troop.",
+    "timestamp": "2016-03-21T17:53:26.000Z",
+    "player": "gcochard",
+    "round": 15
+  },
+  {
+    "message": "Södermanland (gcochard) was fortified from Nordjylland (gcochard) with 3 troops.",
+    "timestamp": "2016-03-21T17:53:44.000Z",
+    "player": "gcochard",
+    "round": 15
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-03-21T17:53:44.000Z",
+    "player": "gcochard",
+    "round": 15
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-03-21T17:53:44.000Z",
+    "player": "gcochard",
+    "round": 15
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-03-21T18:09:50.000Z",
+    "player": "ryanbmilbourne",
+    "round": 15
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 11 territories.",
+    "timestamp": "2016-03-21T18:09:50.000Z",
+    "player": "ryanbmilbourne",
+    "round": 15
+  },
+  {
+    "message": "ryanbmilbourne received 4 troops for holding Rossiya.",
+    "timestamp": "2016-03-21T18:09:50.000Z",
+    "player": "ryanbmilbourne",
+    "round": 15
+  },
+  {
+    "message": "ryanbmilbourne received 12 troops for turning in cards Sjælland, Pärnumaa, and Östergötland.",
+    "timestamp": "2016-03-21T18:09:53.000Z",
+    "player": "ryanbmilbourne",
+    "round": 15
+  },
+  {
+    "message": "Turku (ryanbmilbourne) was reinforced by ryanbmilbourne with 19 troops.",
+    "timestamp": "2016-03-21T18:10:00.000Z",
+    "player": "ryanbmilbourne",
+    "round": 15
+  },
+  {
+    "message": "Turku (ryanbmilbourne) attacked Åland (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T18:10:03.000Z",
+    "player": "ryanbmilbourne",
+    "round": 15
+  },
+  {
+    "message": "Turku (ryanbmilbourne) occupied Åland with 19 troops.",
+    "timestamp": "2016-03-21T18:10:04.000Z",
+    "player": "ryanbmilbourne",
+    "round": 15
+  },
+  {
+    "message": "Åland (ryanbmilbourne) attacked Stockholm (gcochard) conquering it, killing 7, losing 4.",
+    "timestamp": "2016-03-21T18:10:17.000Z",
+    "player": "ryanbmilbourne",
+    "round": 15
+  },
+  {
+    "message": "Åland (ryanbmilbourne) occupied Stockholm with 14 troops.",
+    "timestamp": "2016-03-21T18:10:18.000Z",
+    "player": "ryanbmilbourne",
+    "round": 15
+  },
+  {
+    "message": "Stockholm (ryanbmilbourne) attacked Uppsala (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-21T18:10:23.000Z",
+    "player": "ryanbmilbourne",
+    "round": 15
+  },
+  {
+    "message": "Stockholm (ryanbmilbourne) occupied Uppsala with 1 troop.",
+    "timestamp": "2016-03-21T18:10:27.000Z",
+    "player": "ryanbmilbourne",
+    "round": 15
+  },
+  {
+    "message": "Åland (ryanbmilbourne) was fortified from Stockholm (ryanbmilbourne) with 11 troops.",
+    "timestamp": "2016-03-21T18:10:53.000Z",
+    "player": "ryanbmilbourne",
+    "round": 15
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-03-21T18:10:53.000Z",
+    "player": "ryanbmilbourne",
+    "round": 15
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-03-21T18:10:53.000Z",
+    "player": "ryanbmilbourne",
+    "round": 15
+  },
+  {
+    "message": "Round 16 started.",
+    "timestamp": "2016-03-21T18:10:53.000Z",
+    "player": "unknown",
+    "round": 16
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-03-21T19:24:19.000Z",
+    "player": "tanleach1001",
+    "round": 16
+  },
+  {
+    "message": "tanleach1001 received 7 troops for 21 territories.",
+    "timestamp": "2016-03-21T19:24:19.000Z",
+    "player": "tanleach1001",
+    "round": 16
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Deutschland.",
+    "timestamp": "2016-03-21T19:24:19.000Z",
+    "player": "tanleach1001",
+    "round": 16
+  },
+  {
+    "message": "tanleach1001 received 5 troops for holding Latvija/Lietuva.",
+    "timestamp": "2016-03-21T19:24:19.000Z",
+    "player": "tanleach1001",
+    "round": 16
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Bielaruś.",
+    "timestamp": "2016-03-21T19:24:19.000Z",
+    "player": "tanleach1001",
+    "round": 16
+  },
+  {
+    "message": "Gotland (jobratt) was reinforced by tanleach1001 with 8 troops.",
+    "timestamp": "2016-03-21T19:25:13.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Schleswig-Holstein (tanleach1001) was reinforced by tanleach1001 with 10 troops.",
+    "timestamp": "2016-03-21T19:25:16.000Z",
+    "player": "tanleach1001",
+    "round": 16
+  },
+  {
+    "message": "Schleswig-Holstein (tanleach1001) attacked Syddanmark (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T19:25:19.000Z",
+    "player": "tanleach1001",
+    "round": 16
+  },
+  {
+    "message": "Schleswig-Holstein (tanleach1001) occupied Syddanmark with 1 troop.",
+    "timestamp": "2016-03-21T19:25:26.000Z",
+    "player": "tanleach1001",
+    "round": 16
+  },
+  {
+    "message": "Vidzeme (tanleach1001) was fortified from Brest (tanleach1001) with 2 troops.",
+    "timestamp": "2016-03-21T19:25:33.000Z",
+    "player": "tanleach1001",
+    "round": 16
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-03-21T19:25:33.000Z",
+    "player": "tanleach1001",
+    "round": 16
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-03-21T19:25:33.000Z",
+    "player": "tanleach1001",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier started the turn.",
+    "timestamp": "2016-03-21T19:30:21.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier received 3 troops for 7 territories.",
+    "timestamp": "2016-03-21T19:30:22.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier received 4 troops for holding Eesti.",
+    "timestamp": "2016-03-21T19:30:22.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "Haapsalu (mmacfreier) was reinforced by mmacfreier with 7 troops.",
+    "timestamp": "2016-03-21T19:30:25.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier ended the turn.",
+    "timestamp": "2016-03-21T19:30:32.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-03-21T19:30:46.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "jobratt received 6 troops for 20 territories.",
+    "timestamp": "2016-03-21T19:30:46.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "jobratt received 4 troops for holding Polska.",
+    "timestamp": "2016-03-21T19:30:46.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "jobratt received 1 troop for holding Kaliningrad Oblast.",
+    "timestamp": "2016-03-21T19:30:46.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Gotland (jobratt) was reinforced by jobratt with 11 troops.",
+    "timestamp": "2016-03-21T19:31:01.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Gotland (jobratt) attacked Saaremaa (mmacfreier) conquering it, killing 8, losing 1.",
+    "timestamp": "2016-03-21T19:31:07.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Gotland (jobratt) occupied Saaremaa with 29 troops.",
+    "timestamp": "2016-03-21T19:31:42.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Saaremaa (jobratt) attacked Haapsalu (mmacfreier) conquering it, killing 15, losing 9.",
+    "timestamp": "2016-03-21T19:31:55.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Saaremaa (jobratt) occupied Haapsalu with 1 troop.",
+    "timestamp": "2016-03-21T19:32:10.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Saaremaa (jobratt) attacked Hiiumaa (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-21T19:32:15.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Saaremaa (jobratt) occupied Hiiumaa with 1 troop.",
+    "timestamp": "2016-03-21T19:32:19.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Saaremaa (jobratt) attacked Pärnumaa (mmacfreier) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-21T19:32:23.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Saaremaa (jobratt) occupied Pärnumaa with 15 troops.",
+    "timestamp": "2016-03-21T19:32:35.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Pärnumaa (jobratt) attacked Tallinn (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T19:32:37.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Pärnumaa (jobratt) occupied Tallinn with 1 troop.",
+    "timestamp": "2016-03-21T19:32:41.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Pärnumaa (jobratt) attacked Tartumaa (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T19:32:44.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Pärnumaa (jobratt) occupied Tartumaa with 1 troop.",
+    "timestamp": "2016-03-21T19:32:47.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Pärnumaa (jobratt) attacked Rakvere (mmacfreier) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T19:32:49.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "mmacfreier was defeated by jobratt.",
+    "timestamp": "2016-03-21T19:32:49.000Z",
+    "player": "mmacfreier",
+    "round": 16
+  },
+  {
+    "message": "Pärnumaa (jobratt) occupied Rakvere with 12 troops.",
+    "timestamp": "2016-03-21T19:32:51.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "jobratt received 2 troops on Mazowieckie",
+    "timestamp": "2016-03-21T19:33:01.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "jobratt received 12 troops for turning in cards Vitebsk, Mazowieckie, and Pskov.",
+    "timestamp": "2016-03-21T19:33:01.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Gotland (jobratt) was reinforced by jobratt with 10 troops.",
+    "timestamp": "2016-03-21T19:33:26.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Skåne (jobratt) was reinforced by jobratt with 2 troops.",
+    "timestamp": "2016-03-21T19:34:18.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Rakvere (jobratt) attacked Slantsy (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T19:34:26.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Rakvere (jobratt) occupied Slantsy with 11 troops.",
+    "timestamp": "2016-03-21T19:34:53.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Slantsy (jobratt) attacked Kotka (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T19:34:59.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Slantsy (jobratt) occupied Kotka with 1 troop.",
+    "timestamp": "2016-03-21T19:35:17.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Slantsy (jobratt) attacked Pskov (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-21T19:35:20.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Slantsy (jobratt) occupied Pskov with 8 troops.",
+    "timestamp": "2016-03-21T19:35:22.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Pskov (jobratt) attacked Velikiye Luki (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-21T19:35:25.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Pskov (jobratt) occupied Velikiye Luki with 6 troops.",
+    "timestamp": "2016-03-21T19:35:27.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Velikiye Luki (jobratt) attacked Novgorod (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T19:35:38.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Velikiye Luki (jobratt) occupied Novgorod with 1 troop.",
+    "timestamp": "2016-03-21T19:36:32.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "Velikiye Luki (jobratt) was fortified from Mazowieckie (jobratt) with 2 troops.",
+    "timestamp": "2016-03-21T19:36:53.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-03-21T19:36:53.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-03-21T19:36:53.000Z",
+    "player": "jobratt",
+    "round": 16
+  },
+  {
+    "message": "gcochard started the turn.",
+    "timestamp": "2016-03-21T19:55:42.000Z",
+    "player": "gcochard",
+    "round": 16
+  },
+  {
+    "message": "gcochard received 5 troops for 15 territories.",
+    "timestamp": "2016-03-21T19:55:42.000Z",
+    "player": "gcochard",
+    "round": 16
+  },
+  {
+    "message": "gcochard received 3 troops for holding Norge.",
+    "timestamp": "2016-03-21T19:55:42.000Z",
+    "player": "gcochard",
+    "round": 16
+  },
+  {
+    "message": "Örebro (gcochard) was reinforced by gcochard with 8 troops.",
+    "timestamp": "2016-03-21T19:55:55.000Z",
+    "player": "gcochard",
+    "round": 16
+  },
+  {
+    "message": "Örebro (gcochard) attacked Uppsala (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T19:55:59.000Z",
+    "player": "gcochard",
+    "round": 16
+  },
+  {
+    "message": "Örebro (gcochard) occupied Uppsala with 4 troops.",
+    "timestamp": "2016-03-21T19:56:15.000Z",
+    "player": "gcochard",
+    "round": 16
+  },
+  {
+    "message": "Uppsala (gcochard) attacked Stockholm (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T19:56:18.000Z",
+    "player": "gcochard",
+    "round": 16
+  },
+  {
+    "message": "Uppsala (gcochard) occupied Stockholm with 3 troops.",
+    "timestamp": "2016-03-21T19:56:19.000Z",
+    "player": "gcochard",
+    "round": 16
+  },
+  {
+    "message": "Örebro (gcochard) attacked Östergötland (jobratt) conquering it, killing 3, losing 2.",
+    "timestamp": "2016-03-21T19:56:29.000Z",
+    "player": "gcochard",
+    "round": 16
+  },
+  {
+    "message": "Örebro (gcochard) occupied Östergötland with 3 troops.",
+    "timestamp": "2016-03-21T19:56:32.000Z",
+    "player": "gcochard",
+    "round": 16
+  },
+  {
+    "message": "Östergötland (gcochard) was fortified from Södermanland (gcochard) with 3 troops.",
+    "timestamp": "2016-03-21T20:06:19.000Z",
+    "player": "gcochard",
+    "round": 16
+  },
+  {
+    "message": "gcochard received a card.",
+    "timestamp": "2016-03-21T20:06:19.000Z",
+    "player": "gcochard",
+    "round": 16
+  },
+  {
+    "message": "gcochard ended the turn.",
+    "timestamp": "2016-03-21T20:06:19.000Z",
+    "player": "gcochard",
+    "round": 16
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-03-21T20:29:56.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 7 territories.",
+    "timestamp": "2016-03-21T20:29:56.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "Åland (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-03-21T20:30:01.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "Åland (ryanbmilbourne) attacked Saaremaa (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:30:05.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "Åland (ryanbmilbourne) occupied Saaremaa with 14 troops.",
+    "timestamp": "2016-03-21T20:30:08.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "Saaremaa (ryanbmilbourne) attacked Pärnumaa (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:30:11.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "Saaremaa (ryanbmilbourne) occupied Pärnumaa with 13 troops.",
+    "timestamp": "2016-03-21T20:30:13.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "Pärnumaa (ryanbmilbourne) attacked Tartumaa (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-21T20:30:33.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "Pärnumaa (ryanbmilbourne) occupied Tartumaa with 11 troops.",
+    "timestamp": "2016-03-21T20:30:34.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "Tartumaa (ryanbmilbourne) attacked Pskov (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:30:38.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "Tartumaa (ryanbmilbourne) occupied Pskov with 10 troops.",
+    "timestamp": "2016-03-21T20:30:39.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "Pskov (ryanbmilbourne) attacked Velikiye Luki (jobratt) conquering it, killing 7, losing 3.",
+    "timestamp": "2016-03-21T20:30:46.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "Pskov (ryanbmilbourne) occupied Velikiye Luki with 6 troops.",
+    "timestamp": "2016-03-21T20:30:48.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "Velikiye Luki (ryanbmilbourne) attacked Vitebsk (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:30:50.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "Velikiye Luki (ryanbmilbourne) occupied Vitebsk with 5 troops.",
+    "timestamp": "2016-03-21T20:30:52.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "Vitebsk (ryanbmilbourne) attacked Dzūkija (tanleach1001) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:30:55.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "Vitebsk (ryanbmilbourne) occupied Dzūkija with 4 troops.",
+    "timestamp": "2016-03-21T20:30:56.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "Dzūkija (ryanbmilbourne) attacked Podlaskie (jobratt) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-21T20:31:01.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "Dzūkija (ryanbmilbourne) occupied Podlaskie with 2 troops.",
+    "timestamp": "2016-03-21T20:31:03.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "Podlaskie (ryanbmilbourne) attacked Sovetsk (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:31:06.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "ryanbmilbourne received a card.",
+    "timestamp": "2016-03-21T20:31:15.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-03-21T20:31:15.000Z",
+    "player": "ryanbmilbourne",
+    "round": 16
+  },
+  {
+    "message": "Round 17 started.",
+    "timestamp": "2016-03-21T20:31:15.000Z",
+    "player": "unknown",
+    "round": 17
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-03-21T20:36:26.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "tanleach1001 received 6 troops for 20 territories.",
+    "timestamp": "2016-03-21T20:36:26.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Deutschland.",
+    "timestamp": "2016-03-21T20:36:26.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "tanleach1001 received 12 troops for turning in cards Oslo, Wielkopolskie, and Espoo.",
+    "timestamp": "2016-03-21T20:36:32.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Hrozna (tanleach1001) was reinforced by tanleach1001 with 5 troops.",
+    "timestamp": "2016-03-21T20:36:55.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Latgale (tanleach1001) was reinforced by tanleach1001 with 16 troops.",
+    "timestamp": "2016-03-21T20:36:58.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Hrozna (tanleach1001) attacked Podlaskie (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:37:03.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Hrozna (tanleach1001) occupied Podlaskie with 5 troops.",
+    "timestamp": "2016-03-21T20:37:05.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Podlaskie (tanleach1001) attacked Sovetsk (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-21T20:37:09.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Podlaskie (tanleach1001) occupied Sovetsk with 1 troop.",
+    "timestamp": "2016-03-21T20:37:14.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Podlaskie (tanleach1001) attacked Dzūkija (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:37:18.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Podlaskie (tanleach1001) occupied Dzūkija with 2 troops.",
+    "timestamp": "2016-03-21T20:37:20.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Dzūkija (tanleach1001) attacked Vitebsk (ryanbmilbourne) killing 0, losing 1.",
+    "timestamp": "2016-03-21T20:37:23.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Latgale (tanleach1001) attacked Vitebsk (ryanbmilbourne) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-03-21T20:37:31.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Latgale (tanleach1001) occupied Vitebsk with 28 troops.",
+    "timestamp": "2016-03-21T20:37:34.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Vitebsk (tanleach1001) attacked Velikiye Luki (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-21T20:37:39.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Vitebsk (tanleach1001) occupied Velikiye Luki with 26 troops.",
+    "timestamp": "2016-03-21T20:37:41.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Velikiye Luki (tanleach1001) attacked Pskov (ryanbmilbourne) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-03-21T20:37:52.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Velikiye Luki (tanleach1001) occupied Pskov with 23 troops.",
+    "timestamp": "2016-03-21T20:37:57.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Pskov (tanleach1001) attacked Tartumaa (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:38:00.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Pskov (tanleach1001) occupied Tartumaa with 22 troops.",
+    "timestamp": "2016-03-21T20:38:07.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Tartumaa (tanleach1001) attacked Pärnumaa (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:38:10.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Tartumaa (tanleach1001) occupied Pärnumaa with 21 troops.",
+    "timestamp": "2016-03-21T20:38:11.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Pärnumaa (tanleach1001) attacked Saaremaa (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-21T20:38:16.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Pärnumaa (tanleach1001) occupied Saaremaa with 19 troops.",
+    "timestamp": "2016-03-21T20:38:18.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Saaremaa (tanleach1001) attacked Åland (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-21T20:38:24.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Saaremaa (tanleach1001) occupied Åland with 17 troops.",
+    "timestamp": "2016-03-21T20:38:29.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Åland (tanleach1001) attacked Stockholm (gcochard) conquering it, killing 3, losing 8.",
+    "timestamp": "2016-03-21T20:38:47.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Åland (tanleach1001) occupied Stockholm with 1 troop.",
+    "timestamp": "2016-03-21T20:38:51.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Åland (tanleach1001) attacked Turku (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:38:54.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Åland (tanleach1001) occupied Turku with 7 troops.",
+    "timestamp": "2016-03-21T20:38:55.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Turku (tanleach1001) attacked Espoo (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:39:00.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Turku (tanleach1001) occupied Espoo with 6 troops.",
+    "timestamp": "2016-03-21T20:39:02.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Espoo (tanleach1001) attacked Lahti (ryanbmilbourne) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-21T20:39:08.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Espoo (tanleach1001) occupied Lahti with 4 troops.",
+    "timestamp": "2016-03-21T20:39:11.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Lahti (tanleach1001) attacked Helsinki (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:39:14.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Lahti (tanleach1001) occupied Helsinki with 3 troops.",
+    "timestamp": "2016-03-21T20:39:15.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Helsinki (tanleach1001) attacked Kotka (jobratt) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:39:19.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Helsinki (tanleach1001) occupied Kotka with 2 troops.",
+    "timestamp": "2016-03-21T20:39:20.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Kotka (tanleach1001) attacked Vyborg (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:39:23.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "Skåne (jobratt) was fortified from Vidzeme (tanleach1001) with 13 troops.",
+    "timestamp": "2016-03-21T20:41:10.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "tanleach1001 received a card.",
+    "timestamp": "2016-03-21T20:41:10.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "tanleach1001 ended the turn.",
+    "timestamp": "2016-03-21T20:41:10.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "jobratt started the turn.",
+    "timestamp": "2016-03-21T20:42:00.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "jobratt received 7 troops for 23 territories.",
+    "timestamp": "2016-03-21T20:42:00.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "jobratt received 12 troops for turning in cards Brandenburg, Uppsala, and Södermanland.",
+    "timestamp": "2016-03-21T20:42:10.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Skåne (jobratt) was reinforced by jobratt with 19 troops.",
+    "timestamp": "2016-03-21T20:42:17.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Skåne (jobratt) attacked Halland (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:42:19.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Skåne (jobratt) occupied Halland with 41 troops.",
+    "timestamp": "2016-03-21T20:42:22.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Halland (jobratt) attacked Jönköping (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:42:42.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Halland (jobratt) occupied Jönköping with 40 troops.",
+    "timestamp": "2016-03-21T20:42:44.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Jönköping (jobratt) attacked Västra Götaland (gcochard) conquering it, killing 8, losing 7.",
+    "timestamp": "2016-03-21T20:42:54.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Jönköping (jobratt) occupied Västra Götaland with 32 troops.",
+    "timestamp": "2016-03-21T20:42:56.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Västra Götaland (jobratt) attacked Nordjylland (gcochard) conquering it, killing 7, losing 4.",
+    "timestamp": "2016-03-21T20:43:07.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Västra Götaland (jobratt) occupied Nordjylland with 27 troops.",
+    "timestamp": "2016-03-21T20:43:08.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Nordjylland (jobratt) attacked Sørlandet (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:43:13.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Nordjylland (jobratt) occupied Sørlandet with 26 troops.",
+    "timestamp": "2016-03-21T20:43:14.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Sørlandet (jobratt) attacked Vestlandet (gcochard) conquering it, killing 1, losing 1.",
+    "timestamp": "2016-03-21T20:43:18.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Sørlandet (jobratt) occupied Vestlandet with 24 troops.",
+    "timestamp": "2016-03-21T20:43:19.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Vestlandet (jobratt) attacked Telemark (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:43:22.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Vestlandet (jobratt) occupied Telemark with 23 troops.",
+    "timestamp": "2016-03-21T20:43:25.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Telemark (jobratt) attacked Jotunheimen (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:43:28.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Telemark (jobratt) occupied Jotunheimen with 22 troops.",
+    "timestamp": "2016-03-21T20:43:29.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Jotunheimen (jobratt) attacked Østlandet (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:43:37.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Jotunheimen (jobratt) occupied Østlandet with 21 troops.",
+    "timestamp": "2016-03-21T20:43:38.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Østlandet (jobratt) attacked Oslo (gcochard) conquering it, killing 1, losing 2.",
+    "timestamp": "2016-03-21T20:43:43.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Østlandet (jobratt) occupied Oslo with 18 troops.",
+    "timestamp": "2016-03-21T20:43:44.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Oslo (jobratt) attacked Värmland (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:43:47.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Oslo (jobratt) occupied Värmland with 17 troops.",
+    "timestamp": "2016-03-21T20:43:49.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Värmland (jobratt) attacked Dalarna (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:44:03.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Värmland (jobratt) occupied Dalarna with 16 troops.",
+    "timestamp": "2016-03-21T20:44:05.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Dalarna (jobratt) attacked Gävleborg (gcochard) conquering it, killing 1, losing 3.",
+    "timestamp": "2016-03-21T20:44:11.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Dalarna (jobratt) occupied Gävleborg with 12 troops.",
+    "timestamp": "2016-03-21T20:44:13.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Gävleborg (jobratt) attacked Uppsala (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:44:15.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Gävleborg (jobratt) occupied Uppsala with 11 troops.",
+    "timestamp": "2016-03-21T20:44:16.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Uppsala (jobratt) attacked Örebro (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:44:19.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Uppsala (jobratt) occupied Örebro with 10 troops.",
+    "timestamp": "2016-03-21T20:44:21.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Örebro (jobratt) attacked Östergötland (gcochard) conquering it, killing 6, losing 3.",
+    "timestamp": "2016-03-21T20:44:27.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Örebro (jobratt) occupied Östergötland with 6 troops.",
+    "timestamp": "2016-03-21T20:44:28.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Östergötland (jobratt) attacked Södermanland (gcochard) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:44:32.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "gcochard was defeated by jobratt.",
+    "timestamp": "2016-03-21T20:44:32.000Z",
+    "player": "gcochard",
+    "round": 17
+  },
+  {
+    "message": "Östergötland (jobratt) occupied Södermanland with 5 troops.",
+    "timestamp": "2016-03-21T20:44:34.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "Vyborg (tanleach1001) was fortified from Gotland (jobratt) with 10 troops.",
+    "timestamp": "2016-03-21T20:44:59.000Z",
+    "player": "tanleach1001",
+    "round": 17
+  },
+  {
+    "message": "jobratt received a card.",
+    "timestamp": "2016-03-21T20:44:59.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "jobratt ended the turn.",
+    "timestamp": "2016-03-21T20:44:59.000Z",
+    "player": "jobratt",
+    "round": 17
+  },
+  {
+    "message": "ryanbmilbourne started the turn.",
+    "timestamp": "2016-03-21T20:46:22.000Z",
+    "player": "ryanbmilbourne",
+    "round": 17
+  },
+  {
+    "message": "ryanbmilbourne received 3 troops for 1 territory.",
+    "timestamp": "2016-03-21T20:46:22.000Z",
+    "player": "ryanbmilbourne",
+    "round": 17
+  },
+  {
+    "message": "St. Petersburg (ryanbmilbourne) was reinforced by ryanbmilbourne with 3 troops.",
+    "timestamp": "2016-03-21T20:46:35.000Z",
+    "player": "ryanbmilbourne",
+    "round": 17
+  },
+  {
+    "message": "St. Petersburg (ryanbmilbourne) attacked Slantsy (jobratt) killing 0, losing 3.",
+    "timestamp": "2016-03-21T20:46:40.000Z",
+    "player": "ryanbmilbourne",
+    "round": 17
+  },
+  {
+    "message": "ryanbmilbourne ended the turn.",
+    "timestamp": "2016-03-21T20:48:11.000Z",
+    "player": "ryanbmilbourne",
+    "round": 17
+  },
+  {
+    "message": "Round 18 started.",
+    "timestamp": "2016-03-21T20:48:11.000Z",
+    "player": "unknown",
+    "round": 18
+  },
+  {
+    "message": "tanleach1001 started the turn.",
+    "timestamp": "2016-03-21T20:48:15.000Z",
+    "player": "tanleach1001",
+    "round": 18
+  },
+  {
+    "message": "tanleach1001 received 12 troops for 37 territories.",
+    "timestamp": "2016-03-21T20:48:15.000Z",
+    "player": "tanleach1001",
+    "round": 18
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Deutschland.",
+    "timestamp": "2016-03-21T20:48:15.000Z",
+    "player": "tanleach1001",
+    "round": 18
+  },
+  {
+    "message": "tanleach1001 received 5 troops for holding Latvija/Lietuva.",
+    "timestamp": "2016-03-21T20:48:15.000Z",
+    "player": "tanleach1001",
+    "round": 18
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Bielaruś.",
+    "timestamp": "2016-03-21T20:48:15.000Z",
+    "player": "tanleach1001",
+    "round": 18
+  },
+  {
+    "message": "tanleach1001 received 3 troops for holding Suomi.",
+    "timestamp": "2016-03-21T20:48:15.000Z",
+    "player": "tanleach1001",
+    "round": 18
+  },
+  {
+    "message": "Vyborg (tanleach1001) was reinforced by tanleach1001 with 26 troops.",
+    "timestamp": "2016-03-21T20:48:17.000Z",
+    "player": "tanleach1001",
+    "round": 18
+  },
+  {
+    "message": "Vyborg (tanleach1001) attacked St. Petersburg (ryanbmilbourne) conquering it, killing 1, losing 0.",
+    "timestamp": "2016-03-21T20:48:23.000Z",
+    "player": "tanleach1001",
+    "round": 18
+  },
+  {
+    "message": "ryanbmilbourne was defeated by tanleach1001.",
+    "timestamp": "2016-03-21T20:48:23.000Z",
+    "player": "ryanbmilbourne",
+    "round": 18
+  },
+  {
+    "message": "Game finished.",
+    "timestamp": "2016-03-21T20:48:23.000Z",
+    "player": "unknown",
+    "round": 18
+  },
+  {
+    "message": "tanleach1001 won the game.",
+    "timestamp": "2016-03-21T20:48:23.000Z",
+    "player": "tanleach1001",
+    "round": 18
+  },
+  {
+    "message": "tanleach1001 received 38 rating.",
+    "timestamp": "2016-03-21T20:48:23.000Z",
+    "player": "tanleach1001",
+    "round": 18
+  },
+  {
+    "message": "tanleach1001 received 20 tokens.",
+    "timestamp": "2016-03-21T20:48:23.000Z",
+    "player": "tanleach1001",
+    "round": 18
+  },
+  {
+    "message": "kwren lost 24 rating.",
+    "timestamp": "2016-03-21T20:48:23.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "kwren received 15 tokens.",
+    "timestamp": "2016-03-21T20:48:23.000Z",
+    "player": "kwren",
+    "round": 18
+  },
+  {
+    "message": "mmacfreier lost 22 rating.",
+    "timestamp": "2016-03-21T20:48:23.000Z",
+    "player": "mmacfreier",
+    "round": 18
+  },
+  {
+    "message": "mmacfreier received 20 tokens.",
+    "timestamp": "2016-03-21T20:48:23.000Z",
+    "player": "mmacfreier",
+    "round": 18
+  },
+  {
+    "message": "jobratt won the game.",
+    "timestamp": "2016-03-21T20:48:23.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "jobratt received 38 rating.",
+    "timestamp": "2016-03-21T20:48:23.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "jobratt received 20 tokens.",
+    "timestamp": "2016-03-21T20:48:23.000Z",
+    "player": "jobratt",
+    "round": 18
+  },
+  {
+    "message": "gcochard lost 13 rating.",
+    "timestamp": "2016-03-21T20:48:23.000Z",
+    "player": "gcochard",
+    "round": 18
+  },
+  {
+    "message": "gcochard received 20 tokens.",
+    "timestamp": "2016-03-21T20:48:23.000Z",
+    "player": "gcochard",
+    "round": 18
+  },
+  {
+    "message": "ryanbmilbourne lost 17 rating.",
+    "timestamp": "2016-03-21T20:48:23.000Z",
+    "player": "ryanbmilbourne",
+    "round": 18
+  },
+  {
+    "message": "ryanbmilbourne received 15 tokens.",
+    "timestamp": "2016-03-21T20:48:23.000Z",
+    "player": "ryanbmilbourne",
+    "round": 18
+  }
+]

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <li><a href="dice-viz.html">Dice Rolls</a></li>
     <li><a href="summary-viz.html">Game Summary</a></li>
     <li><a href="replay-viz.html">Game Replay</a></li>
+    <li><a href="attack-viz.html">Attack Matrix</a></li>
     </ul>
 </body>
 

--- a/js/attack.js
+++ b/js/attack.js
@@ -56,7 +56,7 @@ function vizAttackData() {
     gData.forEach(function (e) {
         var id = e.player + "-" + e.dplayer;
         if (edgeHash[id]) {
-            edgeHash[id].weight += 1;
+            edgeHash[id].weight += (type == 'attacked' ? 1 : (type == 'killed' ? e.killed : e.lost))
         } else {
             edgeHash[id] = {
                 source: e.player,
@@ -81,7 +81,6 @@ function vizAttackData() {
         }
     }
 
-    // var colors = ["#ffffd9","#edf8b1","#c7e9b4","#7fcdbb","#41b6c4","#1d91c0","#225ea8","#253494","#081d58"]; // alternatively colorbrewer.YlGnBu[9]
     var colors = ['#a50026','#d73027','#f46d43','#fdae61','#fee08b','#ffffbf','#d9ef8b','#a6d96a','#66bd63','#1a9850','#006837'].reverse()
     var colorScale = d3.scale.quantile()
         .domain([d3.min(matrix, function (d) { return d.weight; }),
@@ -90,7 +89,7 @@ function vizAttackData() {
         .range(colors);
     var svg = d3.select("svg");
     svg.call(tip);
-    svg.select('#adjacencyG').remove();
+    svg.select('#adjacencyG').remove(); // Clear out any existing adjacenty matrix
     svg.attr('width', boxWH*u_nodes.length+margins.left+margins.right)
        .attr('height', boxWH*u_nodes.length+margins.top+margins.bottom)
 

--- a/js/attack.js
+++ b/js/attack.js
@@ -134,8 +134,7 @@ function vizAttackData(redrawSlider) {
     var colors = ['#a50026','#d73027','#f46d43','#fdae61','#fee08b','#ffffbf','#d9ef8b','#a6d96a','#66bd63','#1a9850','#006837'].reverse()
     var colorScale = d3.scale.quantile()
         .domain([d3.min(matrix, function (d) { return d.weight; }),
-            colors.length - 1,
-            d3.max(matrix, function (d) { return d.weight; })])
+                 d3.max(matrix, function (d) { return d.weight; })])
         .range(colors);
     var svg = d3.select("svg");
     svg.call(tip);

--- a/js/attack.js
+++ b/js/attack.js
@@ -1,0 +1,190 @@
+var allGameData,
+    gameIds;
+
+var tip = d3.tip()
+    .attr('class', 'd3-tip')
+    .offset([-5, 100])
+    .html(function(d, i) {
+        var A = d.id.split('-')[0];
+        var B = d.id.split('-')[1];
+        var type = d3.select('input[name="atype"]:checked').property("value");
+        if(type == 'attacked')
+            return '<span class="label">'+A+'</span> has '+type+' <span class="label">'+B+'</span> '+d.weight+' times';
+        else if(type == 'lost')
+            return '<span class="label">'+A+'</span> has '+type+' '+d.weight+' troops to <span class="label">'+B+'</span>';
+        else
+            return '<span class="label">'+A+'</span> has '+type+' '+d.weight+' of <span class="label">'+B+'</span> troops';
+
+    });
+
+function gridOver(d,i) {
+    d3.selectAll("rect").style("stroke-width", function (p) {return p.x == d.x && p.y == d.y ? "3px" : "1px"});
+    tip.show(d, i);
+}
+
+function gridOut(d,i) {
+    d3.selectAll("rect").style("stroke-width", "1px");
+    tip.hide();
+}
+
+
+function vizAttackData() {
+    var boxWH = 75,
+        margins = {top: 80, left: 100, right: 30, bottom: 10};
+
+    var game_id = d3.select("#game").property("value");
+    var type = d3.select('input[name="atype"]:checked').property("value");
+    var gData = [];
+    if(game_id == 'All') {
+        gameIds.forEach(function (g) { gData = gData.concat(allGameData[g]); });
+        u_nodes = d3.entries(users);
+    } else {
+        gData = allGameData[game_id];
+        // This is some really kludgy code to create a dictionary similar to the
+        // users dictionary based on the specific players in the game.
+        u_nodes = d3.set(gData.map(function (d) {
+                return d.player
+            })).values().reduce(function(o, v, i) {
+                o[v] = true;
+                return o;
+            }, {});
+        u_nodes = d3.entries(u_nodes);
+    }
+    u_nodes.sort(function (a, b) { return a.key.localeCompare(b.key); });
+
+    var edgeHash = {};
+    gData.forEach(function (e) {
+        var id = e.player + "-" + e.dplayer;
+        if (edgeHash[id]) {
+            edgeHash[id].weight += 1;
+        } else {
+            edgeHash[id] = {
+                source: e.player,
+                target: e.dplayer,
+                weight: (type == 'attacked' ? 1 : (type == 'killed' ? e.killed : e.lost))
+            };
+        }
+    });
+    matrix = [];
+
+    //create all possible edges
+    for (a in u_nodes)
+    {
+        for (b in u_nodes)
+        {
+            var grid = {id: u_nodes[a].key + "-" + u_nodes[b].key, x: b, y: a, weight: 0};
+            if (edgeHash[grid.id])
+            {
+                grid.weight = +edgeHash[grid.id].weight;
+            }
+            matrix.push(grid);
+        }
+    }
+
+    // var colors = ["#ffffd9","#edf8b1","#c7e9b4","#7fcdbb","#41b6c4","#1d91c0","#225ea8","#253494","#081d58"]; // alternatively colorbrewer.YlGnBu[9]
+    var colors = ['#a50026','#d73027','#f46d43','#fdae61','#fee08b','#ffffbf','#d9ef8b','#a6d96a','#66bd63','#1a9850','#006837'].reverse()
+    var colorScale = d3.scale.quantile()
+        .domain([d3.min(matrix, function (d) { return d.weight; }),
+            colors.length - 1,
+            d3.max(matrix, function (d) { return d.weight; })])
+        .range(colors);
+    var svg = d3.select("svg");
+    svg.call(tip);
+    svg.select('#adjacencyG').remove();
+    svg.attr('width', boxWH*u_nodes.length+margins.left+margins.right)
+       .attr('height', boxWH*u_nodes.length+margins.top+margins.bottom)
+
+    svg.append("g")
+        .attr("transform", "translate("+margins.left+","+margins.top+")")
+        .attr("id", "adjacencyG")
+        .selectAll("rect")
+        .data(matrix)
+        .enter()
+        .append("rect")
+        .attr('id', function(d) { return d.id })
+        .attr("width", boxWH)
+        .attr("height", boxWH)
+        .attr("x", function(d) {return d.x * boxWH})
+        .attr("y", function(d) {return d.y * boxWH})
+        .style("stroke", "black")
+        .style("stroke-width", "1px")
+        .style("fill", function(d) { return d.weight == 0 ? "white" : colorScale(d.weight); })
+        .on("mouseover", gridOver)
+        .on('mouseout', gridOut)
+
+    var scaleSize = u_nodes.length * boxWH;
+    var nameScale = d3.scale.ordinal()
+        .domain(u_nodes.map(function (el) {return el.key}))
+        .rangePoints([0,scaleSize],1);
+
+    xAxis = d3.svg.axis().scale(nameScale).orient("top").tickSize(4);
+    yAxis = d3.svg.axis().scale(nameScale).orient("left").tickSize(4);
+    d3.select("#adjacencyG")
+        .append("g")
+        .call(xAxis)
+        .selectAll("text")
+        .style("text-anchor", "start")
+        .style("font-size", "80%")
+        .attr("transform", "translate(0,-5) rotate(-45)");
+    d3.select("#adjacencyG")
+        .append("g")
+        .call(yAxis)
+        .selectAll("text")
+        .style("font-size", "80%");
+}
+
+function collectData(error, data, gid) {
+    if(error) {
+        if(allGameData[gid] == 1) {
+            delete allGameData[gid];
+            gameIds.splice(gameIds.indexOf(gid), 1);
+            $('#game option[value="'+gid+'"]').remove();
+        } else {
+            d3.json('https://hubot-gregcochard.rhcloud.com/hubot/d12log/'+gid, function (error, data) { collectData(error, data, gid); });
+            allGameData[gid] = 1;
+        }
+    } else {
+        allGameData[gid] = data.filter(function (e) {
+            if(fightPattern.test(e.message)) {
+                e.otime = e.timestamp;
+                e.timestamp = new Date(e.timestamp);
+                matchD12(e);
+                return true;
+            }
+            return false;
+        });
+    }
+    var done = true;
+    gameIds.forEach(function (d) { done = done && (allGameData[d] !== null && allGameData[d] != 1); });
+    if(done) {
+        vizAttackData();
+        // The initial display has been loaded, go ahead and allow user to change it
+        d3.select('#game').attr('disabled', null);
+    }
+}
+
+function getAllGameData(error, data) {
+    setGameIds(data, 'All');
+    if (window.location.search) {
+        var parts = window.location.search.split('=');
+        if (parts.length == 2) {
+            // handle the form ?game=234234
+            $('#game').val(parts[1]);
+        } else {
+            // handle the form ?234324
+            $('#game').val(parts.join().split('?')[1]);
+        }
+    }
+    // Modify the on change action, also disable changing until all data has been loaded
+    d3.select('#game')
+        .on('change', vizAttackData)
+        .attr('disabled', '');
+
+    // Get the list of gameIds we found to process all the files
+    gameIds = d3.selectAll('#game option').data().filter(function (d) { return d != 'All'; });
+
+    allGameData = gameIds.reduce(function (o, g, i) { o[g] = null; return o; }, {});
+    gameIds.forEach(function (g) { d3.json('data/'+g+'.json', function (error, data) { collectData(error, data, g); }) });
+}
+
+d3.json('https://hubot-gregcochard.rhcloud.com/hubot/dice', getAllGameData);

--- a/js/viz-utils.js
+++ b/js/viz-utils.js
@@ -254,3 +254,7 @@ function calcTurnOrder(gdata) {
     }
     return pOrder;
 }
+
+function toTitleCase(str) {
+    return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
+}

--- a/tools/fetchD12Log.js
+++ b/tools/fetchD12Log.js
@@ -153,7 +153,7 @@ var fetchLog = function(gameId, cb){
 //     }
 //     var data = JSON.parse(body);
 //     var gameIds = d3.keys(data).filter(function(d) {
-//         return d != "undefined" && d != '600989'
+//         return d != "undefined"
 //     });
 //     gameIds.forEach(function (d) {
 //         fetchLog(Number(d), function(err, data){


### PR DESCRIPTION
Adds a new visualization of the number of times that a player has attacked another player.

Also includes how many troops a player has killed or lost to a particular player.

Can filter by rounds in particular games.
